### PR TITLE
Altered ID linux-alar-fki as deprecated

### DIFF
--- a/map.json
+++ b/map.json
@@ -36,8 +36,8 @@
 	},
 	{
 		"id" : "linux-alar-fki",
-		"path" : "src/linux/linux-alar-fki.sh",
-		"description" : "alar-fki allows to recover a failed VM. Three recover scenarios are possible: fstab, initrd and kernel. NOTE: use option --run-on-repair. Se the docu for more details: https://github.com/Azure/repair-script-library/blob/master/src/linux/common/helpers/alar/README.md"
+		"path" : "src/linux/linux-alar2.sh",
+		"description" : "This ID is deprectated. Please use 'linux-alar2' instead. For backward compatibility it will use the linux-alar2 ID automatically."
 	},
     {
         "id" : "linux-alar2",


### PR DESCRIPTION
Small modification to use only the new alar2 version. linux-alar-fki is the outdated version which isn't supported anymore. For backward compatibility the ID 'linux-alar-fki' dows now use 'linux-alar.sh' instead