### PR TITLE
Win toggle safe mode script

### DIFF
--- a/map.json
+++ b/map.json
@@ -43,5 +43,10 @@
 		"id" : "win-enable-nested-hyperv",
 		"path" : "src/windows/win-enable-nested-hyperv.ps1",
 		"description" : "Enables nested hyperV using attached data disk as OS disk."
+	},
+	{
+		"id" : "win-toggle-safe-mode",
+		"path" : "src/windows/win-toggle-safe-mode.ps1",
+		"description" : "Disable Safe Mode if your VM is booting in Safe Mode. Also activates Safe Mode if you require it (e.g. to uninstall certain software)."
 	}
 ]

--- a/map.json
+++ b/map.json
@@ -47,6 +47,6 @@
 	{
 		"id" : "win-toggle-safe-mode",
 		"path" : "src/windows/win-toggle-safe-mode.ps1",
-		"description" : "Disable Safe Mode if your VM is booting in Safe Mode. Also activates Safe Mode if you require it (e.g. to uninstall certain software)."
+		"description" : "Disable Safe Mode if your Windows VM is booting in Safe Mode. Also activates Safe Mode if you require it (e.g. to uninstall certain software)."
 	}
 ]

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -135,6 +135,6 @@ catch {
     $scriptEndTime = get-date -f yyyyMMddHHmmss
     $scriptEndTime | out-file -FilePath $logFile -Append   
 
-    throw $_
+    throw $_ | out-file -FilePath $logFile -Append
     return $STATUS_ERROR
 }

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -31,12 +31,12 @@ try {
     # Make sure guest VM is shut down
     $guestHyperVVirtualMachine = Get-VM
     Log-Info "#01 - Stopping nested guest VM $guestHyperVVirtualMachine.VMName" | out-file -FilePath $logFile -Append
-    $return = Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
+    Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
 
     # Make sure the disk is online
     Log-Info "#02 - Bringing disk online" | out-file -FilePath $logFile -Append
     $disk = get-disk -ErrorAction Stop | where { $_.FriendlyName -eq 'Msft Virtual Disk' }
-    $return = $disk | set-disk -IsOffline $false -ErrorAction Stop
+    $disk | set-disk -IsOffline $false -ErrorAction Stop
  
     # Handle disk partitions
     $partitionlist = Get-Disk-Partitions
@@ -104,11 +104,11 @@ try {
 
             # Bring disk offline 
             Log-Info "#06 - Bringing disk offline" | out-file -FilePath $logFile -Append
-            $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
+            $disk | set-disk -IsOffline $true -ErrorAction Stop
 
             # Start Hyper-V VM
             Log-Output "END: Starting VM, please verify status of Safe Mode using MSCONFIG.exe" | out-file -FilePath $logFile -Append
-            $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
+            start-vm $guestHyperVVirtualMachine -ErrorAction Stop
 
             # Log finish time
             $scriptEndTime = get-date -f yyyyMMddHHmmss
@@ -125,11 +125,11 @@ catch {
 
     # Bring disk offline again
     Log-Info "#05 - Bringing disk offline" | out-file -FilePath $logFile -Append
-    $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
+    $disk | set-disk -IsOffline $true -ErrorAction Stop
 
     # Start Hyper-V VM again
     Log-Output "END: could not start Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
-    $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
+    start-vm $guestHyperVVirtualMachine -ErrorAction Stop
 
     # Log finish time
     $scriptEndTime = get-date -f yyyyMMddHHmmss

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -105,6 +105,9 @@ try {
             Log-Info "END: Starting VM, please verify Safe Mode w/ Networking using MSCONFIG.exe" | out-file -FilePath $logFile -Append
             $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
 
+            $scriptEndTime = get-date -f yyyyMMddHHmmss
+            $scriptEndTime | out-file -FilePath $logFile -Append
+
             return $STATUS_SUCCESS
         }
     }
@@ -121,6 +124,9 @@ catch {
     # Start Hyper-V VM again
     Log-Info "END: could not start Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
     $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
+
+    $scriptEndTime = get-date -f yyyyMMddHHmmss
+    $scriptEndTime | out-file -FilePath $logFile -Append   
 
     throw $_
     return $STATUS_ERROR

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -1,0 +1,121 @@
+. .\src\windows\common\setup\init.ps1
+. .\src\windows\common\helpers\Get-Disk-Partitions.ps1
+
+# https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-rdp-safe-mode
+
+# Initialize script log variables
+$scriptStartTime = get-date -f yyyyMMddHHmmss
+$scriptPath = split-path -path $MyInvocation.MyCommand.Path -parent
+$scriptName = (split-path -path $MyInvocation.MyCommand.Path -leaf).Split('.')[0]
+
+# Initialize script log
+$logFile = "$env:PUBLIC\Desktop\$($scriptName).log"
+Log-Info 'START: Running Script win-toggle-safe-mode' | out-file -FilePath $logFile -Append
+$scriptStartTime | out-file -FilePath $logFile -Append
+
+# Make sure guest VM is shut down
+$guestHyperVVirtualMachine = Get-VM
+Log-Info "#01 - Stopping nested guest VM $guestHyperVVirtualMachine.VMName" | out-file -FilePath $logFile -Append
+$return = Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
+
+# Make sure the disk is online
+Log-Info "#02 - Bringing disk online" | out-file -FilePath $logFile -Append
+$disk = get-disk -ErrorAction Stop | where {$_.FriendlyName -eq 'Msft Virtual Disk'}
+$return = $disk | set-disk -IsOffline $false -ErrorAction Stop
+ 
+# Handle disk partitions
+$partitionlist = Get-Disk-Partitions
+Log-Info $partitionlist | out-file -FilePath $logFile -Append
+$partitionGroup = $partitionlist | group DiskNumber | out-file -FilePath $logFile -Append
+
+Log-Info '#03 - enumerate partitions to reconfigure boot cfg' | out-file -FilePath $logFile -Append
+
+forEach ( $partitionGroup in $partitionlist | group DiskNumber )
+{
+    #reset paths for each part group (disk)
+    $isBcdPath = $false
+    $bcdPath = ''
+    $bcdDrive = ''
+    $isOsPath = $false
+    $osPath = ''
+    $osDrive = ''
+
+    #scan all partitions of a disk for bcd store and os file location 
+    ForEach ($drive in $partitionGroup.Group | select -ExpandProperty DriveLetter )
+    {      
+        #check if no bcd store was found on the previous partition already
+        if ( -not $isBcdPath )
+        {
+            $bcdPath =  $drive + ':\boot\bcd'
+            $bcdDrive = $drive + ':'
+            $isBcdPath = Test-Path $bcdPath
+
+            #if no bcd was found yet at the default location look for the uefi location too
+            if ( -not $isBcdPath )
+            {
+                $bcdPath =  $drive + ':\efi\microsoft\boot\bcd'
+                $bcdDrive = $drive + ':'
+                $isBcdPath = Test-Path $bcdPath
+            } 
+        }        
+
+        #check if os loader was found on the previous partition already
+        if (-not $isOsPath)
+        {
+            $osPath = $drive + ':\windows\system32\winload.exe'
+            $isOsPath = Test-Path $osPath
+            if ($isOsPath)
+            {
+                $osDrive = $drive + ':'
+            }
+        }
+    }
+        #if both was found grab bcd store
+    if ( $isBcdPath -and $isOsPath )
+    {
+        # Get Safe Mode State
+        Log-Info "#04 - Checking safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
+        $bcdout = bcdedit /store $bcdPath /enum
+        $defaultLine = $bcdout | Select-String 'displayorder' | select -First 1
+        $defaultId = '{'+$defaultLine.ToString().Split('{}')[1] + '}'
+        $safeModeIndicator = $bcdout | Select-String 'safeboot' | select -First 1
+
+        # Check if flag exists
+        if ($safeModeIndicator)
+        {            
+            
+            # Flag exists, delete to take VM out of Safe Mode
+            Log-Info "#05 - Removing safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
+            bcdedit /store $bcdPath /deletevalue $defaultId safeboot
+         
+        } else {
+            
+            # Flag doesn't exist, adding so VM boots in Safe Mode
+            Log-Info "#05 - Configuring safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
+            bcdedit /store $bcdPath /set $defaultId safeboot network
+        }
+
+        # Bring disk offline 
+        Log-Info "Bringing disk offline" | out-file -FilePath $logFile -Append
+        $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
+
+        # Start Hyper-V VM
+        Log-Info "END: Starting VM, please verify Safe Mode w/ Networking using MSCONFIG.exe" | out-file -FilePath $logFile -Append
+        $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
+
+        return $STATUS_SUCCESS
+    }
+}
+
+# Log failure to run successfully
+Log-Error "Unable to find the BCD Path" | out-file -FilePath $logFile -Append
+
+# Bring disk offline again
+Log-Info "Bringing disk offline" | out-file -FilePath $logFile -Append
+$return = $disk | set-disk -IsOffline $true -ErrorAction Stop
+
+# Start Hyper-V VM again
+Log-Info "END: could not start Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
+$return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
+
+return $STATUS_ERROR

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -10,6 +10,8 @@
 # may then access their VM in Safe Mode via the Rescue VM or revert Safe Mode on their Azure VM. They 
 # may then swap the disk using the `az vm repair restore` functionality.
 #
+# Tested on Windows Server 2019 Datacenter (Gen 1)
+#
 # https://docs.microsoft.com/en-us/cli/azure/ext/vm-repair/vm/repair?view=azure-cli-latest
 # https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-rdp-safe-mode
 #########################################################################################################
@@ -21,7 +23,7 @@ $scriptName = (split-path -path $MyInvocation.MyCommand.Path -leaf).Split('.')[0
 
 # Initialize script log
 $logFile = "$env:PUBLIC\Desktop\$($scriptName).log"
-Log-Info 'START: Running Script win-toggle-safe-mode' | out-file -FilePath $logFile -Append
+Log-Output 'START: Running Script win-toggle-safe-mode' | out-file -FilePath $logFile -Append
 $scriptStartTime | out-file -FilePath $logFile -Append
 
 try {
@@ -80,7 +82,7 @@ try {
 
         # If both was found grab bcd store
         if ( $isBcdPath -and $isOsPath ) {
-            
+
             # Get Safe Mode state
             Log-Info "#04 - Checking safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
             $bcdout = bcdedit /store $bcdPath /enum
@@ -105,7 +107,7 @@ try {
             $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
 
             # Start Hyper-V VM
-            Log-Info "END: Starting VM, please verify Safe Mode w/ Networking using MSCONFIG.exe" | out-file -FilePath $logFile -Append
+            Log-Output "END: Starting VM, please verify Safe Mode w/ Networking using MSCONFIG.exe" | out-file -FilePath $logFile -Append
             $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
 
             # Log finish time
@@ -126,7 +128,7 @@ catch {
     $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
 
     # Start Hyper-V VM again
-    Log-Info "END: could not start Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
+    Log-Output "END: could not start Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
     $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
 
     # Log finish time

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -107,7 +107,7 @@ try {
             $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
 
             # Start Hyper-V VM
-            Log-Output "END: Starting VM, please verify Safe Mode w/ Networking using MSCONFIG.exe" | out-file -FilePath $logFile -Append
+            Log-Output "END: Starting VM, please verify status of Safe Mode using MSCONFIG.exe" | out-file -FilePath $logFile -Append
             $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
 
             # Log finish time

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -124,11 +124,11 @@ catch {
     Log-Error "ERROR: Unable to find the BCD Path" | out-file -FilePath $logFile -Append
 
     # Bring disk offline again
-    Log-Info "#05 - Bringing disk offline" | out-file -FilePath $logFile -Append
+    Log-Info "#05 - Bringing disk offline to restart Hyper-V VM" | out-file -FilePath $logFile -Append
     $disk | set-disk -IsOffline $true -ErrorAction Stop
 
     # Start Hyper-V VM again
-    Log-Output "END: could not start Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
+    Log-Output "END: could not start/stop Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
     start-vm $guestHyperVVirtualMachine -ErrorAction Stop
 
     # Log finish time

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -1,7 +1,18 @@
 . .\src\windows\common\setup\init.ps1
 . .\src\windows\common\helpers\Get-Disk-Partitions.ps1
 
+#########################################################################################################
+# Azure VMs do not natively support Safe Mode because RDP access is disabled in Safe Mode. Some users
+# need to boot their VM in Safe Mode for specific reasons (e.g. uninstalling certain software). Other
+# users may find their VM booting into Safe Mode inadvertantly due to user error or misconfiguration,
+# which will disable RDP access until corrected. This script utilizes the az vm repair extension to 
+# clone the VM into a Hyper-V environment using Nested Virtualization and toggle Safe Boot. The user
+# may then access their VM in Safe Mode via the Rescue VM or revert Safe Mode on their Azure VM. They may
+# then swap the disk using the `az vm repair restore` functionality.
+#
+# https://docs.microsoft.com/en-us/cli/azure/ext/vm-repair/vm/repair?view=azure-cli-latest
 # https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-rdp-safe-mode
+#########################################################################################################
 
 # Initialize script log variables
 $scriptStartTime = get-date -f yyyyMMddHHmmss

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -120,7 +120,7 @@ try {
 }
 catch {
     
-    # Log failure to run successfully
+    # Log failure
     Log-Error "ERROR: Unable to find the BCD Path" | out-file -FilePath $logFile -Append
 
     # Bring disk offline again

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -77,8 +77,10 @@ try {
                 }
             }
         }
+
         # If both was found grab bcd store
         if ( $isBcdPath -and $isOsPath ) {
+            
             # Get Safe Mode state
             Log-Info "#04 - Checking safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
             $bcdout = bcdedit /store $bcdPath /enum
@@ -97,6 +99,7 @@ try {
                 Log-Info "#05 - Configuring safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
                 bcdedit /store $bcdPath /set $defaultId safeboot network
             }
+
             # Bring disk offline 
             Log-Info "#06 - Bringing disk offline" | out-file -FilePath $logFile -Append
             $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
@@ -105,6 +108,7 @@ try {
             Log-Info "END: Starting VM, please verify Safe Mode w/ Networking using MSCONFIG.exe" | out-file -FilePath $logFile -Append
             $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
 
+            # Log finish time
             $scriptEndTime = get-date -f yyyyMMddHHmmss
             $scriptEndTime | out-file -FilePath $logFile -Append
 
@@ -125,6 +129,7 @@ catch {
     Log-Info "END: could not start Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
     $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
 
+    # Log finish time
     $scriptEndTime = get-date -f yyyyMMddHHmmss
     $scriptEndTime | out-file -FilePath $logFile -Append   
 

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -7,8 +7,8 @@
 # users may find their VM booting into Safe Mode inadvertantly due to user error or misconfiguration,
 # which will disable RDP access until corrected. This script utilizes the az vm repair extension to 
 # clone the VM into a Hyper-V environment using Nested Virtualization and toggle Safe Boot. The user
-# may then access their VM in Safe Mode via the Rescue VM or revert Safe Mode on their Azure VM. They may
-# then swap the disk using the `az vm repair restore` functionality.
+# may then access their VM in Safe Mode via the Rescue VM or revert Safe Mode on their Azure VM. They 
+# may then swap the disk using the `az vm repair restore` functionality.
 #
 # https://docs.microsoft.com/en-us/cli/azure/ext/vm-repair/vm/repair?view=azure-cli-latest
 # https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-rdp-safe-mode
@@ -24,109 +24,104 @@ $logFile = "$env:PUBLIC\Desktop\$($scriptName).log"
 Log-Info 'START: Running Script win-toggle-safe-mode' | out-file -FilePath $logFile -Append
 $scriptStartTime | out-file -FilePath $logFile -Append
 
-# Make sure guest VM is shut down
-$guestHyperVVirtualMachine = Get-VM
-Log-Info "#01 - Stopping nested guest VM $guestHyperVVirtualMachine.VMName" | out-file -FilePath $logFile -Append
-$return = Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
+try {
 
-# Make sure the disk is online
-Log-Info "#02 - Bringing disk online" | out-file -FilePath $logFile -Append
-$disk = get-disk -ErrorAction Stop | where {$_.FriendlyName -eq 'Msft Virtual Disk'}
-$return = $disk | set-disk -IsOffline $false -ErrorAction Stop
+    # Make sure guest VM is shut down
+    $guestHyperVVirtualMachine = Get-VM
+    Log-Info "#01 - Stopping nested guest VM $guestHyperVVirtualMachine.VMName" | out-file -FilePath $logFile -Append
+    $return = Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
+
+    # Make sure the disk is online
+    Log-Info "#02 - Bringing disk online" | out-file -FilePath $logFile -Append
+    $disk = get-disk -ErrorAction Stop | where { $_.FriendlyName -eq 'Msft Virtual Disk' }
+    $return = $disk | set-disk -IsOffline $false -ErrorAction Stop
  
-# Handle disk partitions
-$partitionlist = Get-Disk-Partitions
-Log-Info $partitionlist | out-file -FilePath $logFile -Append
-$partitionGroup = $partitionlist | group DiskNumber | out-file -FilePath $logFile -Append
+    # Handle disk partitions
+    $partitionlist = Get-Disk-Partitions
+    Log-Info $partitionlist | out-file -FilePath $logFile -Append
+    $partitionGroup = $partitionlist | group DiskNumber | out-file -FilePath $logFile -Append
 
-Log-Info '#03 - enumerate partitions to reconfigure boot cfg' | out-file -FilePath $logFile -Append
+    Log-Info '#03 - enumerate partitions for boot config' | out-file -FilePath $logFile -Append
 
-forEach ( $partitionGroup in $partitionlist | group DiskNumber )
-{
-    #reset paths for each part group (disk)
-    $isBcdPath = $false
-    $bcdPath = ''
-    $bcdDrive = ''
-    $isOsPath = $false
-    $osPath = ''
-    $osDrive = ''
+    forEach ( $partitionGroup in $partitionlist | group DiskNumber ) {
+        # Reset paths for each part group (disk)
+        $isBcdPath = $false
+        $bcdPath = ''
+        $bcdDrive = ''
+        $isOsPath = $false
+        $osPath = ''
+        $osDrive = ''
 
-    #scan all partitions of a disk for bcd store and os file location 
-    ForEach ($drive in $partitionGroup.Group | select -ExpandProperty DriveLetter )
-    {      
-        #check if no bcd store was found on the previous partition already
-        if ( -not $isBcdPath )
-        {
-            $bcdPath =  $drive + ':\boot\bcd'
-            $bcdDrive = $drive + ':'
-            $isBcdPath = Test-Path $bcdPath
-
-            #if no bcd was found yet at the default location look for the uefi location too
-            if ( -not $isBcdPath )
-            {
-                $bcdPath =  $drive + ':\efi\microsoft\boot\bcd'
+        # Scan all partitions of a disk for bcd store and os file location 
+        ForEach ($drive in $partitionGroup.Group | select -ExpandProperty DriveLetter ) {      
+            # Check if no bcd store was found on the previous partition already
+            if ( -not $isBcdPath ) {
+                $bcdPath = $drive + ':\boot\bcd'
                 $bcdDrive = $drive + ':'
                 $isBcdPath = Test-Path $bcdPath
-            } 
-        }        
 
-        #check if os loader was found on the previous partition already
-        if (-not $isOsPath)
-        {
-            $osPath = $drive + ':\windows\system32\winload.exe'
-            $isOsPath = Test-Path $osPath
-            if ($isOsPath)
-            {
-                $osDrive = $drive + ':'
+                # If no bcd was found yet at the default location look for the uefi location too
+                if ( -not $isBcdPath ) {
+                    $bcdPath = $drive + ':\efi\microsoft\boot\bcd'
+                    $bcdDrive = $drive + ':'
+                    $isBcdPath = Test-Path $bcdPath
+                } 
+            }        
+
+            # Check if os loader was found on the previous partition already
+            if (-not $isOsPath) {
+                $osPath = $drive + ':\windows\system32\winload.exe'
+                $isOsPath = Test-Path $osPath
+                if ($isOsPath) {
+                    $osDrive = $drive + ':'
+                }
             }
         }
-    }
-        #if both was found grab bcd store
-    if ( $isBcdPath -and $isOsPath )
-    {
-        # Get Safe Mode State
-        Log-Info "#04 - Checking safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
-        $bcdout = bcdedit /store $bcdPath /enum
-        $defaultLine = $bcdout | Select-String 'displayorder' | select -First 1
-        $defaultId = '{'+$defaultLine.ToString().Split('{}')[1] + '}'
-        $safeModeIndicator = $bcdout | Select-String 'safeboot' | select -First 1
+        # If both was found grab bcd store
+        if ( $isBcdPath -and $isOsPath ) {
+            # Get Safe Mode state
+            Log-Info "#04 - Checking safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
+            $bcdout = bcdedit /store $bcdPath /enum
+            $defaultLine = $bcdout | Select-String 'displayorder' | select -First 1
+            $defaultId = '{' + $defaultLine.ToString().Split('{}')[1] + '}'
+            $safeModeIndicator = $bcdout | Select-String 'safeboot' | select -First 1
 
-        # Check if flag exists
-        if ($safeModeIndicator)
-        {            
-            
-            # Flag exists, delete to take VM out of Safe Mode
-            Log-Info "#05 - Removing safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
-            bcdedit /store $bcdPath /deletevalue $defaultId safeboot
-         
-        } else {
-            
-            # Flag doesn't exist, adding so VM boots in Safe Mode
-            Log-Info "#05 - Configuring safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
-            bcdedit /store $bcdPath /set $defaultId safeboot network
+            # Check if flag exists
+            if ($safeModeIndicator) {                        
+                # Flag exists, delete to take VM out of Safe Mode
+                Log-Info "#05 - Removing safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
+                bcdedit /store $bcdPath /deletevalue $defaultId safeboot         
+            }
+            else {            
+                # Flag doesn't exist, adding so VM boots in Safe Mode
+                Log-Info "#05 - Configuring safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
+                bcdedit /store $bcdPath /set $defaultId safeboot network
+            }
+            # Bring disk offline 
+            Log-Info "#06 - Bringing disk offline" | out-file -FilePath $logFile -Append
+            $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
+
+            # Start Hyper-V VM
+            Log-Info "END: Starting VM, please verify Safe Mode w/ Networking using MSCONFIG.exe" | out-file -FilePath $logFile -Append
+            $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
+
+            return $STATUS_SUCCESS
         }
-
-        # Bring disk offline 
-        Log-Info "Bringing disk offline" | out-file -FilePath $logFile -Append
-        $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
-
-        # Start Hyper-V VM
-        Log-Info "END: Starting VM, please verify Safe Mode w/ Networking using MSCONFIG.exe" | out-file -FilePath $logFile -Append
-        $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
-
-        return $STATUS_SUCCESS
     }
 }
+catch {
+    
+    # Log failure to run successfully
+    Log-Error "ERROR: Unable to find the BCD Path" | out-file -FilePath $logFile -Append
 
-# Log failure to run successfully
-Log-Error "Unable to find the BCD Path" | out-file -FilePath $logFile -Append
+    # Bring disk offline again
+    Log-Info "#05 - Bringing disk offline" | out-file -FilePath $logFile -Append
+    $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
 
-# Bring disk offline again
-Log-Info "Bringing disk offline" | out-file -FilePath $logFile -Append
-$return = $disk | set-disk -IsOffline $true -ErrorAction Stop
+    # Start Hyper-V VM again
+    Log-Info "END: could not start Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
+    $return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
 
-# Start Hyper-V VM again
-Log-Info "END: could not start Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
-$return = start-vm $guestHyperVVirtualMachine -ErrorAction Stop
-
-return $STATUS_ERROR
+    throw $_
+    return $STATUS_ERROR
+}

--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -1,35 +1,47 @@
+#########################################################################################################
+<#
+# .SYNOPSIS
+#   Disable Safe Mode if your Windows VM is booting in Safe Mode. Also activates Safe Mode 
+#   if you require it (e.g. to uninstall certain software).
+#
+# .DESCRIPTION
+#   Azure VMs do not natively support Safe Mode because RDP access is disabled in Safe Mode. Some users
+#   need to boot their VM in Safe Mode for specific reasons (e.g. uninstalling certain software). Other
+#   users may find their VM booting into Safe Mode inadvertantly due to user error or misconfiguration,
+#   which will disable RDP access until corrected. This script utilizes the az vm repair extension to 
+#   clone the VM into a Hyper-V environment using Nested Virtualization and toggle Safe Boot. The user
+#   may then access their VM in Safe Mode via the Rescue VM or revert Safe Mode on their Azure VM. They 
+#   may then swap the disk using the `az vm repair restore` functionality.
+#
+#   Testing:
+#       1. Copied scripts to newly created Windows Server 2019 Datacenter (Gen 1)
+#       2. Ran win-enable-nested-hyperv once to install Hyper-V, restarted, and ran again to create new nested VM
+#       3. Ran win-toggle-safe-mode.ps1, worked successfully in toggling Safe Mode
+#       4. Set up new VM and ran the following from my local machine, worked successfully (~69 seconds): 
+#           az vm repair run -g sourcevm_group -n sourcevm --custom-script-file .\win-toggle-safe-mode.ps1 --verbose --run-on-repair
+#       5. Tried on a WS 2016 Gen 2 Azure VM, but was unsuccessful, not compatible with Gen 2 right now
+#       6. Tested on WS2012R2, WS2016 Datacenter, and WS2019 Datacenter (Gen 1)
+#
+#   https://docs.microsoft.com/en-us/cli/azure/ext/vm-repair/vm/repair?view=azure-cli-latest
+#   https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-rdp-safe-mode
+#
+# .PARAMETER safeModeSwitch
+#   "On" to enable Safe Mode, "Off" to disable Safe Mode, no parameter to toggle whatever the current state is.
+#
+# .EXAMPLE
+#   az vm repair run -g sourceRG -n sourceVM --run-id win-toggle-safe-mode --verbose --run-on-repair
+#   az vm repair run -g sourceRG -n sourceVM --run-id win-toggle-safe-mode --parameters safeModeSwitch=on --verbose --run-on-repair
+#   az vm repair run -g sourceRG -n sourceVM --run-id win-toggle-safe-mode --parameters safeModeSwitch=off --verbose --run-on-repair
+#>
+#########################################################################################################
+
+# Set the Parameters for the script
+Param([Parameter(Mandatory = $false)][string]$safeModeSwitch = '')
+
+# Initialize script
 . .\src\windows\common\setup\init.ps1
 . .\src\windows\common\helpers\Get-Disk-Partitions.ps1
-
-#########################################################################################################
-# Azure VMs do not natively support Safe Mode because RDP access is disabled in Safe Mode. Some users
-# need to boot their VM in Safe Mode for specific reasons (e.g. uninstalling certain software). Other
-# users may find their VM booting into Safe Mode inadvertantly due to user error or misconfiguration,
-# which will disable RDP access until corrected. This script utilizes the az vm repair extension to 
-# clone the VM into a Hyper-V environment using Nested Virtualization and toggle Safe Boot. The user
-# may then access their VM in Safe Mode via the Rescue VM or revert Safe Mode on their Azure VM. They 
-# may then swap the disk using the `az vm repair restore` functionality.
-#
-# Testing:
-# 1. Copied scripts to newly created Windows Server 2019 Datacenter (Gen 1)
-# 2. Ran win-enable-nested-hyperv once to install Hyper-V, restarted, and ran again to create new nested VM
-# 3. Ran win-toggle-safe-mode.ps1, worked successfully in toggling Safe Mode
-# 4. Set up new VM and ran the following from my local machine, worked successfully (~69 seconds): 
-#    az vm repair run -g sourcevm_group -n sourcevm --custom-script-file .\win-toggle-safe-mode.ps1 --verbose --run-on-repair
-# 5. Tried on a WS 2016 Gen 2 Azure VM, but was unsuccessful, not compatible with Gen 2 right now
-#
-# https://docs.microsoft.com/en-us/cli/azure/ext/vm-repair/vm/repair?view=azure-cli-latest
-# https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-rdp-safe-mode
-#########################################################################################################
-
-# Initialize script log variables
-$scriptStartTime = get-date -f yyyyMMddHHmmss
-$scriptName = (split-path -path $MyInvocation.MyCommand.Path -leaf).Split('.')[0]
-
-# Initialize script log
-$logFile = "$env:PUBLIC\Desktop\$($scriptName).log"
-Log-Output 'START: Running script win-toggle-safe-mode' | out-file -FilePath $logFile -Append
-$scriptStartTime | out-file -FilePath $logFile -Append
+Log-Output 'START: Running script win-toggle-safe-mode'
 
 try {
 
@@ -38,16 +50,16 @@ try {
     $guestHyperVVirtualMachineName = $guestHyperVVirtualMachine.VMName
     if ($guestHyperVVirtualMachine) {
         if ($guestHyperVVirtualMachine.State -eq 'Running') {
-            Log-Info "#01 - Stopping nested guest VM $guestHyperVVirtualMachineName" | out-file -FilePath $logFile -Append
+            Log-Output "#01 - Stopping nested guest VM $guestHyperVVirtualMachineName"
             Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force   
         }         
     }
     else {
-        Log-Info "#01 - No nested guest VM, flipping safeboot switch anyways" | out-file -FilePath $logFile -Append
+        Log-Output "#01 - No nested guest VM, flipping safeboot switch anyways"
     }  
 
     # Make sure the disk is online
-    Log-Info "#02 - Bringing disk online" | out-file -FilePath $logFile -Append
+    Log-Output "#02 - Bringing disk online"
     $disk = get-disk -ErrorAction Stop | where { $_.FriendlyName -eq 'Msft Virtual Disk' }
     $disk | set-disk -IsOffline $false -ErrorAction Stop
  
@@ -55,7 +67,7 @@ try {
     $partitionlist = Get-Disk-Partitions
     $partitionGroup = $partitionlist | group DiskNumber
 
-    Log-Info '#03 - enumerate partitions for boot config' | out-file -FilePath $logFile -Append
+    Log-Output '#03 - enumerate partitions for boot config'
 
     forEach ( $partitionGroup in $partitionlist | group DiskNumber ) {
         # Reset paths for each part group (disk)
@@ -89,65 +101,66 @@ try {
         if ( $isBcdPath -and $isOsPath ) {
 
             # Get Safe Mode state
-            Log-Info "#04 - Checking safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
+            Log-Output "#04 - Checking safeboot flag for $bcdPath"
             $bcdout = bcdedit /store $bcdPath /enum
             $defaultLine = $bcdout | Select-String 'displayorder' | select -First 1
             $defaultId = '{' + $defaultLine.ToString().Split('{}')[1] + '}'
             $safeModeIndicator = $bcdout | Select-String 'safeboot' | select -First 1
 
-            # Check if flag exists
-            if ($safeModeIndicator) {                        
-                # Flag exists, delete to take VM out of Safe Mode
-                Log-Info "#05 - Removing safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
-                bcdedit /store $bcdPath /deletevalue $defaultId safeboot         
-            }
-            else {            
-                # Flag doesn't exist, adding so VM boots in Safe Mode
-                Log-Info "#05 - Configuring safeboot flag for $bcdPath" | out-file -FilePath $logFile -Append
+            if ($safeModeSwitch -eq "on") {
+                # Setting flag so VM boots in Safe Mode
+                Log-Output "#05 - Configuring safeboot flag for $bcdPath"
                 bcdedit /store $bcdPath /set $defaultId safeboot network
+            }
+            elseif ($safeModeSwitch -eq "off") {
+                # Removing flag so VM doesn't boot in Safe Mode   
+                Log-Output "#05 - Removing safeboot flag for $bcdPath"             
+                bcdedit /store $bcdPath /deletevalue $defaultId safeboot
+            }
+            else {
+                
+                # Toggle Mode, check if flag exists
+                if ($safeModeIndicator) {                        
+                    # Flag exists, delete to take VM out of Safe Mode
+                    Log-Output "#05 - Removing safeboot flag for $bcdPath"
+                    bcdedit /store $bcdPath /deletevalue $defaultId safeboot
+                }
+                else {            
+                    # Flag doesn't exist, adding so VM boots in Safe Mode
+                    Log-Output "#05 - Configuring safeboot flag for $bcdPath"
+                    bcdedit /store $bcdPath /set $defaultId safeboot network
+                }
             }
 
             if ($guestHyperVVirtualMachine) {
                 # Bring disk offline 
-                Log-Info "#06 - Bringing disk offline" | out-file -FilePath $logFile -Append
+                Log-Output "#06 - Bringing disk offline"
                 $disk | set-disk -IsOffline $true -ErrorAction Stop
 
                 # Start Hyper-V VM            
-                Log-Output "#07 - Starting VM" | out-file -FilePath $logFile -Append
+                Log-Output "#07 - Starting VM"
                 start-vm $guestHyperVVirtualMachine -ErrorAction Stop
             }
 
-            Log-Output "END: Please verify status of Safe Mode using MSCONFIG.exe" | out-file -FilePath $logFile -Append
-
-            # Log finish time
-            $scriptEndTime = get-date -f yyyyMMddHHmmss
-            $scriptEndTime | out-file -FilePath $logFile -Append
-
+            Log-Output "END: Please verify status of Safe Mode using MSCONFIG.exe"
             return $STATUS_SUCCESS
         }
     }
 }
 catch {
     
-    # Log failure
-    Log-Error "ERROR: Unable to find the BCD Path" | out-file -FilePath $logFile -Append
-
     if ($guestHyperVVirtualMachine) {
         # Bring disk offline again
-        Log-Info "#05 - Bringing disk offline to restart Hyper-V VM" | out-file -FilePath $logFile -Append
+        Log-Output "#05 - Bringing disk offline to restart Hyper-V VM"
         $disk | set-disk -IsOffline $true -ErrorAction Stop
 
         # Start Hyper-V VM again
-        Log-Output "#06 - Starting VM" | out-file -FilePath $logFile -Append
+        Log-Output "#06 - Starting VM"
         start-vm $guestHyperVVirtualMachine -ErrorAction Stop
     }
 
-    Log-Output "END: could not start/stop Safe Mode, BCD store may need to be repaired" | out-file -FilePath $logFile -Append
-
-    # Log finish time
-    $scriptEndTime = get-date -f yyyyMMddHHmmss
-    $scriptEndTime | out-file -FilePath $logFile -Append   
-
-    throw $_ | out-file -FilePath $logFile -Append
+    # Log failure scenario
+    Log-Error "END: could not start/stop Safe Mode, BCD store may need to be repaired"
+    throw $_
     return $STATUS_ERROR
 }


### PR DESCRIPTION
 Azure VMs do not natively support Safe Mode because RDP access is disabled in Safe Mode. Some users need to boot their VM in Safe Mode for specific reasons (e.g. uninstalling certain software). Other users may find their VM booting into Safe Mode inadvertantly due to user error or misconfiguration, which will disable RDP access until corrected. This script utilizes the az vm repair extension to clone the VM into a Hyper-V environment using Nested Virtualization and toggle Safe Boot. The user may then access their VM in Safe Mode via the Rescue VM or revert Safe Mode on their Azure VM. They may then swap the disk using the `az vm repair restore` functionality.

Testing:
1. Copied scripts to newly created Windows Server 2019 Datacenter (Gen 1)
2. Ran win-enable-nested-hyperv once to install Hyper-V, restarted, and ran again to create new nested VM
3. Ran win-toggle-safe-mode.ps1, worked successfully in toggling Safe Mode
4. Set up new VM and ran the following from my local machine, worked successfully (~69 seconds): `az vm repair run -g sourcevm_group -n sourcevm --custom-script-file .\win-toggle-safe-mode.ps1 --verbose --run-on-repair`
5. Tried on a WS 2016 Gen 2 Azure VM, but was unsuccessful, not compatible with Gen 2 right now

* https://docs.microsoft.com/en-us/cli/azure/ext/vm-repair/vm/repair?view=azure-cli-latest
* https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/troubleshoot-rdp-safe-mode