### PR TITLE
Fix various win-toggle-safe-mode errors and confirm gen2 compatible

### DIFF
--- a/src/windows/win-toggle-safe-mode.ps1
+++ b/src/windows/win-toggle-safe-mode.ps1
@@ -148,7 +148,7 @@ try {
                 $osPath = "${root}\windows\system32\winload.exe"
                 $isOsPath = Test-Path $osPath
                 if ($isOsPath) {
-                    $osDrive = $drive
+                    $osDrive = $root
                 }
             }
         }
@@ -164,7 +164,7 @@ try {
             $safeModeIndicator = $bcdout | Select-String 'safeboot' | select -First 1
 
             # Check if partition has Registry path (use OS partition that contained winload.exe)
-            $regPath = $osDrive + ':\Windows\System32\config\'
+            $regPath = $osDrive + '\Windows\System32\config\'
             $isRegPath = Test-Path $regPath
         
             # If Registry path found and we're enabling safe mode, check if DC
@@ -173,7 +173,7 @@ try {
                 Log-Output "Load requested Registry hive from $($osDrive)" | Tee-Object -FilePath $logFile -Append
         
                 # Load hive into Rescue VM's registry from attached disk
-                reg load "HKLM\BROKENSYSTEM" "$($osDrive):\Windows\System32\config\SYSTEM"
+                reg load "HKLM\BROKENSYSTEM" "$($osDrive)\Windows\System32\config\SYSTEM"
                 $regLoaded = $true
         
                 # Verify the active Control Set if using the System registry and if not already defined (1 is ControlSet001, 2 is ControlSet002)
@@ -271,8 +271,13 @@ try {
                 $disk | set-disk -IsOffline $true -ErrorAction Stop
 
                 # Start Hyper-V VM
-                Log-Output "#07 - Starting VM" | Tee-Object -FilePath $logFile -Append
-                start-vm $guestHyperVVirtualMachine -ErrorAction SilentlyContinue #Sometimes the repair VM doesn't have enough memory to power it on
+                try {
+                    Start-VM $guestHyperVVirtualMachine -ErrorAction Stop
+                }
+                catch {
+                    Log-Output "WARNING: Could not start nested VM (may need more memory). BCD changes were applied successfully." |
+                        Tee-Object -FilePath $logFile -Append
+                }
             }
 
             Log-Output "END: Please verify status of Safe Mode using MSCONFIG.exe (GUI) or BCDEDIT /enum (shell)" | Tee-Object -FilePath $logFile -Append
@@ -284,8 +289,16 @@ catch {
 
     if ($guestHyperVVirtualMachine) {
         # Bring disk offline again
-        Log-Output "#99 - Bringing disk offline to restart Hyper-V VM" | Tee-Object -FilePath $logFile -Append
+        Log-Output "ERR-01 - Bringing disk offline to restart Hyper-V VM" | Tee-Object -FilePath $logFile -Append
         $disk | set-disk -IsOffline $true -ErrorAction Stop
+        # Start Hyper-V VM
+        try {
+            Start-VM $guestHyperVVirtualMachine -ErrorAction Stop
+        }
+        catch {
+            Log-Output "WARNING: Could not start nested VM (may need more memory). BCD changes were applied successfully." |
+                Tee-Object -FilePath $logFile -Append
+        }
     }
 
     # Log failure scenario


### PR DESCRIPTION
Hi,

Thanks for this project!

I've encountered various issues with the `win-toggle-safe-mode` script which this PR fixes:
1) Missing comments on line 48-49 which stop the script starting entirely
2) AZ CLI always passes parameters as strings so the current DC switch does not work
3) Any partitions without a drive letter get ignored (which includes the EFI partition we care about for safe mode which normally doesn't have a drive letter) so refactored to also check access paths
4) Script error if it can't start up the ProblemVM - I've found by default my repair VM doesn't have enough memory to power up the nested VM, but we don't need the ProblemVM to be started to perform the safe mode changes so I've changed the error action to SilentlyContinue

I've tested this updated version successfully against a 2016 domain controller running in Azure as a Gen2:
```
az vm repair create -g rg-adrestore-tst01 -n vm-adrestore-tst01 --yes --repair-username local_admin --repair-password 'password!234' --enable-nested --verbose

az vm repair run -g rg-adrestore-tst01 -n vm-adrestore-tst01 --preview "https://github.com/Vorsku/repair-script-library/blob/main/map.json" --run-id win-toggle-safe-mode --parameters safeModeSwitch=on DC=yes --verbose --run-on-repair

az vm repair restore -g rg-adrestore-tst01 -n vm-adrestore-tst01 --verbose
```

Thanks,
Josh