### PR TITLE
Added a run-id entry to run the Azure Agent fixer from this path src/windows/GA_offlinefixer_damunozl.ps1

### DIFF
--- a/map.json
+++ b/map.json
@@ -1,5 +1,10 @@
 [
 	{
+		"id" : "win-GA-fix",
+		"path" : "src/windows/GA_offlinefixer_damunozl.ps1",
+		"description" : "Fixes integrity of files and registry from windows guest agent offline"
+	},
+	{
 		"id" : "win-hello-world",
 		"path" : "src/windows/win-hello-world.ps1",
 		"description" : "Hello world test script"


### PR DESCRIPTION
QUICK DESCRIPTION:

•	The PowerShell script mitigates issues with Azure Guest Agent offline related to integrity of files, services, and registry corruption/damaged. Common "Not Ready" status scenario of Azure GA from portal.
•	Before processing mitigation of GA, the script takes a registry backup as well as a backup of the waagent folder with its logs in case of requiring an RCA and/or for further investigation.

APPLIES IF THE FOLLOWING AND/OR STATEMENTS ARE TRUE:

-	RDP/GUI not available.
-	Shell/CLI not available.
-	VM Agent Not Ready, corrupted, or not installed.
-	If working normally but GA requires reset for different reasons and GUI doesn’t let and interactive reinstallation/deletion.

STEPS TO RUN MITIGATION(FOR NOW, AS IT RUNS LOCALLY, AND 3 AZ COMMANDS ARE NOT MERGED YET):

az vm repair create -n winserverGAtest -g winserverGAtest_group --repair-username denial --repair-password Microsoft123! --associate-public-ip --verbose --debug
az vm repair run -g winserverGAtest_group -n winserverGAtest --custom-script-file ./VMAFv2.ps1 --run-on-repair --verbose --debug
az vm repair restore -n winserverGAtest -g winserverGAtest_group --yes --verbose --debug

Objectives:

	• Get most or all GA scenarios fixed quicker either by customers themselves or by engineers.

What it does?

	• Fixes integrity of GA files.
	• Fixes integrity of registries.
	• Takes a backup of the registry
	• Takes a backup of the previous GA installed with its logs, in case of requiring an RCA.

Which scenarios this fix can be applied?

	• When GA is not installed.
	• When GA is damaged or corrupted from files and/or registry ends.
	• When customer cannot uninstall current GA version or need a reset.

It applies for all scenarios for the documentation below:

-= Install the Azure VM Agent in offline mode - Virtual Machines | Microsoft Docs =-
https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/install-vm-agent-offline

The test was done on a windows server 2016 datacenter:

-	Registry for GA was purposely corrupted with special characters for rdagent and waagent.
-	Files from folder /WindowsAzure were forcedly deleted and corrupted.
-	Services were stopped, disabled, and deleted.
-	GA process ids were forcedly killed.
-	Agent shows from portal as "Not Ready"

If any feedback or something that can improve the script, please let me know. damunozl@microsoft / jotmeil.com@hotmail.com.
