### PR TITLE
win-dumpconfigurator typo

### DIFF
--- a/src/windows/win-dumpconfigurator.ps1
+++ b/src/windows/win-dumpconfigurator.ps1
@@ -63,7 +63,7 @@ if ($DDFileLength -gt 0)
     {
         if ([bool]((Get-itemproperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl").DedicatedDumpFile)) 
         {
-            Remove-ItemProperty -Path $CrashCtrlPath -Name DedicatedDumpFiled
+            Remove-ItemProperty -Path $CrashCtrlPath -Name DedicatedDumpFile
         }
 
     }else


### PR DESCRIPTION

Changed
Remove-ItemProperty -Path $CrashCtrlPath -Name DedicatedDumpFiled
To:
Remove-ItemProperty -Path $CrashCtrlPath -Name DedicatedDumpFile

