### PR TITLE
add apt update

### DIFF
--- a/src/linux/linux-alar2.sh
+++ b/src/linux/linux-alar2.sh
@@ -2,7 +2,9 @@
 . ./src/linux/common/setup/init.sh
 
 # libclang needs to be installed as well, due to a new dependency
+apt-get update
 apt-get install libclang-dev -y
+
 Log-Output "Starting the recovery"
 cd ./src/linux/common/helpers/alar2
 if [[ -f target/debug/alar2 ]]; then


### PR DESCRIPTION
due to a change at vm-repair extension level the command 'apt update' was not executed before which results in an install error, which at the end prevents ALAR2 to run.