### PR TITLE
Support for gen2 Nested Hyper-V VMs

### DIFF
--- a/src/windows/win-enable-nested-hyperv.ps1
+++ b/src/windows/win-enable-nested-hyperv.ps1
@@ -83,7 +83,6 @@ if ($hyperv.Installed -and $hypervTools.Installed -and $hypervPowerShell.Install
         $return = set-vm -name $nestedGuestVmName -ProcessorCount 2 -CheckpointType Disabled -ErrorAction Stop
         $disk = get-disk -ErrorAction Stop | where {$_.FriendlyName -eq 'Msft Virtual Disk'}
         $return = $disk | set-disk -IsOffline $true -ErrorAction Stop
-        $return = $disk | Add-VMHardDiskDrive -VMName $nestedGuestVmName -ErrorAction Stop
 
         if (!$gen) {
             Log-Info "Gen1: Adding hard drive to IDE controller" | Out-File -FilePath $logFile -Append
@@ -93,7 +92,7 @@ if ($hyperv.Installed -and $hypervTools.Installed -and $hypervPowerShell.Install
             Log-Info "Gen$($gen): Adding hard drive to SCSI controller" | Out-File -FilePath $logFile -Append
             $return = $disk | Add-VMHardDiskDrive -VMName $nestedGuestVmName -ControllerType SCSI -ControllerNumber 0 -ErrorAction Stop
             Log-Info "Gen$($gen): Modifying firmware boot order (we do not need to network boot)" | Out-File -FilePath $logFile -Append
-            $return = Set-VMFirmware $nestedGuestVmName -FirstBootDevice ((Get-VMFirmware $nestedGuestVmName).BootOrder | Where-Object { $_.BootType -eq "File" })[0]
+            $return = Set-VMFirmware $nestedGuestVmName -FirstBootDevice ((Get-VMFirmware $nestedGuestVmName).BootOrder | Where-Object { $_.BootType -eq "Drive" })[0]
         }
 
         $return = $switch | Connect-VMNetworkAdapter -VMName $nestedGuestVmName -ErrorAction Stop


### PR DESCRIPTION
## Purpose
win-enable-nested-hyperv.ps1 was recently updated on GitHub to include a generation parameter $gen, but fails on a Gen2 OS disk due to the error  “Generation 2 virtual machines do not support IDE.” This update is to fix the error.

## Usage
- If the source/broken VM is Gen1, no parameter needs to be passed. Works as it always does.
- If the source/broken VM is Gen2, set $gen parameter equal to 2 when running the script. The updated script then:
  - adds the hard drive to the SCSI controller instead of the IDE controller (Gen2 VMs only support SCSI)
  - adjusts the boot order so the hard drive boots first (prevents PXE boot attempt, which saves some time on first startup)

## Testing
- Since I couldn't pass in a parameter to test at this time or point az vm repair to another repo for testing just yet, I adapted the logic from the primary script to test within the rescue VM with 4 different OS drives from Gen2 Azure VMs (attached one at a time, then removed after successfully creating a new VM):
  - "2012-r2-datacenter-gensecond"
  - "2016-datacenter-gensecond"
  - "2019-datacenter-gensecond"
  - "2022-datacenter-g2"
- All successful:

```PowerShell
    Write-Host 'START: Creating nested guest VM' | out-file -FilePath $logFile -Append 
    # Sets "Do not start Server Manager automatically at logon" 
    $return = New-ItemProperty -Path HKLM:\Software\Microsoft\ServerManager -Name DoNotOpenServerManagerAtLogon -PropertyType DWORD -Value 1 -force -ErrorAction SilentlyContinue 
    $return = New-ItemProperty -Path HKLM:\Software\Microsoft\ServerManager\Oobe -Name DoNotOpenInitialConfigurationTasksAtLogon -PropertyType DWORD -Value 1 -force -ErrorAction SilentlyContinue 

    try { 

        # Configure NAT so nested guest has external network connectivity 
        # See also https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/user-guide/nested-virtualization#networking-options 
        $switch = Get-VMSwitch -Name Internal -SwitchType Internal -ErrorAction SilentlyContinue | select -first 1 
        if (!$switch) 
        { 
            $switch = New-VMSwitch -Name Internal -SwitchType Internal -ErrorAction Stop 
            Write-Host 'New VMSwitch Successfully created' | out-file -FilePath $logFile -Append 
        } 
        $adapter = Get-NetAdapter -Name 'vEthernet (Internal)' -ErrorAction Stop 

        $ip = get-netipaddress -IPAddress 192.168.0.1 -ErrorAction SilentlyContinue | select -first 1 
        if (!$ip) 
        { 
            $return = New-NetIPAddress -IPAddress 192.168.0.1 -PrefixLength 24 -InterfaceIndex $adapter.ifIndex -ErrorAction Stop 
            Write-Host 'New NetIPAddress Successfully created' | out-file -FilePath $logFile -Append 
        } 

        $nat = Get-NetNat -Name InternalNAT -ErrorAction SilentlyContinue | select -first 1 
        if (!$nat) 
        { 
            $return = New-NetNat -Name InternalNAT -InternalIPInterfaceAddressPrefix 192.168.0.0/24 -ErrorAction Stop 
            Write-Host 'New NetNat Successfully created' | out-file -FilePath $logFile -Append 
        } 

        # Configure DHCP server service so nested guest can get an IP from DHCP and will use 168.63.129.16 for DNS and 192.168.0.1 as default gateway 
        if ($dhcp.Installed -eq $false -or $rsatDhcp.Installed -eq $false) 
        { 
            $return = Install-WindowsFeature -Name DHCP -IncludeManagementTools -ErrorAction Stop 
            Write-Host 'New NetIPAddress Successfully created' | out-file -FilePath $logFile -Append 
        } 
        $scope = Get-DhcpServerv4Scope -ErrorAction SilentlyContinue | where Name -eq Scope1 | select -first 1 
        if (!$scope) 
        { 
            $return = Add-DhcpServerV4Scope -Name Scope1 -StartRange 192.168.0.100 -EndRange 192.168.0.200 -SubnetMask 255.255.255.0 -ErrorAction Stop 
        } 
        $return = Set-DhcpServerv4OptionValue -DnsServer 168.63.129.16 -Router 192.168.0.1 -ErrorAction Stop 

        # Create the nested guest VM 
        if (!$gen) { 
            Write-Host 'Creating Gen1 VM with 4GB memory' | Out-File -FilePath $logFile -Append 
            $return = New-VM -Name $nestedGuestVmName -MemoryStartupBytes 4GB -NoVHD -BootDevice IDE -Generation 1 -ErrorAction Stop 
        } 
        else { 
            Write-Host "Creating Gen$($gen) VM with 4GB memory" | Out-File -FilePath $logFile -Append 
            $return = New-VM -Name $nestedGuestVmName -MemoryStartupBytes 4GB -NoVHD -Generation $gen -ErrorAction Stop 
        } 
        $return = set-vm -name $nestedGuestVmName -ProcessorCount 2 -CheckpointType Disabled -ErrorAction Stop 
        $disk = get-disk -ErrorAction Stop | where {$_.FriendlyName -eq 'Msft Virtual Disk'} 
        $return = $disk | set-disk -IsOffline $true -ErrorAction Stop 

        if (!$gen) { 
            Write-Host "Gen1: Adding hard drive to IDE controller" | Out-File -FilePath $logFile -Append 
            $return = $disk | Add-VMHardDiskDrive -VMName $nestedGuestVmName -ErrorAction Stop             
        } 
        else { 
            Write-Host "Gen$($gen): Adding hard drive to SCSI controller" | Out-File -FilePath $logFile -Append 
            $return = $disk | Add-VMHardDiskDrive -VMName $nestedGuestVmName -ControllerType SCSI -ControllerNumber 0 -ErrorAction Stop 
            Write-Host "Gen$($gen): Modifying firmware boot order (we do not need to network boot)" | Out-File -FilePath $logFile -Append 
$return = Set-VMFirmware $nestedGuestVmName -FirstBootDevice ((Get-VMFirmware $nestedGuestVmName).BootOrder | Where-Object { $_.BootType -eq "Drive" })[0] 
        } 

        $return = $switch | Connect-VMNetworkAdapter -VMName $nestedGuestVmName -ErrorAction Stop 
        $return = start-vm -Name $nestedGuestVmName 
        $nestedGuestVmState = (get-vm -Name $nestedGuestVmName -ErrorAction Stop).State 

        # Create a batch file in the all users startup folder so both Hyper-V Manager and VMConnect run automatically at logon. 
        $return = $batchFileContents | out-file -FilePath $batchFile -Force -Encoding Default 
        $return = copy-item -path "C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Administrative Tools\Hyper-V Manager.lnk" -Destination "C:\Users\Public\Desktop" 
        # Suppress the prompt for "Do you want to allow your PC to be discoverable by other PCs and devices on this network" 
        $return = new-item -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff" -Force 
        "END: Creating nested guest VM" | out-file -FilePath $logFile -Append 
    } 
    catch { 
        throw $_ 
        return $STATUS_ERROR 
    } 

    # Returns the nested guest VM status to the calling script - "Running" if all went well. 
    $nestedGuestVmState 
```