### PR TITLE
Fix for issue 29

### DIFF
--- a/src/linux/common/helpers/alar2/Cargo.toml
+++ b/src/linux/common/helpers/alar2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alar2"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["malachma <malachma@microsoft.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/linux/common/helpers/alar2/README.md
+++ b/src/linux/common/helpers/alar2/README.md
@@ -37,7 +37,7 @@ The script-id for the automated recovery is: linux-alar2
 
 #### Example ####
 
-az vm repair create --verbose -g centos7 -n cent7 --repair-username rescue --repair-password 'password!234’ 
+az vm repair create --verbose -g centos7 -n cent7 --repair-username rescue --repair-password 'password!234’ --copy-disk-name repairdiskcopy'
 
 az vm repair run --verbose -g centos7 -n cent7 --run-id linux-alar2 --parameters initrd --run-on-repair
 

--- a/src/linux/common/helpers/alar2/src/Changelog
+++ b/src/linux/common/helpers/alar2/src/Changelog
@@ -1,3 +1,8 @@
+20022-02-17  Marcus Lachmanez  <malachma@microsoft.com>
+    * version changed to 0.3.1
+    * fixed the issue (https://github.com/Azure/repair-script-library/issues/29)
+      Ubuntu distro or RedHat/CentOS distros yre recognized correct
+      previous kernel version is set correct. Workarounds for 8.1 or 8.2 removed
 20022-01-17  Marcus Lachmanez  <malachma@microsoft.com>
     * version changed to 0.3
     * fixed an issue with identifying RedHat images

--- a/src/linux/common/helpers/alar2/src/action_implementation/kernel-impl.sh
+++ b/src/linux/common/helpers/alar2/src/action_implementation/kernel-impl.sh
@@ -5,75 +5,36 @@
 # From the man page
 # Set the default boot menu entry for GRUB.  This requires setting GRUB_DEFAULT=saved in /etc/default/grub
 set_grub_default() {
-        # if not set to saved, replace it
+        # verify whether GRUB_DEFAULT is available
+        grep -q 'GRUB_DEFAULT=.*' /etc/default/grub || echo 'GRUB_DEFAULT=saved' >>/etc/default/grub
+        # The next line could be garded and/or improved with the help of an if for instance
+        # though I keep it simple
         sed -i "s/GRUB_DEFAULT=[[:digit:]]/GRUB_DEFAULT=saved/" /etc/default/grub
 }
 
 # set the default kernel accordingly
 # This is different for RedHat and Ubuntu/SUSE distros
 # Ubuntu and SLES use sub-menues
+# Variables are set by action.rs
 
-# the variables are defined in base.sh
 if [[ $isRedHat == "true" ]]; then
         if [[ $isRedHat6 == "true" ]]; then
                 grubby --set-default=1 # This is the previous kernel
                 ldconfig
         else
                 set_grub_default
-                grubby --set-default=1 # This is the previous kernel
+                # set to previous kernel
+                sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT=1/' /etc/default/grub
 
-                if [[ $(grep -qe 'VERSION_ID=\"7.\?[1-9]\?\"' /etc/os-release) ]]; then
+                if [[ -d /sys/firmware/efi ]]; then
+                        grub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
+                else
                         grub2-mkconfig -o /boot/grub2/grub.cfg
                 fi
 
-                # Exception for RedHat 8.0 i.e sku RedHat:RHEL-HA:8.0:8.0.2020021914
-                # here we don't have to run the patch operation
-                if [[ $(grep -qe 'VERSION_ID="8\.0"' /etc/os-release) -eq 0 ]]; then
-                        grub2-mkconfig -o /boot/grub2/grub.cfg
-                fi
-
-                # Fix for a bug in RedHat 8.1/8.2
-                # https://bugzilla.redhat.com/show_bug.cgi?id=1850193
-                # This needs to be fixed as soon as the bug with grub2-mkconfig is solved too
-                if [[ ($(grep -qe 'ID="rhel"' /etc/os-release) -eq 0) && ($(grep -qe 'VERSION_ID=\"8.\?[1-2]\?\"' /etc/os-release) -eq 0) ]]; then 
-                        # no bug with UEFI
-                        if [[ -d /sys/firmware/efi ]]; then 
-                                grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
-                        else
-
-cat > /boot/grub2/grub-cfg.patch <<EOF
-11,12c
-if [ -f (hd0,gpt15)/efi/redhat/grubenv ]; then
-load_env -f (hd0,gpt15)/efi/redhat/grubenv
-.
-EOF
-grub2-mkconfig -o /boot/grub2/grub.cfg
-
-                                # Need to handle the condition where grubenv is a softlink
-                                # This needs to be fixed if the new grub2 for redhat is available -->  https://bugzilla.redhat.com/show_bug.cgi?id=1850193
-                                if [[ -L /boot/grub2/grubenv ]]; then
-                                        yum install -y patch
-                                        patch /boot/grub2/grub.cfg /boot/grub2/grub-cfg.patch
-                                fi
-
-                                # These lines are required as we have the ld.so.cache not build correct
-                                # Otherwise this can lead in no functional network afterwards
-                                # TODO find a better solution and the root cause for it
-                                mv /sbin/dhclient /sbin/dhclient.org
-cat > /sbin/dhclient <<EOF
-#!/bin/bash
-# This script got created by linux-alar-fki
-# in order to fix an ld.so.cache issue that does the dhclient not to work properly
-ldconfig
-/sbin/dhclient.org
-EOF
-chmod 755 /sbin/dhclient
-                        fi
-                fi
+                # enable sysreq
+                echo "kernel.sysrq = 1" >>/etc/sysctl.conf
         fi
-
-        # enable sysreq
-        echo "kernel.sysrq = 1" >> /etc/sysctl.conf
 fi
 
 if [[ $isUbuntu == "true" ]]; then

--- a/src/linux/common/helpers/alar2/src/action_implementation/kernel-impl.sh
+++ b/src/linux/common/helpers/alar2/src/action_implementation/kernel-impl.sh
@@ -27,7 +27,7 @@ if [[ $isRedHat == "true" ]]; then
                 sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT=1/' /etc/default/grub
 
                 # Generate both config files. 
-                rub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
+                grub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
                 grub2-mkconfig -o /boot/grub2/grub.cfg
 
                 # enable sysreq

--- a/src/linux/common/helpers/alar2/src/action_implementation/kernel-impl.sh
+++ b/src/linux/common/helpers/alar2/src/action_implementation/kernel-impl.sh
@@ -26,11 +26,9 @@ if [[ $isRedHat == "true" ]]; then
                 # set to previous kernel
                 sed -i -e 's/GRUB_DEFAULT=.*/GRUB_DEFAULT=1/' /etc/default/grub
 
-                if [[ -d /sys/firmware/efi ]]; then
-                        grub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
-                else
-                        grub2-mkconfig -o /boot/grub2/grub.cfg
-                fi
+                # Generate both config files. 
+                rub2-mkconfig -o /boot/efi/EFI/$(ls /boot/efi/EFI | grep -i -E "centos|redhat")/grub.cfg
+                grub2-mkconfig -o /boot/grub2/grub.cfg
 
                 # enable sysreq
                 echo "kernel.sysrq = 1" >>/etc/sysctl.conf

--- a/src/linux/common/helpers/alar2/src/cli.rs
+++ b/src/linux/common/helpers/alar2/src/cli.rs
@@ -40,7 +40,7 @@ one or more different actions in order to get a VM in a running state that allow
 the administrator to further recover the VM after it is up, running and accessible again.
 ";
    let matches = App::new("Azure Linux Auto Recover")
-                          .version("0.3")
+                          .version("0.3.1")
                           .author("Marcus Lachmanez , malachma@microsoft.com")
                           .about(about)
                           .arg(Arg::with_name("standalone")

--- a/src/linux/common/helpers/alar2/src/distro.rs
+++ b/src/linux/common/helpers/alar2/src/distro.rs
@@ -234,8 +234,9 @@ fn do_recent_ubuntu_or(partition_info: Vec<String>, distro: &mut Distro) {
     ubuntu::do_ubuntu(partition_info, distro);
 
     // In the next step we figure out what it is
-    ubuntu::verify_ubuntu(distro);
+    // The order is important otherwise an incorrect distro gets reported
     redhat::verify_redhat_nolvm(distro);
+    ubuntu::verify_ubuntu(distro);
 }
 
 // if we have 4 partition detected


### PR DESCRIPTION
This PR fix the issues report in #29 
Fixed the order in which the distros are verified. 
Removed the code for the 8.1 and 8.2 workarounds.
Simplified how the default kernel gets loaded as the behaviour for grubby is not consistent.
grub.cfg is now created for both EFI and non EFI VM at the same time. 