### PR TITLE
New command to workaround corrupt crowdstrike sensor

### DIFF
--- a/map.json
+++ b/map.json
@@ -118,5 +118,10 @@
 		"id": "win-update-registry",
 		"path": "src/windows/win-update-registry.ps1",
 		"description": "Modify the registry on an OS disk attached to a Rescue VM as an Azure Data Disk."
+	},
+	{
+		"id": "win-crowdstrike-fix-bootloop",
+		"path": "src/windows/win-crowdstrike-fix-bootloop.ps1",
+		"description": "Workaround for machines stuck in boot loop due to corrupt crowdstrike falcon sensor 2024-07-19"
 	}
 ]

--- a/src/windows/win-crowdstrike-fix-bootloop.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop.ps1
@@ -1,0 +1,25 @@
+. .\src\windows\common\setup\init.ps1
+. .\src\windows\common\helpers\Get-Disk-Partitions.ps1
+
+$partitionlist = Get-Disk-Partitions
+$actionTaken = $false
+
+forEach ( $partition in $partitionlist )
+{
+    $driveLetter = ($partition.DriveLetter + ":")
+    $corruptFiles = "$driveLetter\Windows\System32\drivers\CrowdStrike\C-00000291*.sys"
+
+    if (Test-Path -Path $corruptFiles) {
+        Log-Info "Found crowdstrike files to cleanup, removing..."
+        Remove-Item $corruptFiles
+        $actionTaken = $true
+    }
+}
+
+if ($actionTaken) {
+    Log-Info "Successfully cleaned up crowdstrike files"
+} else {
+    Log-Warning "No bad crowdstrike files found"
+}
+
+return $STATUS_SUCCESS


### PR DESCRIPTION
A recent crowdstrike agent has caused many machines to be stuck in a boot loop. The official vendor guidance for the incident is to delete a number of files to allow the machine to boot successfully. Given the procedural challenges with modifying the disk of a non-booting VM, this new command seeks to streamline the remediation process for anyone who has impacted IaaS.