### PR TITLE
Merge win-crowdstrike-fix-bootloop-v2 updates to  win-crowdstrike-fix-bootloop

### DIFF
--- a/map.json
+++ b/map.json
@@ -122,7 +122,7 @@
 	{
 		"id": "win-crowdstrike-fix-bootloop",
 		"path": "src/windows/win-crowdstrike-fix-bootloop.ps1",
-		"description": "Workaround for machines stuck in boot loop due to corrupt crowdstrike falcon sensor 2024-07-19 by removing corrupt crowdstrike files"
+		"description": "Workaround for machines stuck in boot loop due to corrupt crowdstrike falcon sensor 2024-07-19 by removing corrupt crowdstrike files, loading/unloading the registry hives, and removing regtrans-ms and txr.blf files under config\\TxR folder"
 	},
 	{
 		"id": "win-crowdstrike-fix-bootloop-v2",

--- a/src/windows/win-crowdstrike-fix-bootloop.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop.ps1
@@ -4,6 +4,58 @@
 $partitionlist = Get-Disk-Partitions
 $actionTaken = $false
 
+function CleanUpRegtransmsAndTxrblfFiles 
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$GuidSuffix,
+        [Parameter(Mandatory = $true)]
+        [string]$DriveLetter
+    )
+
+    Log-Info "Deleting regtrans-ms and txr.blf files under config\TxR for Windows Server 2016 or newer version..."
+    Log-Info "Checking Windows Build number..."
+    $regKey = "HKLM:\temp_software_hive_$GuidSuffix\Microsoft\Windows NT\CurrentVersion"
+    $currentBuild = (Get-ItemProperty $regKey -Name CurrentBuild).CurrentBuild
+    Log-Info "CurrentBuild: $currentBuild"
+    if ($null -eq $currentBuild) {
+        Log-Error "Failed to retrieve the Build Number of the Windows System from the mounted data disk"
+        return
+    }
+
+    # On Server 2016 and newer, we know that the logs will never replay their changes successfully and so their contents aren't useful.
+    # We can safely remove these files in this case.
+    if ($currentBuild -ge 14393) # 14393 is the build number of Windows 2016. 
+    {
+        Log-Info "Trying to Delete regtrans-ms and txr.blf files under config\TxR..."
+        $regtransmsFiles = "$DriveLetter\Windows\system32\config\TxR\*.TxR.*.regtrans-ms"
+        try 
+        {
+            Remove-Item $regtransmsFiles  -ErrorAction Stop -Force
+             Log-Info "regtrans-ms files under config\TxR removed"
+        }
+        catch 
+        {
+            Log-Error "Remove regtrans-ms files under config\TxR failed: Error: $_"
+        }
+
+        $txrBlfFiles = "$DriveLetter\Windows\system32\config\TxR\*.TxR.blf"
+        try 
+        {
+            Remove-Item $txrBlfFiles  -ErrorAction Stop -Force
+            Log-Info "txr.blf files under config\TxR removed"
+        }
+        catch 
+        {
+            Log-Error "Remove txr.blf files under config\TxR failed: Error: $_"
+        } 
+    } 
+    else 
+    {
+        Log-Info "Skip deleting regtrans-ms and txr.blf files under config\TxR"
+    }
+}
+
 forEach ( $partition in $partitionlist )
 {
     $driveLetter = ($partition.DriveLetter + ":")
@@ -12,12 +64,46 @@ forEach ( $partition in $partitionlist )
     if (Test-Path -Path $corruptFiles) {
         Log-Info "Found crowdstrike files to cleanup, removing..."
         Remove-Item $corruptFiles
+        Log-Info "Corrupt crowdstrike files are removed."
+
+        Log-Info "Loading/unloading registry hives from data disk..."
+        $guidSuffix = "f85afa50-13cc-48e0-8a29-90603a43cfe2" # get a guid online as the reg key suffix in case the reg key name already exist
+        $regKeyToFile = @{
+            "HKLM\temp_system_hive_$guidSuffix" = "$driveLetter\windows\system32\config\system"
+            "HKLM\temp_software_hive_$guidSuffix" = "$driveLetter\windows\system32\config\software"
+        }
+
+        foreach ($regKey in $regKeyToFile.Keys)
+        {
+            $regFile = $regKeyToFile[$regKey]
+            Log-Info "Loading registry hive $regKey from $regFile..."
+            $result = reg load $regKey $regFile 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                Log-Error "Load registry hive $regKey from $regFile failed with error: $result"
+            } else {
+                Log-Info "Load registry hive $regKey from $regFile succeeded with message: $result"
+
+                if ($regKey -eq "HKLM\temp_software_hive_$guidSuffix") {
+                    CleanUpRegtransmsAndTxrblfFiles -GuidSuffix $guidSuffix -DriveLetter $driveLetter
+                }
+
+                Log-Info "Unloading registry hive $regKey..."
+                $result = reg unload $regKey 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                    Log-Error "Unload registry hive $regKey failed with error: $result"
+                } else {
+                    Log-Info "Unload registry hive $regKey succeeded with message: $result"
+                }
+            }
+        }
+
+        Log-Info "Registry hives load/unload: done."
         $actionTaken = $true
     }
 }
 
 if ($actionTaken) {
-    Log-Info "Successfully cleaned up crowdstrike files"
+    Log-Info "Successfully cleaned up crowdstrike files and loaded/unloaded the registry hives"
 } else {
     Log-Warning "No bad crowdstrike files found"
 }


### PR DESCRIPTION
With this merge, the v2 and v1 script become identical. The v2 script is not removed in case it is still used by someone.