### PR TITLE
Update win-crowdstrike-fix-bootloop.ps1

### DIFF
--- a/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop-v2.ps1
@@ -1,5 +1,5 @@
 . .\src\windows\common\setup\init.ps1
-. .\src\windows\common\helpers\Get-Disk-Partitions.ps1
+. .\src\windows\common\helpers\Get-Disk-Partitions-v2.ps1
 
 $partitionlist = Get-Disk-Partitions
 $actionTaken = $false

--- a/src/windows/win-crowdstrike-fix-bootloop.ps1
+++ b/src/windows/win-crowdstrike-fix-bootloop.ps1
@@ -1,5 +1,5 @@
 . .\src\windows\common\setup\init.ps1
-. .\src\windows\common\helpers\Get-Disk-Partitions.ps1
+. .\src\windows\common\helpers\Get-Disk-Partitions-v2.ps1
 
 $partitionlist = Get-Disk-Partitions
 $actionTaken = $false


### PR DESCRIPTION
fix bug that depending on the disk partition ordering may report that there are no crowdstrike files