### PR TITLE
Delete regtrans-ms and txr.blf files under config\TxR for Windows Server 2016 or newer version

### DIFF
--- a/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
@@ -24,7 +24,7 @@ function CleanUpRegtransmsAndTxrblfFiles
         $regtransmsFiles = "$DriveLetter\Windows\system32\config\TxR\*.TxR.*.regtrans-ms"
         try {
             Remove-Item $regtransmsFiles  -ErrorAction Stop
-             Log-Error "regtrans-ms files under config\TxR removed"
+             Log-Info "regtrans-ms files under config\TxR removed"
         }
         catch {
             Log-Error "Remove regtrans-ms files under config\TxR failed: Error: $_"
@@ -33,7 +33,7 @@ function CleanUpRegtransmsAndTxrblfFiles
         $txrBlfFiles = "$DriveLetter\Windows\system32\config\TxR\*.TxR.blf"
         try {
             Remove-Item $txrBlfFiles  -ErrorAction Stop
-             Log-Error "txr.blf files under config\TxR removed"
+            Log-Info "txr.blf files under config\TxR removed"
         }
         catch {
             Log-Error "Remove txr.blf files under config\TxR failed: Error: $_"

--- a/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
@@ -21,7 +21,7 @@ function CleanUpRegtransmsAndTxrblfFiles
     if ($currentBuild -ge 14393) 
     {
         Log-Info "Trying to Delete regtrans-ms and txr.blf files under config\TxR..."
-        $regtransmsFiles = "$driveLetter\Windows\system32\config\TxR\*.TxR.*.regtrans-ms"
+        $regtransmsFiles = "$DriveLetter\Windows\system32\config\TxR\*.TxR.*.regtrans-ms"
         try {
             Remove-Item $regtransmsFiles  -ErrorAction Stop
              Log-Error "regtrans-ms files under config\TxR removed"
@@ -30,7 +30,7 @@ function CleanUpRegtransmsAndTxrblfFiles
             Log-Error "Remove regtrans-ms files under config\TxR failed: Error: $_"
         }
 
-        $txrBlfFiles = "$driveLetter\Windows\system32\config\TxR\*.TxR.blf"
+        $txrBlfFiles = "$DriveLetter\Windows\system32\config\TxR\*.TxR.blf"
         try {
             Remove-Item $txrBlfFiles  -ErrorAction Stop
              Log-Error "txr.blf files under config\TxR removed"

--- a/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
@@ -22,20 +22,24 @@ function CleanUpRegtransmsAndTxrblfFiles
     {
         Log-Info "Trying to Delete regtrans-ms and txr.blf files under config\TxR..."
         $regtransmsFiles = "$DriveLetter\Windows\system32\config\TxR\*.TxR.*.regtrans-ms"
-        try {
+        try 
+        {
             Remove-Item $regtransmsFiles  -ErrorAction Stop
              Log-Info "regtrans-ms files under config\TxR removed"
         }
-        catch {
+        catch 
+        {
             Log-Error "Remove regtrans-ms files under config\TxR failed: Error: $_"
         }
 
         $txrBlfFiles = "$DriveLetter\Windows\system32\config\TxR\*.TxR.blf"
-        try {
+        try 
+        {
             Remove-Item $txrBlfFiles  -ErrorAction Stop
             Log-Info "txr.blf files under config\TxR removed"
         }
-        catch {
+        catch 
+        {
             Log-Error "Remove txr.blf files under config\TxR failed: Error: $_"
         }
         

--- a/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
@@ -4,6 +4,50 @@
 $partitionlist = Get-Disk-Partitions
 $actionTaken = $false
 
+function CleanUpRegtransmsAndTxrblfFiles 
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$GuidSuffix,
+        [Parameter(Mandatory = $true)]
+        [string]$DriveLetter
+    )
+
+    Log-Info "Deleting regtrans-ms and txr.blf files under config\TxR for Windows Server 2016 or newer version..."
+    Log-Info "Checking Windows Build number..."
+    $regKey = "HKLM:\temp_software_hive_$GuidSuffix\Microsoft\Windows NT\CurrentVersion"
+    $currentBuild = (Get-ItemProperty $regKey -Name CurrentBuild).CurrentBuild
+    Log-Info "CurrentBuild: $currentBuild"
+    if ($currentBuild -ge 14393) 
+    {
+        Log-Info "Trying to Delete regtrans-ms and txr.blf files under config\TxR..."
+        $regtransmsFiles = "$driveLetter\Windows\system32\config\TxR\*.TxR.*.regtrans-ms"
+        try {
+            Remove-Item $regtransmsFiles  -ErrorAction Stop
+             Log-Error "regtrans-ms files under config\TxR removed"
+        }
+        catch {
+            Log-Error "Remove regtrans-ms files under config\TxR failed: Error: $_"
+        }
+
+        $txrBlfFiles = "$driveLetter\Windows\system32\config\TxR\*.TxR.blf"
+        try {
+            Remove-Item $txrBlfFiles  -ErrorAction Stop
+             Log-Error "txr.blf files under config\TxR removed"
+        }
+        catch {
+            Log-Error "Remove txr.blf files under config\TxR failed: Error: $_"
+        }
+        
+    } 
+    else 
+    {
+        Log-Info "Skip deleting regtrans-ms and txr.blf files under config\TxR"
+    }
+
+
+}
+
 forEach ( $partition in $partitionlist )
 {
     $driveLetter = ($partition.DriveLetter + ":")
@@ -30,6 +74,11 @@ forEach ( $partition in $partitionlist )
                 Log-Error "Load registry hive $regKey from $regFile failed with error: $result"
             } else {
                 Log-Info "Load registry hive $regKey from $regFile succeeded with message: $result"
+
+                if ($regKey -eq "HKLM\temp_software_hive_$guidSuffix") {
+                    CleanUpRegtransmsAndTxrblfFiles($guidSuffix, $driveLetter)
+                }
+
                 Log-Info "Unloading registry hive $regKey..."
                 $result = reg unload $regKey 2>&1
                 if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
Delete all regtrans-ms and txr.blf files under config\TxR to better handle the WS2019 scenario in case the system is stuck in the registry hang