### PR TITLE
Azure Guest Agent Offline Fixer

### DIFF
--- a/src/windows/GA_offlinefixer_damunozl.ps1
+++ b/src/windows/GA_offlinefixer_damunozl.ps1
@@ -7,7 +7,6 @@ cmd /c color 0A
 $title="                                                                                  --== VMAgent Fixer by Daniel Muñoz L ==--"
 $host.UI.RawUI.WindowTitle = $Title
 # Welcome to the VMAgent fixer by Daniel Muñoz L!"
-# ***** THIS SCRIPT MUST RUN IN AN ELEVATED CMD WITH ADMIN CREDENTIALS *****"
 
 # Rescue OS variable
 $diska='c'
@@ -37,12 +36,10 @@ if (Test-Path -Path 'h:\Windows') {
 "Path doesn't exist."
 }}}}}}}
 
-
 # HIVE LOADER
 # A Backup of the BROKENSYSTEM was taken and left on $($diskb):\ as regbackupbeforeGAchanges just in case!
 reg load "HKLM\BROKENSYSTEM" "$($diskb):\Windows\System32\config\SYSTEM"
 reg export "HKLM\BROKENSYSTEM" "$($diskb):\regbackupbeforeGAchanges" /y
-
 
 # EXPORTING GOOD VMAGENT REGS FROM RESCUE VM
 reg export "HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\WindowsAzureGuestAgent" "$($diskb):\WAGA.reg" /y
@@ -71,7 +68,6 @@ reg export "HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\RdAgent" "$($diskb)
 regedit /s "$($diskb):\WATS.reg"
 regedit /s "$($diskb):\WAGA.reg"
 regedit /s "$($diskb):\RdAgent.reg"
-
 
 # BACKUP TAKEN ON FOLDER $($diskb):\WindowsazurefaultyGAbackup"
 mkdir "$($diskb):\WindowsazurefaultyGAbackup"

--- a/src/windows/GA_offlinefixer_damunozl.ps1
+++ b/src/windows/GA_offlinefixer_damunozl.ps1
@@ -1,0 +1,110 @@
+# Contact me Daniel Muñoz L : damunozl@microsoft.com if support is required.
+# Echo off null outputs
+out-null
+
+# Change color
+cmd /c color 0A
+
+# Change title of console
+$title="                                                                                  --== VMAgent Fixer by Daniel Muñoz L ==--"
+$host.UI.RawUI.WindowTitle = $Title
+
+# Clear Screen
+Clear-Host
+
+Write-Output "Welcome to the VMAgent fixer by Daniel Muñoz L!"
+Write-output ""
+Write-Output "***** THIS SCRIPT MUST RUN IN AN ELEVATED CMD WITH ADMIN CREDENTIALS *****"
+Write-output ""
+# get-psdrive -psprovider filesystem
+
+# Rescue OS variable
+$diska='c'
+
+# Finder for faulty OS letter
+if (Test-Path -Path 'l:\Windows') {
+  $diskb='l'
+} else {
+if (Test-Path -Path 'i:\Windows') {
+  $diskb='i'
+} else {
+if (Test-Path -Path 'g:\Windows') {
+  $diskb='g'
+} else {
+if (Test-Path -Path 'j:\Windows') {
+  $diskb='j'
+} else {
+if (Test-Path -Path 'k:\Windows') {
+  $diskb='k'
+} else {
+if (Test-Path -Path 'f:\Windows') {
+  $diskb='f'
+} else {
+if (Test-Path -Path 'h:\Windows') {
+  $diskb='h'
+} else {	
+"Path doesn't exist."
+}}}}}}}
+
+
+# Hive loader into rescue VM
+reg load "HKLM\BROKENSYSTEM" "$($diskb):\Windows\System32\config\SYSTEM"
+reg export "HKLM\BROKENSYSTEM" "$($diskb):\regbackupbeforeGAchanges" /y
+Write-output ""
+write-output "A Backup of the BROKENSYSTEM was taken and left on $($diskb):\ as regbackupbeforeGAchanges just in case!"
+
+# EXPORTING GOOD VMAGENT REGS!
+reg export "HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\WindowsAzureGuestAgent" "$($diskb):\WAGA.reg" /y
+# Telemetry service was merged into rdagent so an error might be displayed for wats
+reg export "HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\WindowsAzureTelemetryService" "$($diskb):\WATS.reg"  /y
+reg export "HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\RdAgent" "$($diskb):\RdAgent.reg" /y
+
+# MODIFYING REG FILES!
+(gc "$($diskb):\waga.reg") -replace 'LocalSystem', 'notyet' | Out-File "$($diskb):\waga.reg"
+(gc "$($diskb):\waga.reg") -replace 'system', 'BROKENSYSTEM' | Out-File "$($diskb):\waga.reg"
+(gc "$($diskb):\waga.reg") -replace 'notyet', 'localsystem' | Out-File "$($diskb):\waga.reg"
+Write-output "                                   -----------============-----------"
+# Telemetry service was merged into rdagent so an error might be displayed for wats
+(gc "$($diskb):\wats.reg") -replace 'LocalSystem', 'notyet' | Out-File "$($diskb):\wats.reg"
+(gc "$($diskb):\wats.reg") -replace 'system', 'BROKENSYSTEM' | Out-File "$($diskb):\wats.reg"
+(gc "$($diskb):\wats.reg") -replace 'notyet', 'localsystem' | Out-File "$($diskb):\wats.reg"
+Write-output "                                   -----------============-----------"
+(gc "$($diskb):\RdAgent.reg") -replace 'LocalSystem', 'notyet' | Out-File "$($diskb):\RdAgent.reg"
+(gc "$($diskb):\RdAgent.reg") -replace 'system', 'BROKENSYSTEM' | Out-File "$($diskb):\RdAgent.reg"
+(gc "$($diskb):\RdAgent.reg") -replace 'notyet', 'localsystem' | Out-File "$($diskb):\RdAgent.reg"
+Write-output "                                   -----------============-----------"
+Write-output "ADDING REG FILES IN %diskb% DRIVE!"
+regedit /s "$($diskb):\WATS.reg"
+regedit /s "$($diskb):\WAGA.reg"
+regedit /s "$($diskb):\RdAgent.reg"
+Write-output ""
+Write-output "RESTORING VMAgent BIN FILES!"
+mkdir "$($diskb):\WindowsazurefaultyGAbackup"
+xcopy "$($diskb):\WindowsAzure" "$($diskb):\WindowsazurefaultyGAbackup" /e /h /y
+Write-output ""
+Write-output "BACKUP TAKEN ON FOLDER $($diskb):\WindowsazurefaultyGAbackup"
+Write-output ""
+del "$($diskb):\WindowsAzure" -force -recurse
+mkdir "$($diskb):\WindowsAzure"
+xcopy "$($diska):\WindowsAzure" "$($diskb):\WindowsAzure" /e /h /y
+Write-output ""
+Write-output "VMAgent FILES RESTORED!"
+Write-output ""
+del "$($diskb):\WindowsAzure\logs" -force -recurse
+Write-output ""
+Write-output "A Backup was created on the following folder $($diskb)\WindowsazurefaultyGAbackup in case the folder existed."
+Write-output "Unloading HIVE"
+reg.exe unload "HKLM\BROKENSYSTEM"
+del "$($diskb):\rdagent.reg" -force
+del "$($diskb):\waga.reg" -force
+del "$($diskb):\wats.reg" -force
+
+Write-output "IF FOR SOME REASON THE SCRIPT FAILED AT SOME POINT, PLEASE DO NOT ATTEMPT TO RUN THE SCRIPT AGAIN."
+Write-output "REASONS WHY THE SCRIPT COULD HAVE FAILED:"
+Write-output ""
+Write-output "* Drive letters swapped. (This could affect the troubleshooter VM)"
+Write-output "* Used colon character, extra blank spaces and/or typos when the drive letter(s) was/were typed."
+Write-output "* Windows directories have different names from the standard(example: c:\windows)"
+Write-output ""
+Write-output "I hope this script fixes the VMAgent accordingly. :)"
+Write-output ""

--- a/src/windows/GA_offlinefixer_damunozl.ps1
+++ b/src/windows/GA_offlinefixer_damunozl.ps1
@@ -2,26 +2,17 @@
 # Echo off null outputs
 out-null
 
-# Change color
+# Change color, title and welcome
 cmd /c color 0A
-
-# Change title of console
 $title="                                                                                  --== VMAgent Fixer by Daniel Muñoz L ==--"
 $host.UI.RawUI.WindowTitle = $Title
-
-# Clear Screen
-Clear-Host
-
-Write-Output "Welcome to the VMAgent fixer by Daniel Muñoz L!"
-Write-output ""
-Write-Output "***** THIS SCRIPT MUST RUN IN AN ELEVATED CMD WITH ADMIN CREDENTIALS *****"
-Write-output ""
-# get-psdrive -psprovider filesystem
+# Welcome to the VMAgent fixer by Daniel Muñoz L!"
+# ***** THIS SCRIPT MUST RUN IN AN ELEVATED CMD WITH ADMIN CREDENTIALS *****"
 
 # Rescue OS variable
 $diska='c'
 
-# Finder for faulty OS letter
+# FINDER FOR FAULTY OS DRIVE
 if (Test-Path -Path 'l:\Windows') {
   $diskb='l'
 } else {
@@ -47,64 +38,54 @@ if (Test-Path -Path 'h:\Windows') {
 }}}}}}}
 
 
-# Hive loader into rescue VM
+# HIVE LOADER
+# A Backup of the BROKENSYSTEM was taken and left on $($diskb):\ as regbackupbeforeGAchanges just in case!
 reg load "HKLM\BROKENSYSTEM" "$($diskb):\Windows\System32\config\SYSTEM"
 reg export "HKLM\BROKENSYSTEM" "$($diskb):\regbackupbeforeGAchanges" /y
-Write-output ""
-write-output "A Backup of the BROKENSYSTEM was taken and left on $($diskb):\ as regbackupbeforeGAchanges just in case!"
 
-# EXPORTING GOOD VMAGENT REGS!
+
+# EXPORTING GOOD VMAGENT REGS FROM RESCUE VM
 reg export "HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\WindowsAzureGuestAgent" "$($diskb):\WAGA.reg" /y
 # Telemetry service was merged into rdagent so an error might be displayed for wats
 reg export "HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\WindowsAzureTelemetryService" "$($diskb):\WATS.reg"  /y
 reg export "HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\RdAgent" "$($diskb):\RdAgent.reg" /y
 
-# MODIFYING REG FILES!
+# MODIFYING REG FILES WITH GOOD REG KEYS
+# WAAGENT MODIFICATIONS
 (gc "$($diskb):\waga.reg") -replace 'LocalSystem', 'notyet' | Out-File "$($diskb):\waga.reg"
 (gc "$($diskb):\waga.reg") -replace 'system', 'BROKENSYSTEM' | Out-File "$($diskb):\waga.reg"
 (gc "$($diskb):\waga.reg") -replace 'notyet', 'localsystem' | Out-File "$($diskb):\waga.reg"
-Write-output "                                   -----------============-----------"
+
+# TELEMETRY MODIFICATIONS
 # Telemetry service was merged into rdagent so an error might be displayed for wats
 (gc "$($diskb):\wats.reg") -replace 'LocalSystem', 'notyet' | Out-File "$($diskb):\wats.reg"
 (gc "$($diskb):\wats.reg") -replace 'system', 'BROKENSYSTEM' | Out-File "$($diskb):\wats.reg"
 (gc "$($diskb):\wats.reg") -replace 'notyet', 'localsystem' | Out-File "$($diskb):\wats.reg"
-Write-output "                                   -----------============-----------"
+
+# RDAGENT MODIFICATIONS
 (gc "$($diskb):\RdAgent.reg") -replace 'LocalSystem', 'notyet' | Out-File "$($diskb):\RdAgent.reg"
 (gc "$($diskb):\RdAgent.reg") -replace 'system', 'BROKENSYSTEM' | Out-File "$($diskb):\RdAgent.reg"
 (gc "$($diskb):\RdAgent.reg") -replace 'notyet', 'localsystem' | Out-File "$($diskb):\RdAgent.reg"
-Write-output "                                   -----------============-----------"
-Write-output "ADDING REG FILES IN %diskb% DRIVE!"
+
+# ADDING REG FILES IN %diskb% DRIVE
 regedit /s "$($diskb):\WATS.reg"
 regedit /s "$($diskb):\WAGA.reg"
 regedit /s "$($diskb):\RdAgent.reg"
-Write-output ""
-Write-output "RESTORING VMAgent BIN FILES!"
+
+
+# BACKUP TAKEN ON FOLDER $($diskb):\WindowsazurefaultyGAbackup"
 mkdir "$($diskb):\WindowsazurefaultyGAbackup"
 xcopy "$($diskb):\WindowsAzure" "$($diskb):\WindowsazurefaultyGAbackup" /e /h /y
-Write-output ""
-Write-output "BACKUP TAKEN ON FOLDER $($diskb):\WindowsazurefaultyGAbackup"
-Write-output ""
+
+# RESTORING VMAgent BIN FILES
 del "$($diskb):\WindowsAzure" -force -recurse
 mkdir "$($diskb):\WindowsAzure"
 xcopy "$($diska):\WindowsAzure" "$($diskb):\WindowsAzure" /e /h /y
-Write-output ""
-Write-output "VMAgent FILES RESTORED!"
-Write-output ""
 del "$($diskb):\WindowsAzure\logs" -force -recurse
-Write-output ""
-Write-output "A Backup was created on the following folder $($diskb)\WindowsazurefaultyGAbackup in case the folder existed."
-Write-output "Unloading HIVE"
+
+# Unloading HIVE"
 reg.exe unload "HKLM\BROKENSYSTEM"
 del "$($diskb):\rdagent.reg" -force
 del "$($diskb):\waga.reg" -force
 del "$($diskb):\wats.reg" -force
 
-Write-output "IF FOR SOME REASON THE SCRIPT FAILED AT SOME POINT, PLEASE DO NOT ATTEMPT TO RUN THE SCRIPT AGAIN."
-Write-output "REASONS WHY THE SCRIPT COULD HAVE FAILED:"
-Write-output ""
-Write-output "* Drive letters swapped. (This could affect the troubleshooter VM)"
-Write-output "* Used colon character, extra blank spaces and/or typos when the drive letter(s) was/were typed."
-Write-output "* Windows directories have different names from the standard(example: c:\windows)"
-Write-output ""
-Write-output "I hope this script fixes the VMAgent accordingly. :)"
-Write-output ""


### PR DESCRIPTION
QUICK DESCRIPTION:

•	The PowerShell script mitigates issues with Azure Guest Agent offline related to integrity of files, services, and registry corruption/damaged. Common "Not Ready" status scenario of Azure GA from portal.
•	Before processing mitigation of GA, the script takes a registry backup as well as a backup of the waagent folder with its logs in case of requiring an RCA and/or for further investigation.

APPLIES IF THE FOLLOWING AND/OR STATEMENTS ARE TRUE:

-	RDP/GUI not available.
-	Shell/CLI not available.
-	VM Agent Not Ready, corrupted, or not installed.
-	If working normally but GA requires reset for different reasons and GUI doesn’t let and interactive reinstallation/deletion.

STEPS TO RUN MITIGATION(FOR NOW, AS IT RUNS LOCALLY, AND 3 AZ COMMANDS ARE NOT MERGED YET):

az vm repair create -n winserverGAtest -g winserverGAtest_group --repair-username denial --repair-password Microsoft123! --associate-public-ip --verbose --debug
az vm repair run -g winserverGAtest_group -n winserverGAtest --custom-script-file ./VMAFv2.ps1 --run-on-repair --verbose --debug
az vm repair restore -n winserverGAtest -g winserverGAtest_group --yes --verbose --debug

Objectives:

	• Get most or all GA scenarios fixed quicker either by customers themselves or by engineers.

What it does?

	• Fixes integrity of GA files.
	• Fixes integrity of registries.
	• Takes a backup of the registry
	• Takes a backup of the previous GA installed with its logs, in case of requiring an RCA.

Which scenarios this fix can be applied?

	• When GA is not installed.
	• When GA is damaged or corrupted from files and/or registry ends.
	• When customer cannot uninstall current GA version or need a reset.

It applies for all scenarios for the documentation below:

-= Install the Azure VM Agent in offline mode - Virtual Machines | Microsoft Docs =-
https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/install-vm-agent-offline

The test was done on a windows server 2016 datacenter:

-	Registry for GA was purposely corrupted with special characters for rdagent and waagent.
-	Files from folder /WindowsAzure were forcedly deleted and corrupted.
-	Services were stopped, disabled, and deleted.
-	GA process ids were forcedly killed.
-	Agent shows from portal as "Not Ready"

If any feedback or something that can improve the script, please let me know. damunozl@microsoft / jotmeil.com@hotmail.com.