### PR TITLE
Create a new script to load/unload registry hives after deleting the corrupt CrowdStrike files

### DIFF
--- a/map.json
+++ b/map.json
@@ -122,6 +122,11 @@
 	{
 		"id": "win-crowdstrike-fix-bootloop",
 		"path": "src/windows/win-crowdstrike-fix-bootloop.ps1",
-		"description": "Workaround for machines stuck in boot loop due to corrupt crowdstrike falcon sensor 2024-07-19"
+		"description": "Workaround for machines stuck in boot loop due to corrupt crowdstrike falcon sensor 2024-07-19 by removing corrupt crowdstrike files"
+	},
+	{
+		"id": "win-crowdstrike-fix-bootloop-v2",
+		"path": "src/windows/win-crowdstrike-fix-bootloop-v2.ps1",
+		"description": "Workaround for machines stuck in boot loop due to corrupt crowdstrike falcon sensor 2024-07-19 by removing corrupt crowdstrike files and load/unload the registry hives"
 	}
 ]

--- a/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
@@ -1,0 +1,64 @@
+. .\src\windows\common\setup\init.ps1
+. .\src\windows\common\helpers\Get-Disk-Partitions.ps1
+
+$partitionlist = Get-Disk-Partitions
+$actionTaken = $false
+
+forEach ( $partition in $partitionlist )
+{
+    $driveLetter = ($partition.DriveLetter + ":")
+    $corruptFiles = "$driveLetter\Windows\System32\drivers\CrowdStrike\C-00000291*.sys"
+
+    if (Test-Path -Path $corruptFiles) {
+        Log-Info "Found crowdstrike files to cleanup, removing..."
+        Remove-Item $corruptFiles
+        Log-Info "Corrupt crowdstrike files are removed."
+
+        Log-Info "Load/unload registry hives from data disk..."
+
+        $result = reg load HKLM\temp_system_hiv $driverletter\windows\system32\config\system
+        if ($LASTEXITCODE -ne 0) {
+            Log-Error "Load registry hive from $driverletter\windows\system32\config\system failed with error: $result"
+            return $STATUS_ERROR
+        } else {
+            Log-Info "Load registry hive from $driverletter\windows\system32\config\system succeeded: $result"
+        }
+
+        $result = reg unload HKLM\temp_system_hiv
+        if ($LASTEXITCODE -ne 0) {
+            Log-Error "Unload registry hive HKLM\temp_system_hiv failed with error: $result"
+            return $STATUS_ERROR
+        } else {
+            Log-Info "Unload registry hive HKLM\temp_system_hiv succeeded: $result"
+        }
+ 
+        $result = reg load HKLM\temp_software_hive $driverletter\windows\system32\config\software
+        if ($LASTEXITCODE -ne 0) {
+            Log-Error "Load registry hive from $driverletter\windows\system32\config\software failed with error: $result"
+            return $STATUS_ERROR
+        } else {
+            Log-Info "Load registry hive from $driverletter\windows\system32\config\software succeeded: $result"
+        }
+
+        $result = reg unload HKLM\temp_software_hive 
+        if ($LASTEXITCODE -ne 0) {
+            Log-Error "Unload registry hive HKLM\temp_software_hive failed with error: $result"
+            return $STATUS_ERROR
+        } else {
+            Log-Info "Unload registry hive HKLM\temp_software_hive succeeded: $result"
+        }
+
+        Log-Info "Registry hives load/unload: done."
+
+
+        $actionTaken = $true
+    }
+}
+
+if ($actionTaken) {
+    Log-Info "Successfully cleaned up crowdstrike files"
+} else {
+    Log-Warning "No bad crowdstrike files found"
+}
+
+return $STATUS_SUCCESS

--- a/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
@@ -56,7 +56,7 @@ forEach ( $partition in $partitionlist )
 }
 
 if ($actionTaken) {
-    Log-Info "Successfully cleaned up crowdstrike files"
+    Log-Info "Successfully cleaned up crowdstrike files and loaded/unloaded the registry hives"
 } else {
     Log-Warning "No bad crowdstrike files found"
 }


### PR DESCRIPTION
This PR adds a new script to fix the Crowdstrike issue after vm bootstrap. Based on the investigation, it is needed to reg load/reg unload some registry hives from %windir%\system32\config into SYSTEM and SOFTWARE hives under HKLM to prevent the script hang issue.

Below are the testings I manually did:
Step 1: Create a VM1 in west US
Step 2: deleted VM1 but keep its OS disk
Step 3: create a VM2 in west US
Step 4: attach VM1's OS disk as VM2's data disk with Drive letter F:
Step 5: run the script to test the registry hive load/unload from data disk F: