### PR TITLE
Initializing the partitions list as an empty array

### DIFF
--- a/map.json
+++ b/map.json
@@ -128,5 +128,10 @@
 		"id": "win-crowdstrike-fix-bootloop-v2",
 		"path": "src/windows/win-crowdstrike-fix-bootloop-v2.ps1",
 		"description": "Workaround for machines stuck in boot loop due to corrupt crowdstrike falcon sensor 2024-07-19 by removing corrupt crowdstrike files, loading/unloading the registry hives, and removing regtrans-ms and txr.blf files under config\\TxR folder"
+	},
+	{
+		"id": "win-crowdstrike-fix-bootloop-cvm-test",
+		"path": "src/windows/win-crowdstrike-fix-bootloop-cvm-test.ps1",
+		"description": "Workaround for cvm machines stuck in boot loop due to corrupt crowdstrike falcon sensor 2024-07-19 by removing corrupt crowdstrike files"
 	}
 ]

--- a/src/windows/common/helpers/Get-Disk-Partitions-v2-test.ps1
+++ b/src/windows/common/helpers/Get-Disk-Partitions-v2-test.ps1
@@ -1,6 +1,6 @@
 function Get-Disk-Partitions()
 {
-	$partitionlist = $null
+	$partitionlist = @()
 	$disklist = get-wmiobject Win32_diskdrive |Where-Object {$_.model -like 'Microsoft Virtual Disk'} 
 	ForEach ($disk in $disklist)
 	{

--- a/src/windows/common/helpers/Get-Disk-Partitions.ps1
+++ b/src/windows/common/helpers/Get-Disk-Partitions.ps1
@@ -1,6 +1,6 @@
 function Get-Disk-Partitions()
 {
-	$partitionlist = $null
+	$partitionlist = @()
 	$disklist = get-wmiobject Win32_diskdrive |Where-Object {$_.model -like 'Microsoft Virtual Disk'} 
 	ForEach ($disk in $disklist)
 	{

--- a/src/windows/win-crowdstrike-fix-bootloop-cvm-test.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop-cvm-test.ps1
@@ -1,0 +1,25 @@
+. .\src\windows\common\setup\init.ps1
+. .\src\windows\common\helpers\Get-Disk-Partitions-v2-test.ps1
+
+$partitionlist = Get-Disk-Partitions
+$actionTaken = $false
+
+forEach ( $partition in $partitionlist )
+{
+    $driveLetter = ($partition.DriveLetter + ":")
+    $corruptFiles = "$driveLetter\Windows\System32\drivers\CrowdStrike\C-00000291*.sys"
+
+    if (Test-Path -Path $corruptFiles) {
+        Log-Info "Found crowdstrike files to cleanup, removing..."
+        Remove-Item $corruptFiles
+        $actionTaken = $true
+    }
+}
+
+if ($actionTaken) {
+    Log-Info "Successfully cleaned up crowdstrike files"
+} else {
+    Log-Warning "No bad crowdstrike files found"
+}
+
+return $STATUS_SUCCESS


### PR DESCRIPTION
Initializing a list to null can cause issues when the first addition to the list is 1 element. It can then take the type of that element (instead of a list), so this change initializes it to an empty array.

Other scripts that depend on it do not check if the value is null. The return is passed to an iterator or to another function/command.