### PR TITLE
Update GA_offlinefixer.ps1 to v1.3

### DIFF
--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -1,125 +1,343 @@
 <#
 .SYNOPSIS
-    VMAgent Offline Fixer - Comprehensive Version.
-    - Fixes Registry and Binaries for Guest Agent and RDAgent.
-    - Automatically detects and updates active/backup ControlSets (001 and 002).
-    - Implements strict validation and handle releasing for clean hive unloads.
-    - Created by Tony.Mocanu@Microsoft.com
+    VMAgent Offline Fixer - Restores Guest Agent registry keys and binaries from a rescue VM.
+
+.DESCRIPTION
+    This script runs from a rescue VM to repair a broken Azure Guest Agent on an attached OS disk.
+    It performs the following steps:
+    1. Enumerates attached partitions via Get-Disk-Partitions to locate the faulty OS drive.
+    2. Loads the SYSTEM registry hive from the target disk into HKLM\BROKENSYSTEM.
+    3. Creates a full backup of the loaded hive to the disk root (regbackupbeforeGAchanges).
+    4. Identifies the primary and backup ControlSets (001/002) from the Select key.
+    5. Exports healthy service keys (WindowsAzureGuestAgent, WindowsAzureTelemetryService, RdAgent)
+       from the rescue VM and injects them into both ControlSets on the target hive.
+    6. Verifies the ImagePath value was written correctly.
+    7. Backs up the existing WindowsAzure folder (WindowsazurefaultyGAbackup), then replaces
+       it with the full rescue VM WindowsAzure copy.
+    8. Releases handles and safely unloads the registry hive (with retry logic).
+
+.NOTES
+    Name:    GA_offlinefixer.ps1
+    Version: 1.3
+    Original Author: Daniel Munoz L (damunozl@microsoft.com)
+    Modified by: Tony.Mocanu@Microsoft.com
+
+.VERSION
+    v1.3: [May 2026] - Updated the script (current)
+                       - Aligned nested VM detection with win-LKGC guard pattern.
+                       - Skips Get-VM safely when Hyper-V module is unavailable.
+    v1.2: [May 2026] - Updated the script again (current)
+                       - Fixed breaking exception when the Hyper-V module is not installed on the host.
+                       - Added explicit checking via Get-Module before executing nested VM discovery.
+    v1.1: [May 2026] - Updated the script
+                       - Included advanced Gen2 unlettered EFI fallback and dynamic drive-letter assignment.
+    v1.0: Initial commit. This was the version 1.0 of the script.
+
+.SCENARIO_RECREATION
+    To recreate a testable broken Guest Agent scenario on a rescue VM with an attached OS disk:
+    1. Create a test VM in Azure and attach its OS disk to a rescue VM.
+    2. Load the SYSTEM hive from the attached disk (replace F with actual drive letter):
+reg load HKLM\TESTBREAK F:\Windows\System32\config\SYSTEM
+    3. Delete or corrupt the Guest Agent service keys:
+Remove-Item -Path "HKLM:\TESTBREAK\ControlSet001\Services\WindowsAzureGuestAgent" -Recurse -Force
+Remove-Item -Path "HKLM:\TESTBREAK\ControlSet001\Services\RdAgent" -Recurse -Force
+    4. Unload the hive:
+reg unload HKLM\TESTBREAK
+    5. Optionally rename/remove GuestAgent binary folders on the target disk:
+Get-ChildItem F:\WindowsAzure\GuestAgent_* | Rename-Item -NewName { $_.Name + '_BACKUP' }
+    6. Run the script. It should restore service keys from the rescue VM and copy binaries.
+    7. Verify via the .VERIFICATION steps below.
+
+.EXAMPLE
+    az vm repair run -g <rg> -n <vm> --run-id win-GA_offlinefixer --run-on-repair
+
+.VERIFICATION
+    1. Check the log file for success:
+Get-ChildItem "C:\WindowsAzure\Logs\Plugins\Microsoft.Compute.CustomScriptExtension\GA_offlinefixer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1 | Get-Content
+    Expected: "VMAgent Fix completed and verified successfully." and return code 0 ($STATUS_SUCCESS).
+    2. Reload the SYSTEM hive and verify agent service keys exist (replace F with disk letter):
+reg load HKLM\VERIFY F:\Windows\System32\config\SYSTEM
+Get-ItemProperty -Path "HKLM:\VERIFY\ControlSet001\Services\WindowsAzureGuestAgent" -Name ImagePath
+Get-ItemProperty -Path "HKLM:\VERIFY\ControlSet001\Services\RdAgent" -Name ImagePath
+reg unload HKLM\VERIFY
+    Expected: ImagePath values are populated for both services.
+    3. Verify GuestAgent binaries were copied to the target disk:
+Get-ChildItem F:\WindowsAzure\GuestAgent_*
+    Expected: One or more GuestAgent folders present.
 #>
 
-# 1. Import common logic
+# Initialization
 . .\src\windows\common\setup\init.ps1
-. .\src\windows\common\helpers\Get-Disk-Partitions.ps1
+. .\src\windows\common\helpers\Get-Disk-Partitions-v2.ps1
 
-# Define log path (SystemDrive is safest for SYSTEM account)
-$logFile = "$env:SystemDrive\VMAgent-Fix.log"
+# Log Configuration
+$logDir = "C:\WindowsAzure\Logs\Plugins\Microsoft.Compute.CustomScriptExtension"
+if (-not (Test-Path $logDir)) { $null = New-Item -ItemType Directory -Path $logDir -Force }
+$timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$logFile = "$logDir\GA_offlinefixer_$timestamp.log"
+
+# Status Tracking
+$script_final_status = $STATUS_ERROR
 
 try {
     Log-Info "Starting VMAgent Offline Fixer..." | Tee-Object -FilePath $logFile -Append
 
-    # 2. Finder for faulty OS letter
-    $diskb = "000"
-    $diskarray = "d","q","w","e","r","t","y","u","i","o","p","s","f","g","h","j","k","l","z","x","v","n","m"
-    foreach ($diskt in $diskarray) {
-        if (Test-Path -Path "$($diskt):\Windows") { $diskb = $diskt; break }
+    # Stop nested guest VM if running
+    # Guard Get-VM if Hyper-V module is not available
+    try {
+        if (Get-Module -ListAvailable -Name Hyper-V) {
+            $guestHyperVVirtualMachine = Get-VM -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+            if ($guestHyperVVirtualMachine) {
+                if ($guestHyperVVirtualMachine.State -eq 'Running') {
+                    Log-Info "Stopping nested guest VM $($guestHyperVVirtualMachine.VMName)" | Tee-Object -FilePath $logFile -Append
+                    try {
+                        Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
+                    }
+                    catch {
+                        Log-Warning "Failed to stop nested guest VM, will continue but may have limited success" | Tee-Object -FilePath $logFile -Append
+                    }
+                }
+            }
+        } else {
+            Log-Info "Hyper-V PowerShell module is not available on this host. Skipping nested VM validation." | Tee-Object -FilePath $logFile -Append
+        }
+    }
+    catch {
+        Log-Warning "Nested VM check encountered an error but will be skipped: $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
     }
 
-    if ($diskb -eq "000") { throw "Could not find a rescue OS disk attached." }
-    Log-Info "Target OS disk found on letter: $($diskb):" | Tee-Object -FilePath $logFile -Append
+    # Clean up stale hive mounts from previous failed runs
+    Log-Info "Cleaning up any stale registry hive mounts..." | Tee-Object -FilePath $logFile -Append
+    foreach ($staleKey in @("BROKENSYSTEM", "BROKENSW")) {
+        & reg.exe unload "HKLM\$staleKey" 2>$null
+        & reg.exe unload "HKU\$staleKey" 2>$null
+    }
+    'C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z' | ForEach-Object {
+        & reg.exe unload "HKLM\BROKENSYSTEM_$_" 2>$null
+        & reg.exe unload "HKLM\BROKENSW_$_" 2>$null
+        & reg.exe unload "HKU\BROKENSYS_$_" 2>$null
+        & reg.exe unload "HKU\BROKENSW_$_" 2>$null
+    }
 
-    # 3. Hive Management (Safety Unload & Load)
-    & reg.exe unload "HKLM\BROKENSYSTEM" 2>$null
-    Log-Info "Loading SYSTEM hive..." | Tee-Object -FilePath $logFile -Append
-    $loadResult = & reg.exe load "HKLM\BROKENSYSTEM" "$($diskb):\Windows\System32\config\SYSTEM" 2>&1
-    if ($LASTEXITCODE -ne 0) { throw "Failed to load Registry Hive: $loadResult" }
-    Start-Sleep -Seconds 2
+    # Log any externally loaded hives (diagnostic)
+    $hklmKeys = & reg.exe query HKLM 2>$null | Where-Object { $_ -match 'BROKEN|OFFLINE|SYSTEM_' }
+    $hkuKeys = & reg.exe query HKU 2>$null | Where-Object { $_ -match 'BROKEN|OFFLINE|SYSTEM_' }
+    if ($hklmKeys) { Log-Info "Loaded HKLM hives: $($hklmKeys -join ', ')" | Tee-Object -FilePath $logFile -Append }
+    if ($hkuKeys) { Log-Info "Loaded HKU hives: $($hkuKeys -join ', ')" | Tee-Object -FilePath $logFile -Append }
 
-    # 4. Registry Injection - Dual ControlSet Logic
-    # Identify which ControlSet is the default boot set
-    $selectPath = "Registry::HKLM\BROKENSYSTEM\Select"
-    $defaultSetID = (Get-ItemProperty -path $selectPath).default
-    $primarySet = "ControlSet00$defaultSetID"
-    $otherSet = if ($primarySet -eq "ControlSet001") { "ControlSet002" } else { "ControlSet001" }
+    # Stop services that scan/index attached disks and lock hive files
+    Log-Info "Stopping services that may lock disk files..." | Tee-Object -FilePath $logFile -Append
+    Stop-Service WSearch -Force -ErrorAction SilentlyContinue 2>$null
+    Stop-Service WinDefend -Force -ErrorAction SilentlyContinue 2>$null
 
-    Log-Info "Primary ControlSet identified: $primarySet" | Tee-Object -FilePath $logFile -Append
+    [System.GC]::Collect()
+    [System.GC]::WaitForPendingFinalizers()
 
-    $services = @("WindowsAzureGuestAgent", "WindowsAzureTelemetryService", "RdAgent")
+    # Cycle non-system disks offline/online to release ALL file handles
+    Log-Info "Cycling attached disks offline/online to release file locks..." | Tee-Object -FilePath $logFile -Append
+    $rescueDiskNum = (Get-Partition -DriveLetter ($env:SystemDrive -replace ':', '') -ErrorAction SilentlyContinue).DiskNumber
+    Get-Disk | Where-Object { $_.Number -ne $rescueDiskNum -and $_.OperationalStatus -eq 'Online' } | ForEach-Object {
+        $dnum = $_.Number
+        Log-Info "Cycling disk $dnum offline/online..." | Tee-Object -FilePath $logFile -Append
+        Set-Disk -Number $dnum -IsOffline $true -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 2
+        Set-Disk -Number $dnum -IsOffline $false -ErrorAction SilentlyContinue
+        Set-Disk -Number $dnum -IsReadOnly $false -ErrorAction SilentlyContinue
+    }
+    Start-Sleep -Seconds 3
 
-    foreach ($service in $services) {
-        $regFile = "$($diskb):\$service.reg"
-        # Export healthy key from the current Rescue VM
-        & reg.exe export "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\$service" "$regFile" /y 2>$null
-        
-        if (Test-Path $regFile) {
-            $originalContent = Get-Content $regFile
-            
-            # Update Primary Set
-            Log-Info "Updating $service in $primarySet..." | Tee-Object -FilePath $logFile -Append
-            $content = $originalContent -replace 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet', "HKEY_LOCAL_MACHINE\BROKENSYSTEM\$primarySet"
-            $content | Set-Content $regFile
-            & reg.exe import $regFile 2>&1 | Out-Null
+    # Step 1 - Enumerate partitions to locate the faulty OS drive(s)
+    $partitionlist = Get-Disk-Partitions
+    $rescueDrive = $env:SystemDrive -replace ':', ''
+    $fixedDisks = @()
 
-            # Update Secondary Set (if it exists on disk)
-            if (Test-Path "Registry::HKLM\BROKENSYSTEM\$otherSet") {
-                Log-Info "Updating $service in backup $otherSet..." | Tee-Object -FilePath $logFile -Append
-                $content = $originalContent -replace 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet', "HKEY_LOCAL_MACHINE\BROKENSYSTEM\$otherSet"
-                $content | Set-Content $regFile
-                & reg.exe import $regFile 2>&1 | Out-Null
+    foreach ($partition in $partitionlist) {
+        if (-not $partition.DriveLetter) { continue }
+        # Skip the rescue VM's own OS drive (its hives are locked by the running OS)
+        if ($partition.DriveLetter -eq $rescueDrive) {
+            Log-Info "Skipping rescue VM system drive $rescueDrive (own OS)" | Tee-Object -FilePath $logFile -Append
+            continue
+        }
+        if (-not (Test-Path -Path "$($partition.DriveLetter):\Windows")) { continue }
+
+        $diskb = $partition.DriveLetter
+        Log-Info "Target OS disk found on letter: $($diskb):" | Tee-Object -FilePath $logFile -Append
+
+        # Step 2 - Load the SYSTEM registry hive from the target disk
+        $hiveName = "BROKENSYSTEM_$diskb"
+        $hiveSource = "$($diskb):\Windows\System32\config\SYSTEM"
+        $hiveCopy = $null
+        & reg.exe unload "HKLM\$hiveName" 2>$null
+        [System.GC]::Collect()
+        Start-Sleep -Seconds 1
+        Log-Info "Loading SYSTEM hive from $($diskb): as $hiveName..." | Tee-Object -FilePath $logFile -Append
+        $loadResult = & reg.exe load "HKLM\$hiveName" $hiveSource 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            # Retry once after a short wait
+            Log-Warning "First reg load attempt failed for $($diskb):, retrying in 5 seconds..." | Tee-Object -FilePath $logFile -Append
+            Start-Sleep -Seconds 5
+            [System.GC]::Collect()
+            [System.GC]::WaitForPendingFinalizers()
+            $loadResult = & reg.exe load "HKLM\$hiveName" $hiveSource 2>&1
+        }
+        if ($LASTEXITCODE -ne 0) {
+            # Fallback: use esentutl.exe /y to copy locked hive via Windows Backup API semantics
+            Log-Warning "Direct load failed. Trying esentutl copy fallback for $($diskb):..." | Tee-Object -FilePath $logFile -Append
+            $hiveCopy = "$env:TEMP\SYSTEM_COPY_$diskb"
+            try {
+                $esentResult = & esentutl.exe /y $hiveSource /d $hiveCopy /o 2>&1
+                if ($LASTEXITCODE -eq 0 -and (Test-Path $hiveCopy)) {
+                    Log-Info "Hive copied successfully to $hiveCopy via esentutl" | Tee-Object -FilePath $logFile -Append
+                    $loadResult = & reg.exe load "HKLM\$hiveName" $hiveCopy 2>&1
+                }
+                else {
+                    Log-Warning "esentutl copy failed for $($diskb): $esentResult" | Tee-Object -FilePath $logFile -Append
+                }
             }
-            Remove-Item $regFile -Force
+            catch {
+                Log-Warning "esentutl fallback failed for $($diskb):: $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+            }
+        }
+        if ($LASTEXITCODE -ne 0) {
+            Log-Warning "Failed to load Registry Hive from $($diskb): $loadResult - skipping this partition" | Tee-Object -FilePath $logFile -Append
+            if ($hiveCopy -and (Test-Path $hiveCopy)) { Remove-Item $hiveCopy -Force -ErrorAction SilentlyContinue }
+            continue
+        }
+        Start-Sleep -Seconds 2
+
+        try {
+            # Step 3 - Create a full backup of the loaded hive before making changes
+            $backupFile = "$($diskb):\regbackupbeforeGAchanges_$diskb.reg"
+            Log-Info "Backing up full registry hive to $backupFile..." | Tee-Object -FilePath $logFile -Append
+            & reg.exe export "HKLM\$hiveName" $backupFile /y 2>&1 | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Log-Warning "Registry backup failed for $($diskb): -- continuing anyway" | Tee-Object -FilePath $logFile -Append
+            }
+
+            # Step 4 - Identify the primary and backup ControlSets from the Select key
+            $selectPath = "Registry::HKLM\$hiveName\Select"
+            $defaultSetID = (Get-ItemProperty -path $selectPath).default
+            $primarySet = "ControlSet00$defaultSetID"
+            $otherSet = if ($primarySet -eq "ControlSet001") { "ControlSet002" } else { "ControlSet001" }
+
+            Log-Info "Primary ControlSet identified: $primarySet" | Tee-Object -FilePath $logFile -Append
+
+            # Step 5 - Export healthy service keys and inject into both ControlSets
+            $services = @("WindowsAzureGuestAgent", "WindowsAzureTelemetryService", "RdAgent")
+
+            foreach ($service in $services) {
+                $regFile = "$($diskb):\$service.reg"
+                # Export healthy key from the current Rescue VM
+                & reg.exe export "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\$service" "$regFile" /y 2>$null
+                
+                if (Test-Path $regFile) {
+                    $originalContent = Get-Content $regFile
+                    
+                    # Update Primary Set
+                    Log-Info "Updating $service in $primarySet on $($diskb):..." | Tee-Object -FilePath $logFile -Append
+                    $content = $originalContent -replace 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet', "HKEY_LOCAL_MACHINE\$hiveName\$primarySet"
+                    $content | Set-Content $regFile
+                    & reg.exe import $regFile 2>&1 | Out-Null
+
+                    # Update Secondary Set (if it exists on disk)
+                    if (Test-Path "Registry::HKLM\$hiveName\$otherSet") {
+                        Log-Info "Updating $service in backup $otherSet on $($diskb):..." | Tee-Object -FilePath $logFile -Append
+                        $content = $originalContent -replace 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet', "HKEY_LOCAL_MACHINE\$hiveName\$otherSet"
+                        $content | Set-Content $regFile
+                        & reg.exe import $regFile 2>&1 | Out-Null
+                    }
+                    Remove-Item $regFile -Force
+                }
+            }
+
+            # Step 6 - Verify the ImagePath value was written correctly
+            $wagaPath = "HKLM\$hiveName\$primarySet\Services\WindowsAzureGuestAgent"
+            $afterImagePath = (Get-ItemProperty -Path "Registry::$wagaPath" -ErrorAction SilentlyContinue).ImagePath
+            if ([string]::IsNullOrWhiteSpace($afterImagePath)) {
+                Log-Warning "Verification Warning on $($diskb): VMAgent ImagePath is empty after injection." | Tee-Object -FilePath $logFile -Append
+            }
+            else {
+                Log-Info "Verification Success on $($diskb):: ImagePath is now $afterImagePath" | Tee-Object -FilePath $logFile -Append
+            }
+
+            # Step 7 - Backup existing WindowsAzure folder and replace with rescue VM copy
+            $sourcePath = "C:\WindowsAzure"
+            $destPath = "$($diskb):\WindowsAzure"
+            $backupPath = "$($diskb):\WindowsazurefaultyGAbackup"
+
+            if (Test-Path $destPath) {
+                Log-Info "Backing up existing WindowsAzure folder on $($diskb): to WindowsazurefaultyGAbackup..." | Tee-Object -FilePath $logFile -Append
+                if (-not (Test-Path $backupPath)) { $null = New-Item -Path $backupPath -ItemType Directory -Force }
+                & xcopy "$destPath" "$backupPath" /E /Y /H /Q 2>&1 | Out-Null
+                Log-Info "Removing old WindowsAzure folder on $($diskb):..." | Tee-Object -FilePath $logFile -Append
+                Remove-Item $destPath -Recurse -Force -ErrorAction SilentlyContinue
+            }
+
+            Log-Info "Copying full WindowsAzure folder from rescue VM to $($diskb):..." | Tee-Object -FilePath $logFile -Append
+            $null = New-Item -Path $destPath -ItemType Directory -Force
+            & xcopy "$sourcePath" "$destPath" /E /Y /H /Q 2>&1 | Out-Null
+
+            # Remove Logs folder from copied content (not relevant to the target VM)
+            $logsPath = "$destPath\Logs"
+            if (Test-Path $logsPath) {
+                Remove-Item $logsPath -Recurse -Force -ErrorAction SilentlyContinue
+            }
+
+            $fixedDisks += $diskb
+        }
+        catch {
+            Log-Error "Failed to process $($diskb):: $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+        }
+        finally {
+            # Step 8 - Release handles and safely unload the registry hive
+            Log-Info "Unloading registry hive $hiveName..." | Tee-Object -FilePath $logFile -Append
+            [System.GC]::Collect()
+            [System.GC]::WaitForPendingFinalizers()
+            Start-Sleep -Seconds 3
+
+            $unloaded = $false
+            for ($i=1; $i -le 3; $i++) {
+                & reg.exe unload "HKLM\$hiveName" 2>&1 | Out-Null
+                if ($LASTEXITCODE -eq 0) { $unloaded = $true; break }
+                Log-Warning "Unload attempt $i for $hiveName failed, retrying..." | Tee-Object -FilePath $logFile -Append
+                Start-Sleep -Seconds 5
+            }
+            if (-not $unloaded) {
+                Log-Warning "Could not unload $hiveName hive - may need manual cleanup" | Tee-Object -FilePath $logFile -Append
+            }
+
+            # If we used the copy fallback, copy the modified hive back to the original location
+            if ($hiveCopy -and (Test-Path $hiveCopy)) {
+                if ($unloaded) {
+                    Log-Info "Copying modified hive back to $hiveSource..." | Tee-Object -FilePath $logFile -Append
+                    try {
+                        Copy-Item -Path $hiveCopy -Destination $hiveSource -Force -ErrorAction Stop
+                    }
+                    catch {
+                        Log-Error "Failed to copy modified hive back to $($diskb):: $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+                    }
+                }
+                Remove-Item $hiveCopy -Force -ErrorAction SilentlyContinue
+            }
         }
     }
 
-    # 5. Strict Verification of Changes
-    $wagaPath = "HKLM\BROKENSYSTEM\$primarySet\Services\WindowsAzureGuestAgent"
-    $afterImagePath = (Get-ItemProperty -Path "Registry::$wagaPath" -ErrorAction SilentlyContinue).ImagePath
-    if ([string]::IsNullOrWhiteSpace($afterImagePath)) {
-        throw "Verification Failed: VMAgent ImagePath is empty after injection attempt."
+    if ($fixedDisks.Count -gt 0) {
+        Log-Output "VMAgent Fix completed and verified successfully on drives: $($fixedDisks -join ', ')" | Tee-Object -FilePath $logFile -Append
+        $script_final_status = $STATUS_SUCCESS
     }
-    Log-Info "Verification Success: ImagePath is now $afterImagePath" | Tee-Object -FilePath $logFile -Append
-
-    # 6. Binary Copy (GuestAgent Folders Only)
-    Log-Info "Restoring GuestAgent binaries from Troubleshooter..." | Tee-Object -FilePath $logFile -Append
-    $sourcePath = "C:\WindowsAzure"
-    $destPath = "$($diskb):\WindowsAzure"
-    if (-not (Test-Path $destPath)) { New-Item -Path $destPath -ItemType Directory | Out-Null }
-
-    $agentFolders = Get-ChildItem -Path $sourcePath -Directory -Filter "GuestAgent_*"
-    foreach ($folder in $agentFolders) {
-        Log-Info "Copying $($folder.Name) to target..." | Tee-Object -FilePath $logFile -Append
-        Copy-Item -Path $folder.FullName -Destination $destPath -Recurse -Force -ErrorAction SilentlyContinue
+    else {
+        throw "Could not find any rescue OS disk attached with \Windows."
     }
-
-    # 7. Release Handles and Unload
-    Log-Info "Releasing registry handles and unloading hive..." | Tee-Object -FilePath $logFile -Append
-    [System.GC]::Collect()
-    [System.GC]::WaitForPendingFinalizers()
-    Start-Sleep -Seconds 3
-
-    $unloaded = $false
-    for ($i=1; $i -le 3; $i++) {
-        & reg.exe unload "HKLM\BROKENSYSTEM" 2>&1 | Out-Null
-        if ($LASTEXITCODE -eq 0) { $unloaded = $true; break }
-        Log-Warning "Unload attempt $i failed, retrying..." | Tee-Object -FilePath $logFile -Append
-        Start-Sleep -Seconds 5
-    }
-
-    if (-not $unloaded) { throw "Critical Failure: Could not unload BROKENSYSTEM hive." }
-
-    Log-Output "VMAgent Fix completed and verified successfully." | Tee-Object -FilePath $logFile -Append
-    return $STATUS_SUCCESS
 
 }
 catch {
     $errorMessage = $_.Exception.Message
     Log-Error "SCRIPT FAILED: $errorMessage" | Tee-Object -FilePath $logFile -Append
-    
-    # Final emergency attempt to unload hive so disk can detach
-    [System.GC]::Collect()
-    & reg.exe unload "HKLM\BROKENSYSTEM" 2>$null
-    
-    return $STATUS_ERROR
+    $script_final_status = $STATUS_ERROR
 }
 finally {
     Log-Info "Execution ended at $(Get-Date)" | Tee-Object -FilePath $logFile -Append
 }
+
+return $script_final_status

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -8,15 +8,16 @@
     1. Uses the shared repair-library partition helper to locate the faulty OS drive.
     2. Loads the SYSTEM registry hive from the target disk into HKLM\BROKENSYSTEM.
     3. Creates and verifies a binary backup of the SYSTEM hive before loading it.
-    4. Identifies and validates the existing boot-referenced ControlSets from the Select key.
-    5. Exports healthy service keys (WindowsAzureGuestAgent, WindowsAzureTelemetryService, RdAgent)
-       from the rescue VM and injects them into both ControlSets on the target hive.
-     6. Verifies both required services use automatic startup and have non-empty ImagePath values.
-     7. Copies the latest GuestAgent installation folder, or the documented ImagePath folder fallback,
+     4. Validates the same-disk BCD loader and repairs unknown device mappings before registry writes.
+     5. Identifies and validates the existing boot-referenced ControlSets from the Select key.
+     6. Exports healthy service keys (WindowsAzureGuestAgent, WindowsAzureTelemetryService, RdAgent)
+         from the rescue VM and injects them into every boot-referenced ControlSet on the target hive.
+     7. Verifies both required services use automatic startup and have non-empty ImagePath values.
+     8. Copies the latest GuestAgent installation folder, or the documented ImagePath folder fallback,
          into a staging directory and verifies the exact executables referenced by both required services.
          The existing Agent folder is restored if activation fails.
-    8. Releases handles and safely unloads the registry hive (with retry logic).
-         If processing fails, restores and hash-verifies the original SYSTEM hive.
+     9. Releases handles, reloads the persisted SYSTEM hive, and verifies the required service keys.
+         If processing fails, restores and hash-verifies SYSTEM, Agent files, and any changed BCD.
 
 .NOTES
     Name:    GA_offlinefixer.ps1
@@ -25,14 +26,19 @@
     Modified by: Tony.Mocanu@Microsoft.com
 
 .VERSION
-    v1.3: [August 2026] - Addressed production review findings and aligned disk safety,
-                        backup verification, rollback accounting, and rescue service restoration
-                        with win-LKGC and win-sac-onLatest.
-                        - Uses a PowerShell 3-compatible streaming SHA-256 implementation.
-                        - Emits structured telemetry only through the local VMRepair logger.
-                        - Performs no IMDS lookup or other telemetry network request.
-                        - Copies only the newest versioned GuestAgent installation folder.
+    v1.3: [August 2026] - Copies only the newest versioned GuestAgent installation folder.
                         - Uses the WindowsAzureGuestAgent ImagePath folder as a fallback.
+                                                - Follows the Microsoft Learn offline VM Agent registry and binary-copy procedure.
+                                                - Aligns disk safety, rollback accounting, and rescue service restoration with
+                                                    win-LKGC and win-sac-onLatest.
+                                                - Validates the same-disk Gen1/Gen2 BCD store before Guest Agent changes.
+                                                - Repairs and verifies only unknown loader device/osdevice mappings.
+                                                - Restores the verified BCD backup after any later transaction failure.
+                                                - Reloads the persisted on-disk SYSTEM hive and re-verifies required services.
+                                                - Writes GA-OfflineRepair-Verification.json to correlate the repaired disk after restore.
+                                                - Uses a PowerShell 3-compatible streaming SHA-256 implementation.
+                                                - Emits structured telemetry only through the local VMRepair logger.
+                                                - Performs no IMDS lookup or other telemetry network request.
                         - Preserves unrelated content in the target WindowsAzure folder.
                         - Stages and validates replacement files before moving the existing Agent folder.
                         - Rolls back the Agent folder and SYSTEM hive after partial repair failures.
@@ -93,6 +99,9 @@ reg unload HKLM\VERIFY
     3. Verify GuestAgent binaries were copied to the target disk:
 Get-ChildItem F:\WindowsAzure\GuestAgent_*
     Expected: The exact executables referenced by both service ImagePath values are present and non-empty.
+    4. After az vm repair restore, verify that the repaired disk was actually reattached:
+Get-Content C:\ProgramData\GA-OfflineRepair-Verification.json
+    Expected: ScriptVersion is 1.3 and PersistedSystemHiveVerified is true.
 #>
 
 # Initialization (path-validated)
@@ -317,6 +326,32 @@ function Invoke-GaDiskPart {
     $output = $Commands | diskpart.exe 2>&1
     foreach ($line in @($output)) {
         if ($line) { Write-GaInfo "diskpart $Operation :: $line" }
+    }
+}
+
+function Invoke-GaBcdEdit {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Operation
+    )
+
+    $script:OperationCount++
+    $output = & bcdedit.exe @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    foreach ($line in @($output)) {
+        if ($line) { Write-GaInfo "bcdedit $Operation :: $line" }
+    }
+    Write-GaTelemetry -Event Operation -Message "bcdedit $Operation" -Properties @{
+        ExitCode = "$exitCode"
+        Success = ($exitCode -eq 0)
+    }
+    return [pscustomobject]@{
+        Output = @($output)
+        ExitCode = $exitCode
+        Success = ($exitCode -eq 0)
     }
 }
 
@@ -784,9 +819,176 @@ try {
         $targetAgentBackup = $null
         $existingAgentMoved = $false
         $agentFolderActivated = $false
+        $bcdPath = $null
+        $bcdBackup = $null
+        $bcdWriteStarted = $false
+        $bcdBackupRestored = $false
         & reg.exe unload "HKLM\$hiveName" 2>$null
         [System.GC]::Collect()
         Start-Sleep -Seconds 1
+
+        try {
+            $diskNumber = [int]$targetVolume.DiskNumber
+            $diskPartitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction Stop)
+            $efiParts = @($diskPartitions | Where-Object {
+                ([string]$_.GptType).Trim().Trim('{', '}') -ieq $efiGptType
+            })
+            $isGen2Disk = $efiParts.Count -gt 0
+            $bcdCandidates = if ($isGen2Disk) { $efiParts } else { $diskPartitions }
+            Write-GaInfo "Disk ${diskNumber}: validating $(if ($isGen2Disk) { 'Gen2/UEFI' } else { 'Gen1/BIOS' }) BCD before Guest Agent changes."
+
+            foreach ($bcdCandidate in $bcdCandidates) {
+                $candidateLetter = $null
+                $letterAssignedByScript = $false
+                if ($bcdCandidate.DriveLetter -and $bcdCandidate.DriveLetter -ne [char]0) {
+                    $candidateLetter = [string]$bcdCandidate.DriveLetter
+                }
+                else {
+                    $candidateLetter = Get-AvailableTempDriveLetter
+                    if (-not $candidateLetter) { continue }
+                    Invoke-GaDiskPart -Operation 'bcd-assign' -Commands @(
+                        "select disk $diskNumber"
+                        "select partition $($bcdCandidate.PartitionNumber)"
+                        "assign letter=$candidateLetter"
+                    )
+                    Start-Sleep -Seconds 2
+                    $letterAssignedByScript = Test-Path -LiteralPath "${candidateLetter}:\" -PathType Container
+                    if ($letterAssignedByScript) {
+                        $temporaryOsMounts += [pscustomobject]@{
+                            DiskNumber = $diskNumber
+                            PartitionNumber = [int]$bcdCandidate.PartitionNumber
+                            DriveLetter = $candidateLetter
+                            TemporaryMount = $true
+                        }
+                    }
+                }
+
+                $candidateBcdPath = if ($isGen2Disk) {
+                    "${candidateLetter}:\EFI\Microsoft\Boot\BCD"
+                }
+                else {
+                    "${candidateLetter}:\Boot\BCD"
+                }
+                if ($candidateLetter -and (Test-Path -LiteralPath $candidateBcdPath -PathType Leaf)) {
+                    $bcdPath = $candidateBcdPath
+                    Write-GaInfo "Disk ${diskNumber}: selected BCD store $bcdPath."
+                    break
+                }
+
+                if ($letterAssignedByScript) {
+                    Invoke-GaDiskPart -Operation 'bcd-probe-remove' -Commands @(
+                        "select disk $diskNumber"
+                        "select partition $($bcdCandidate.PartitionNumber)"
+                        "remove letter=$candidateLetter noerr"
+                    )
+                    Update-HostStorageCache -ErrorAction SilentlyContinue
+                    $temporaryOsMounts = @($temporaryOsMounts | Where-Object {
+                        -not ($_.DiskNumber -eq $diskNumber -and
+                            $_.PartitionNumber -eq [int]$bcdCandidate.PartitionNumber -and
+                            $_.DriveLetter -ieq $candidateLetter)
+                    })
+                }
+            }
+
+            if (-not $bcdPath) {
+                throw "Disk $diskNumber has no generation-appropriate BCD store. No Guest Agent changes were attempted."
+            }
+
+            $bootManagerQuery = Invoke-GaBcdEdit -Arguments @('/store', $bcdPath, '/enum', 'bootmgr', '/v') -Operation 'query-bootmgr'
+            if (-not $bootManagerQuery.Success) {
+                throw "Could not enumerate boot manager from $bcdPath."
+            }
+            $defaultLine = $bootManagerQuery.Output | Select-String -Pattern '^\s*default\s+' | Select-Object -First 1
+            if (-not $defaultLine -or $defaultLine -notmatch '\{([^}]+)\}') {
+                throw "Could not identify the default Windows loader in $bcdPath."
+            }
+            $defaultLoaderId = $matches[0]
+            if ($defaultLoaderId -notmatch '^(?i)\{[0-9a-f\-]{36}\}$') {
+                throw "Default BCD loader identifier '$defaultLoaderId' is invalid."
+            }
+
+            $loaderQuery = Invoke-GaBcdEdit -Arguments @('/store', $bcdPath, '/enum', $defaultLoaderId, '/v') -Operation 'validate-loader'
+            $loaderText = $loaderQuery.Output -join "`n"
+            $loaderPathMatch = [regex]::Match($loaderText, '(?im)^\s*path\s+(.+?)\s*$')
+            $loaderDeviceMatch = [regex]::Match($loaderText, '(?im)^\s*device\s+(.+?)\s*$')
+            $loaderOsDeviceMatch = [regex]::Match($loaderText, '(?im)^\s*osdevice\s+(.+?)\s*$')
+            $loaderSystemRootMatch = [regex]::Match($loaderText, '(?im)^\s*systemroot\s+(.+?)\s*$')
+            if (-not $loaderQuery.Success -or -not $loaderPathMatch.Success -or
+                -not $loaderDeviceMatch.Success -or -not $loaderOsDeviceMatch.Success -or
+                -not $loaderSystemRootMatch.Success) {
+                throw "Default loader $defaultLoaderId is missing required mapping elements."
+            }
+
+            $originalLoaderPath = $loaderPathMatch.Groups[1].Value.Trim()
+            $originalLoaderSystemRoot = $loaderSystemRootMatch.Groups[1].Value.Trim()
+            if ($originalLoaderPath -notmatch '(?i)^\\Windows\\System32\\winload\.(exe|efi)$') {
+                throw "Default loader $defaultLoaderId references unsupported path '$originalLoaderPath'."
+            }
+            $resolvedLoaderFile = Join-Path -Path "${diskb}:\" -ChildPath $originalLoaderPath.TrimStart('\')
+            if (-not (Test-Path -LiteralPath $resolvedLoaderFile -PathType Leaf)) {
+                throw "Default loader references '$originalLoaderPath', but '$resolvedLoaderFile' does not exist."
+            }
+
+            $repairLoaderDevice = $loaderDeviceMatch.Groups[1].Value.Trim() -match '(?i)^unknown$'
+            $repairLoaderOsDevice = $loaderOsDeviceMatch.Groups[1].Value.Trim() -match '(?i)^unknown$'
+            if ($repairLoaderDevice -or $repairLoaderOsDevice) {
+                $bcdBackup = $bcdPath + '.GA.bak.' + $timestamp
+                Copy-Item -LiteralPath $bcdPath -Destination $bcdBackup -Force -ErrorAction Stop
+                if (-not (Test-Path -LiteralPath $bcdBackup -PathType Leaf) -or
+                    (Get-Item -LiteralPath $bcdBackup -Force -ErrorAction Stop).Length -ne
+                    (Get-Item -LiteralPath $bcdPath -Force -ErrorAction Stop).Length) {
+                    throw "BCD backup verification failed for '$bcdBackup'."
+                }
+                Write-GaInfo "Disk ${diskNumber}: BCD backup created and verified at $bcdBackup."
+
+                $validatedWindowsPartition = "partition=${diskb}:"
+                $bcdWriteStarted = $true
+                if ($repairLoaderDevice) {
+                    $setDevice = Invoke-GaBcdEdit -Arguments @('/store', $bcdPath, '/set', $defaultLoaderId, 'device', $validatedWindowsPartition) -Operation 'repair-loader-device'
+                    if (-not $setDevice.Success) { throw "Could not repair device for loader $defaultLoaderId." }
+                }
+                if ($repairLoaderOsDevice) {
+                    $setOsDevice = Invoke-GaBcdEdit -Arguments @('/store', $bcdPath, '/set', $defaultLoaderId, 'osdevice', $validatedWindowsPartition) -Operation 'repair-loader-osdevice'
+                    if (-not $setOsDevice.Success) { throw "Could not repair osdevice for loader $defaultLoaderId." }
+                }
+
+                $verifyLoader = Invoke-GaBcdEdit -Arguments @('/store', $bcdPath, '/enum', $defaultLoaderId, '/v') -Operation 'verify-loader-mapping'
+                $verifyText = $verifyLoader.Output -join "`n"
+                $verifyPath = [regex]::Match($verifyText, '(?im)^\s*path\s+(.+?)\s*$')
+                $verifyDevice = [regex]::Match($verifyText, '(?im)^\s*device\s+(.+?)\s*$')
+                $verifyOsDevice = [regex]::Match($verifyText, '(?im)^\s*osdevice\s+(.+?)\s*$')
+                $verifySystemRoot = [regex]::Match($verifyText, '(?im)^\s*systemroot\s+(.+?)\s*$')
+                if (-not $verifyLoader.Success -or -not $verifyPath.Success -or
+                    -not $verifyDevice.Success -or -not $verifyOsDevice.Success -or
+                    -not $verifySystemRoot.Success -or
+                    $verifyDevice.Groups[1].Value.Trim() -match '(?i)^unknown$' -or
+                    $verifyOsDevice.Groups[1].Value.Trim() -match '(?i)^unknown$' -or
+                    $verifyPath.Groups[1].Value.Trim() -ine $originalLoaderPath -or
+                    $verifySystemRoot.Groups[1].Value.Trim() -ine $originalLoaderSystemRoot) {
+                    throw "Loader mapping repair verification failed for $defaultLoaderId."
+                }
+                Write-GaInfo "Disk ${diskNumber}: BCD loader mapping repaired and verified."
+            }
+            else {
+                Write-GaInfo "Disk ${diskNumber}: BCD loader mapping validated without changes."
+            }
+        }
+        catch {
+            Write-GaError "BCD preflight failed for Disk $($targetVolume.DiskNumber): $($_.Exception.Message)"
+            if ($bcdWriteStarted -and $bcdBackup -and (Test-Path -LiteralPath $bcdBackup -PathType Leaf)) {
+                try {
+                    Copy-Item -LiteralPath $bcdBackup -Destination $bcdPath -Force -ErrorAction Stop
+                    $bcdBackupRestored = $true
+                    Write-GaWarning "Restored BCD backup after failed preflight: $bcdBackup"
+                }
+                catch {
+                    Write-GaError "CRITICAL: Failed to restore BCD backup '$bcdBackup': $($_.Exception.Message)"
+                }
+            }
+            $failedDisks += $diskb
+            $failedCount++
+            continue
+        }
 
         try {
             $backupFile = "$($diskb):\SYSTEM_before_GA_changes_$diskb.hiv"
@@ -1113,6 +1315,92 @@ try {
             }
 
             $diskProcessedSuccessfully = $diskChangesCompleted -and ($diskb -notin $failedDisks)
+            if ($diskProcessedSuccessfully) {
+                $verificationHiveName = "GAVERIFY_$diskb"
+                $verificationHiveLoaded = $false
+                try {
+                    & reg.exe unload "HKLM\$verificationHiveName" 2>$null | Out-Null
+                    $verificationLoad = & reg.exe load "HKLM\$verificationHiveName" $hiveSource 2>&1
+                    if ($LASTEXITCODE -ne 0) {
+                        throw "Could not reload persisted SYSTEM hive: $($verificationLoad -join '; ')"
+                    }
+                    $verificationHiveLoaded = $true
+
+                    foreach ($targetControlSet in $targetControlSets) {
+                        foreach ($requiredService in $requiredAgentServices) {
+                            $persistedServicePath = "Registry::HKLM\$verificationHiveName\$targetControlSet\Services\$requiredService"
+                            $persistedConfiguration = Get-ItemProperty -Path $persistedServicePath -ErrorAction Stop
+                            if ([int]$persistedConfiguration.Start -ne 2 -or
+                                [string]::IsNullOrWhiteSpace([string]$persistedConfiguration.ImagePath)) {
+                                throw "Persisted verification failed for $requiredService in $targetControlSet."
+                            }
+                        }
+                    }
+                    Write-GaInfo "Reloaded persisted SYSTEM hive and verified required Agent services for $($diskb):."
+                }
+                catch {
+                    Write-GaError "Persisted SYSTEM verification failed for $($diskb):: $($_.Exception.Message)"
+                    if ($diskb -notin $failedDisks) { $failedDisks += $diskb }
+                    $diskProcessedSuccessfully = $false
+                }
+                finally {
+                    if ($verificationHiveLoaded) {
+                        [System.GC]::Collect()
+                        [System.GC]::WaitForPendingFinalizers()
+                        $verificationUnload = & reg.exe unload "HKLM\$verificationHiveName" 2>&1
+                        if ($LASTEXITCODE -ne 0) {
+                            Write-GaError "Could not unload verification hive $verificationHiveName`: $($verificationUnload -join '; ')"
+                            if ($diskb -notin $failedDisks) { $failedDisks += $diskb }
+                            $diskProcessedSuccessfully = $false
+                        }
+                    }
+                }
+            }
+
+            if ($diskProcessedSuccessfully) {
+                try {
+                    $verificationMarkerPath = "$($diskb):\ProgramData\GA-OfflineRepair-Verification.json"
+                    $targetIdentity = Get-GaDiskIdentity -DiskNumber $targetVolume.DiskNumber
+                    [ordered]@{
+                        CompletedUtc = (Get-Date).ToUniversalTime().ToString('o')
+                        ScriptVersion = $script:RepairScriptVersion
+                        DiskNumberOnRepairVm = [int]$targetVolume.DiskNumber
+                        DiskPartitionStyle = $targetIdentity.PartitionStyle
+                        DiskIdentityDuringRepair = $targetIdentity.Value
+                        WindowsPartition = "$($diskb):"
+                        ControlSets = @($targetControlSets)
+                        RequiredServices = @($requiredAgentServices)
+                        AgentFolder = $targetAgentFolder
+                        BcdPath = $bcdPath
+                        BcdMappingChanged = [bool]$bcdWriteStarted
+                        PersistedSystemHiveVerified = $true
+                    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $verificationMarkerPath -Encoding UTF8 -ErrorAction Stop
+                    Write-GaInfo "Wrote post-restore correlation marker: $verificationMarkerPath"
+                }
+                catch {
+                    Write-GaError "Could not write the repair correlation marker on $($diskb):: $($_.Exception.Message)"
+                    if ($diskb -notin $failedDisks) { $failedDisks += $diskb }
+                    $diskProcessedSuccessfully = $false
+                }
+            }
+
+            if (-not $diskProcessedSuccessfully -and $diskChangesCompleted -and
+                $backupFile -and (Test-Path -LiteralPath $backupFile -PathType Leaf)) {
+                try {
+                    $expectedHiveHash = Get-GaFileSha256 -LiteralPath $backupFile
+                    Copy-Item -LiteralPath $backupFile -Destination $hiveSource -Force -ErrorAction Stop
+                    $actualHiveHash = Get-GaFileSha256 -LiteralPath $hiveSource
+                    if ($actualHiveHash -ne $expectedHiveHash) {
+                        throw 'SYSTEM hive rollback verification failed after a late transaction failure.'
+                    }
+                    Write-GaWarning "Restored original SYSTEM hive because the complete transaction did not finish for $($diskb):."
+                }
+                catch {
+                    Write-GaError "CRITICAL: Failed to restore SYSTEM after a late transaction failure on $($diskb):: $($_.Exception.Message)"
+                    if ($diskb -notin $failedDisks) { $failedDisks += $diskb }
+                }
+            }
+
             if (-not $diskProcessedSuccessfully -and $agentFolderActivated -and $targetAgentFolder) {
                 try {
                     if (Test-Path -LiteralPath $targetAgentFolder) {
@@ -1132,6 +1420,20 @@ try {
                 }
                 catch {
                     Write-GaError "Failed to roll back the VM Agent folder on $($diskb):: $($_.Exception.Message)"
+                    if ($diskb -notin $failedDisks) { $failedDisks += $diskb }
+                }
+            }
+
+            if (-not $diskProcessedSuccessfully -and $bcdWriteStarted -and
+                -not $bcdBackupRestored -and $bcdBackup -and
+                (Test-Path -LiteralPath $bcdBackup -PathType Leaf)) {
+                try {
+                    Copy-Item -LiteralPath $bcdBackup -Destination $bcdPath -Force -ErrorAction Stop
+                    $bcdBackupRestored = $true
+                    Write-GaWarning "Restored BCD backup because Guest Agent processing did not complete: $bcdBackup"
+                }
+                catch {
+                    Write-GaError "CRITICAL: Failed to restore BCD backup '$bcdBackup': $($_.Exception.Message)"
                     if ($diskb -notin $failedDisks) { $failedDisks += $diskb }
                 }
             }

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -96,14 +96,63 @@ if (-not (Test-Path -Path $diskPartitionsPath -PathType Leaf)) {
 
 . $diskPartitionsPath
 
-# Log Configuration
-$logDir = [Environment]::GetFolderPath('Desktop')
-if ([string]::IsNullOrWhiteSpace($logDir)) {
-    $logDir = Join-Path $env:PUBLIC 'Desktop'
+# Log Configuration (desktop log standard)
+$desktopPath = [Environment]::GetFolderPath('Desktop')
+if ([string]::IsNullOrWhiteSpace($desktopPath)) {
+    $desktopPath = Join-Path $env:PUBLIC 'Desktop'
 }
-if (-not (Test-Path $logDir)) { $null = New-Item -ItemType Directory -Path $logDir -Force }
+
+$logDir = Join-Path $desktopPath 'RepairLogs'
+if (-not (Test-Path -LiteralPath $logDir)) {
+    $null = New-Item -ItemType Directory -Path $logDir -Force
+}
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
-$logFile = "$logDir\GA_offlinefixer_$timestamp.log"
+$logFile = Join-Path $logDir "GA_offlinefixer_$timestamp.log"
+
+if (-not (Test-Path -LiteralPath $logFile)) {
+    $null = New-Item -Path $logFile -ItemType File -Force
+}
+
+function Write-DesktopLogLine {
+    param([string]$Message)
+    if ($null -ne $Message) {
+        Add-Content -LiteralPath $logFile -Value ("[{0}] {1}" -f (Get-Date -Format 's'), $Message)
+    }
+}
+
+$script:_origLogInfo    = (Get-Command Log-Info    -ErrorAction SilentlyContinue).ScriptBlock
+$script:_origLogWarning = (Get-Command Log-Warning -ErrorAction SilentlyContinue).ScriptBlock
+$script:_origLogError   = (Get-Command Log-Error   -ErrorAction SilentlyContinue).ScriptBlock
+$script:_origLogOutput  = (Get-Command Log-Output  -ErrorAction SilentlyContinue).ScriptBlock
+
+if ($script:_origLogInfo) {
+    function Log-Info {
+        param([string]$Message)
+        & $script:_origLogInfo $Message
+        Write-DesktopLogLine "[INFO] $Message"
+    }
+}
+if ($script:_origLogWarning) {
+    function Log-Warning {
+        param([string]$Message)
+        & $script:_origLogWarning $Message
+        Write-DesktopLogLine "[WARN] $Message"
+    }
+}
+if ($script:_origLogError) {
+    function Log-Error {
+        param([string]$Message)
+        & $script:_origLogError $Message
+        Write-DesktopLogLine "[ERROR] $Message"
+    }
+}
+if ($script:_origLogOutput) {
+    function Log-Output {
+        param([string]$Message)
+        & $script:_origLogOutput $Message
+        Write-DesktopLogLine "[OUTPUT] $Message"
+    }
+}
 
 function Invoke-CriticalCommand {
     param(

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -301,11 +301,31 @@ try {
     $rescueDiskNum = [int]$rescueOsPartition.DiskNumber
     Log-Info "Rescue VM OS disk identified as physical Disk $rescueDiskNum."
 
+    # Azure rescue VMs can place the pagefile on a separate temporary resource disk.
+    # Windows treats that disk as critical even though it is not the rescue OS disk.
+    $protectedDiskNumbers = @($rescueDiskNum)
+    $protectedDiskNumbers += @(Get-Disk -ErrorAction Stop |
+        Where-Object { $_.IsBoot -or $_.IsSystem } |
+        Select-Object -ExpandProperty Number)
+    $pageFileDriveLetters = @(Get-CimInstance -ClassName Win32_PageFileUsage -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            if ([string]$_.Name -match '^([A-Za-z]):\\') { $matches[1] }
+        } | Select-Object -Unique)
+    foreach ($pageFileDriveLetter in $pageFileDriveLetters) {
+        $pageFilePartition = Get-Partition -DriveLetter $pageFileDriveLetter -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($pageFilePartition) {
+            $protectedDiskNumbers += [int]$pageFilePartition.DiskNumber
+        }
+    }
+    $protectedDiskNumbers = @($protectedDiskNumbers | Sort-Object -Unique)
+    Log-Info "Protected rescue disk numbers excluded from repair: $($protectedDiskNumbers -join ', ')."
+
     $azureVirtualDiskNumbers = @(Get-CimInstance -ClassName Win32_DiskDrive -ErrorAction Stop |
         Where-Object { $_.Model -like 'Microsoft Virtual Disk*' } |
         ForEach-Object { [int]$_.Index })
     $attachedDisks = @(Get-Disk -ErrorAction Stop | Where-Object {
-        $_.Number -in $azureVirtualDiskNumbers -and $_.Number -ne $rescueDiskNum
+        $_.Number -in $azureVirtualDiskNumbers -and $_.Number -notin $protectedDiskNumbers
     })
     if ($attachedDisks.Count -eq 0) {
         throw 'REPAIR-ONLY SCRIPT: No attached Microsoft virtual disk was found. No service or disk changes were attempted.'

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -18,16 +18,18 @@
 
 .NOTES
     Name:    GA_offlinefixer.ps1
-    Version: 1.3
+    Version: 1.4
     Original Author: Daniel Munoz L (damunozl@microsoft.com)
     Modified by: Tony.Mocanu@Microsoft.com
 
 .VERSION
+    v1.4: [August 2026] - Temporarily resolves attached-disk identity collisions and restores the
+                        - exact original MBR signature or GPT GUID before returning.
     v1.3: [August 2026] - Identifies and excludes the rescue VM OS disk by physical disk number.
                         - Requires an attached Microsoft virtual disk before service or disk disruption.
                         - Groups candidates by physical disk and validates winload plus the SYSTEM hive.
                         - Temporarily mounts unlettered Windows partition candidates and cleans them up.
-                        - Refuses collision-offlined attached disks rather than changing disk identities.
+                        - Detects collision-offlined attached disks before target discovery.
                         - Restores and verifies the original WSearch service state.
                         - No longer stops Windows Defender on the rescue VM.
                         - Makes fallback hive copy-back part of per-disk success accounting.
@@ -60,7 +62,7 @@ Get-ChildItem F:\WindowsAzure\GuestAgent_* | Rename-Item -NewName { $_.Name + '_
     7. Verify via the .VERIFICATION steps below.
 
 .EXAMPLE
-    az vm repair run -g <rg> -n <vm> --run-id win-GA_offlinefixer --run-on-repair
+    az vm repair run -g <rg> -n <vm> --run-id win-GA-fix --run-on-repair
 
 .VERIFICATION
     1. Check the log file for success:
@@ -223,6 +225,8 @@ $skippedCount = 0
 $failedCount = 0
 $changedCount = 0
 $temporaryOsMounts = @()
+$temporaryDiskIdentities = @()
+$successMessage = $null
 
 # Local execution context for diagnostic logging. No data is transmitted off-box.
 $vmMetadata = @{
@@ -334,9 +338,67 @@ try {
     $collisionDisks = @($attachedDisks | Where-Object {
         $_.IsOffline -and [string]$_.OfflineReason -eq 'Collision'
     })
-    if ($collisionDisks.Count -gt 0) {
-        throw "Attached disk identity collision detected on Disk(s) $($collisionDisks.Number -join ', '). Refusing to change disk identities; use a non-colliding rescue VM or matching-generation nested repair."
+    foreach ($collisionDisk in $collisionDisks) {
+        $diskNumber = [int]$collisionDisk.Number
+        $partitionStyle = [string]$collisionDisk.PartitionStyle
+        if ($partitionStyle -notin @('GPT', 'MBR')) {
+            throw "Disk $diskNumber has identity collision with unsupported partition style '$partitionStyle'."
+        }
+
+        $identityRecord = [pscustomobject]@{
+            DiskNumber = $diskNumber
+            PartitionStyle = $partitionStyle
+            OriginalGuid = [string]$collisionDisk.Guid
+            OriginalSignature = $collisionDisk.Signature
+            OriginalIsOffline = [bool]$collisionDisk.IsOffline
+            TemporaryGuid = $null
+            TemporarySignature = $null
+        }
+        $temporaryDiskIdentities += $identityRecord
+
+        if ($partitionStyle -eq 'GPT') {
+            if ([string]::IsNullOrWhiteSpace($identityRecord.OriginalGuid)) {
+                throw "Cannot preserve the original GPT GUID for collision Disk $diskNumber."
+            }
+            do {
+                $identityRecord.TemporaryGuid = ([guid]::NewGuid()).ToString('B')
+            } while (Get-Disk -ErrorAction Stop | Where-Object {
+                [string]$_.Guid -ieq [string]$identityRecord.TemporaryGuid
+            })
+            Log-Warning "Disk $diskNumber has a GPT identity collision. Assigning a temporary GUID for offline repair."
+            Set-Disk -Number $diskNumber -Guid $identityRecord.TemporaryGuid -ErrorAction Stop
+        }
+        else {
+            if ($null -eq $identityRecord.OriginalSignature) {
+                throw "Cannot preserve the original MBR signature for collision Disk $diskNumber."
+            }
+            do {
+                $signatureBytes = New-Object byte[] 4
+                [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($signatureBytes)
+                $identityRecord.TemporarySignature = [BitConverter]::ToUInt32($signatureBytes, 0)
+            } while ($identityRecord.TemporarySignature -eq 0 -or (Get-Disk -ErrorAction Stop | Where-Object {
+                $_.PartitionStyle -eq 'MBR' -and $_.Signature -eq $identityRecord.TemporarySignature
+            }))
+            Log-Warning "Disk $diskNumber has an MBR identity collision. Assigning a temporary signature for offline repair."
+            Set-Disk -Number $diskNumber -Signature $identityRecord.TemporarySignature -ErrorAction Stop
+        }
+
+        Set-Disk -Number $diskNumber -IsOffline $false -ErrorAction Stop
+        Set-Disk -Number $diskNumber -IsReadOnly $false -ErrorAction Stop
+        Update-HostStorageCache -ErrorAction SilentlyContinue
+        $updatedCollisionDisk = Get-Disk -Number $diskNumber -ErrorAction Stop
+        $temporaryIdentityVerified = if ($partitionStyle -eq 'GPT') {
+            [string]$updatedCollisionDisk.Guid -ieq [string]$identityRecord.TemporaryGuid
+        }
+        else {
+            [uint32]$updatedCollisionDisk.Signature -eq [uint32]$identityRecord.TemporarySignature
+        }
+        if (-not $temporaryIdentityVerified -or $updatedCollisionDisk.IsOffline) {
+            throw "Temporary identity activation could not be verified for collision Disk $diskNumber."
+        }
+        Log-Info "Disk $diskNumber temporary identity applied and disk brought online. Original identity will be restored during cleanup."
     }
+    $attachedDisks = @($attachedDisks | ForEach-Object { Get-Disk -Number $_.Number -ErrorAction Stop })
     $attachedDiskNumbers = @($attachedDisks | Select-Object -ExpandProperty Number)
     Log-Info "Attached repair candidate disk numbers: $($attachedDiskNumbers -join ', ')"
 
@@ -719,7 +781,7 @@ try {
 
     Log-Info "Processing summary: processed=$processedCount skipped=$skippedCount failed=$failedCount changed=$changedCount"
     if ($fixedDisks.Count -gt 0) {
-        Log-Output "VMAgent Fix completed and verified successfully on drives: $($fixedDisks -join ', ') | Host=$($vmMetadata.HostName)"
+        $successMessage = "VMAgent Fix completed and verified successfully on drives: $($fixedDisks -join ', ') | Host=$($vmMetadata.HostName)"
         $script_final_status = $STATUS_SUCCESS
     }
     else {
@@ -754,6 +816,36 @@ finally {
         }
     }
 
+    foreach ($identityRecord in @($temporaryDiskIdentities)) {
+        try {
+            $diskNumber = [int]$identityRecord.DiskNumber
+            Log-Info "Restoring original $($identityRecord.PartitionStyle) identity on Disk $diskNumber."
+            Set-Disk -Number $diskNumber -IsOffline $true -ErrorAction Stop
+            if ($identityRecord.PartitionStyle -eq 'GPT') {
+                Set-Disk -Number $diskNumber -Guid $identityRecord.OriginalGuid -ErrorAction Stop
+            }
+            else {
+                Set-Disk -Number $diskNumber -Signature ([uint32]$identityRecord.OriginalSignature) -ErrorAction Stop
+            }
+            Update-HostStorageCache -ErrorAction SilentlyContinue
+            $restoredDisk = Get-Disk -Number $diskNumber -ErrorAction Stop
+            $identityRestored = if ($identityRecord.PartitionStyle -eq 'GPT') {
+                [string]$restoredDisk.Guid -ieq [string]$identityRecord.OriginalGuid
+            }
+            else {
+                [uint32]$restoredDisk.Signature -eq [uint32]$identityRecord.OriginalSignature
+            }
+            if (-not $identityRestored) {
+                throw "Original disk identity verification failed."
+            }
+            Log-Info "Original $($identityRecord.PartitionStyle) identity restored and verified on Disk $diskNumber; disk left offline for repair restore."
+        }
+        catch {
+            Log-Error "CRITICAL: Failed to restore original identity on Disk $($identityRecord.DiskNumber): $($_.Exception.Message)"
+            $script_final_status = $STATUS_ERROR
+        }
+    }
+
     # Log local execution context only; this script performs no telemetry upload.
     if ($vmMetadata.OSVersion) {
         Log-Info "Execution Context - Host: $($vmMetadata.HostName), OS: $($vmMetadata.OSVersion)"
@@ -783,6 +875,10 @@ finally {
             Log-Error "Failed to restore $svc to state $originalState : $($_.Exception.Message)"
             $script_final_status = $STATUS_ERROR
         }
+    }
+
+    if ($script_final_status -eq $STATUS_SUCCESS -and $successMessage) {
+        Log-Output $successMessage
     }
 
     Log-Info "Execution ended at $(Get-Date)"

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
     This script runs from a rescue VM to repair a broken Azure Guest Agent on an attached OS disk.
     It performs the following steps:
-    1. Enumerates partitions only on validated attached repair disks to locate the faulty OS drive.
+    1. Uses the shared repair-library partition helper to locate the faulty OS drive.
     2. Loads the SYSTEM registry hive from the target disk into HKLM\BROKENSYSTEM.
     3. Creates and verifies a binary backup of the SYSTEM hive before loading it.
     4. Identifies the primary and backup ControlSets (001/002) from the Select key.
@@ -27,9 +27,10 @@
                         - Preserves unrelated content in the target WindowsAzure folder.
                         - Bounds file-copy retries to avoid client repair jobs appearing stuck.
                         - Unloads only stale repair hives that actually exist.
-                        - Avoids broad helper disk onlining and full registry text exports.
-                        - Temporarily resolves attached-disk identity collisions and restores the
-                        - exact original MBR signature or GPT GUID before returning.
+                        - Uses the same partition discovery and collision handling as win-sac-onLatest.
+                        - Preserves the Gen2 source GPT GUID by temporarily changing only the
+                        - matching disposable repair VM OS disk GUID.
+                        - Temporarily changes and restores source identity only for Gen1 MBR disks.
                         - Identifies and excludes the rescue VM OS disk by physical disk number.
                         - Requires an attached Microsoft virtual disk before service or disk disruption.
                         - Groups candidates by physical disk and validates winload plus the SYSTEM hive.
@@ -97,12 +98,25 @@ if ([string]::IsNullOrEmpty($resolvedScriptRoot)) {
 }
 
 $initPath = Join-Path -Path $resolvedScriptRoot -ChildPath 'common\setup\init.ps1'
+$diskPartitionsPath = Join-Path -Path $resolvedScriptRoot -ChildPath 'common\helpers\Get-Disk-Partitions-v2.ps1'
 if (-not (Test-Path -Path $initPath -PathType Leaf)) {
     Write-Error "Missing required dependency: $initPath"
     return 1
 }
 
 . $initPath
+
+if (-not (Test-Path -Path $diskPartitionsPath -PathType Leaf)) {
+    Log-Error "Missing required dependency: $diskPartitionsPath"
+    return $STATUS_ERROR
+}
+
+. $diskPartitionsPath
+
+if (-not (Get-Command -Name Get-Disk-Partitions -CommandType Function -ErrorAction SilentlyContinue)) {
+    Log-Error "Dependency did not define the required Get-Disk-Partitions function: $diskPartitionsPath"
+    return $STATUS_ERROR
+}
 
 # Log Configuration (desktop log standard)
 $desktopPath = [Environment]::GetFolderPath('Desktop')
@@ -213,6 +227,108 @@ function Invoke-GaDiskPart {
     }
 }
 
+function Get-GaDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$DiskNumber
+    )
+
+    $disk = Get-Disk -Number $DiskNumber -ErrorAction Stop
+    if ([string]$disk.PartitionStyle -eq 'MBR') {
+        $signature = [uint32]$disk.Signature
+        return [pscustomobject]@{
+            PartitionStyle = 'MBR'
+            Value = $signature.ToString('X8')
+            DiskPartValue = $signature.ToString('X8')
+        }
+    }
+
+    if ([string]$disk.PartitionStyle -eq 'GPT') {
+        $diskGuid = ([guid]$disk.Guid).ToString('D')
+        return [pscustomobject]@{
+            PartitionStyle = 'GPT'
+            Value = $diskGuid
+            DiskPartValue = $diskGuid
+        }
+    }
+
+    throw "Disk $DiskNumber has unsupported partition style '$($disk.PartitionStyle)'."
+}
+
+function Set-GaTemporarySourceIdentity {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Record)
+
+    if ($Record.PartitionStyle -ne 'MBR') {
+        throw 'Temporary source disk identities are permitted only for the Gen1 MBR path.'
+    }
+
+    Invoke-GaDiskPart -Operation 'collision-prepare' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
+        'online disk'
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $currentIdentity = Get-GaDiskIdentity -DiskNumber $Record.DiskNumber
+    $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
+        throw "Disk $($Record.DiskNumber) could not be brought online with its verified temporary identity."
+    }
+}
+
+function Restore-GaOriginalSourceIdentity {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Record)
+
+    if ($Record.PartitionStyle -ne 'MBR') {
+        throw 'Source disk identity restoration is permitted only for the Gen1 MBR path.'
+    }
+
+    Invoke-GaDiskPart -Operation 'collision-restore' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        'offline disk'
+        "uniqueid disk id=$($Record.OriginalDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $restoredIdentity = Get-GaDiskIdentity -DiskNumber $Record.DiskNumber
+    $restoredDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if (-not $restoredDisk.IsOffline -or $restoredIdentity.Value -ine $Record.OriginalValue) {
+        throw "Disk $($Record.DiskNumber) did not return to its original offline identity."
+    }
+}
+
+function Set-GaTemporaryRepairDiskIdentity {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Record)
+
+    Invoke-GaDiskPart -Operation 'repair-host-collision-prepare' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $currentIdentity = Get-GaDiskIdentity -DiskNumber $Record.DiskNumber
+    $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
+        throw 'The repair VM OS disk did not retain a verified temporary GPT identity.'
+    }
+}
+
+function Restore-GaRepairDiskIdentity {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Record)
+
+    Invoke-GaDiskPart -Operation 'repair-host-collision-restore' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.OriginalDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $restoredIdentity = Get-GaDiskIdentity -DiskNumber $Record.DiskNumber
+    $restoredDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if ($restoredDisk.IsOffline -or $restoredIdentity.Value -ine $Record.OriginalValue) {
+        throw 'The repair VM OS disk did not return to its original GPT identity.'
+    }
+}
+
 # Status Tracking
 $script_final_status = $STATUS_ERROR
 $serviceStates = @{}  # Track original service states for restoration
@@ -221,7 +337,9 @@ $skippedCount = 0
 $failedCount = 0
 $changedCount = 0
 $temporaryOsMounts = @()
-$temporaryDiskIdentities = @()
+$collisionDiskRecords = @()
+$gptCollisionDiskNumbers = @()
+$repairDiskIdentityRecord = $null
 $successMessage = $null
 
 # Local execution context for diagnostic logging. No data is transmitted off-box.
@@ -300,7 +418,8 @@ try {
         throw "CRITICAL SAFETY CHECK FAILED: Could not identify the rescue VM OS disk from $($env:SystemDrive)."
     }
     $rescueDiskNum = [int]$rescueOsPartition.DiskNumber
-    Log-Info "Rescue VM OS disk identified as physical Disk $rescueDiskNum."
+    $repairDiskIdentity = Get-GaDiskIdentity -DiskNumber $rescueDiskNum
+    Log-Info "Rescue VM OS disk identified as physical Disk $rescueDiskNum ($($repairDiskIdentity.PartitionStyle))."
 
     # Azure rescue VMs can place the pagefile on a separate temporary resource disk.
     # Windows treats that disk as critical even though it is not the rescue OS disk.
@@ -336,68 +455,84 @@ try {
         $_.IsOffline -and [string]$_.OfflineReason -eq 'Collision'
     })
     foreach ($collisionDisk in $collisionDisks) {
-        $diskNumber = [int]$collisionDisk.Number
-        $partitionStyle = [string]$collisionDisk.PartitionStyle
-        if ($partitionStyle -notin @('GPT', 'MBR')) {
-            throw "Disk $diskNumber has identity collision with unsupported partition style '$partitionStyle'."
-        }
-
-        $identityRecord = [pscustomobject]@{
-            DiskNumber = $diskNumber
-            PartitionStyle = $partitionStyle
-            OriginalGuid = [string]$collisionDisk.Guid
-            OriginalSignature = $collisionDisk.Signature
-            OriginalIsOffline = [bool]$collisionDisk.IsOffline
-            TemporaryGuid = $null
-            TemporarySignature = $null
-        }
-        $temporaryDiskIdentities += $identityRecord
-
-        if ($partitionStyle -eq 'GPT') {
-            if ([string]::IsNullOrWhiteSpace($identityRecord.OriginalGuid)) {
-                throw "Cannot preserve the original GPT GUID for collision Disk $diskNumber."
+        $originalIdentity = Get-GaDiskIdentity -DiskNumber $collisionDisk.Number
+        if ($originalIdentity.PartitionStyle -eq 'GPT') {
+            if ($repairDiskIdentity.PartitionStyle -ne 'GPT' -or $repairDiskIdentity.Value -ine $originalIdentity.Value) {
+                throw "Disk $($collisionDisk.Number) reports a GPT identity collision, but its GUID does not match the repair VM OS disk. Refusing an unverified identity change."
             }
-            do {
-                $identityRecord.TemporaryGuid = ([guid]::NewGuid()).ToString('B')
-            } while (Get-Disk -ErrorAction Stop | Where-Object {
-                [string]$_.Guid -ieq [string]$identityRecord.TemporaryGuid
-            })
-            Log-Warning "Disk $diskNumber has a GPT identity collision. Assigning a temporary GUID for offline repair."
-            Set-Disk -Number $diskNumber -Guid $identityRecord.TemporaryGuid -ErrorAction Stop
-        }
-        else {
-            if ($null -eq $identityRecord.OriginalSignature) {
-                throw "Cannot preserve the original MBR signature for collision Disk $diskNumber."
+
+            if (-not $repairDiskIdentityRecord) {
+                $temporaryRepairGuid = ([guid]::NewGuid()).ToString('D')
+                $repairDiskIdentityRecord = [pscustomobject]@{
+                    DiskNumber = $rescueDiskNum
+                    PartitionStyle = 'GPT'
+                    OriginalValue = $repairDiskIdentity.Value
+                    OriginalDiskPartValue = $repairDiskIdentity.DiskPartValue
+                    TemporaryValue = $temporaryRepairGuid
+                    TemporaryDiskPartValue = $temporaryRepairGuid
+                }
+
+                Log-Warning 'Temporarily changing only the repair VM OS disk GPT identity. The attached source disk GUID will remain unchanged.'
+                Set-GaTemporaryRepairDiskIdentity -Record $repairDiskIdentityRecord
             }
-            do {
-                $signatureBytes = New-Object byte[] 4
-                [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($signatureBytes)
-                $identityRecord.TemporarySignature = [BitConverter]::ToUInt32($signatureBytes, 0)
-            } while ($identityRecord.TemporarySignature -eq 0 -or (Get-Disk -ErrorAction Stop | Where-Object {
-                $_.PartitionStyle -eq 'MBR' -and $_.Signature -eq $identityRecord.TemporarySignature
-            }))
-            Log-Warning "Disk $diskNumber has an MBR identity collision. Assigning a temporary signature for offline repair."
-            Set-Disk -Number $diskNumber -Signature $identityRecord.TemporarySignature -ErrorAction Stop
+
+            $gptCollisionDiskNumbers += [int]$collisionDisk.Number
+            Invoke-GaDiskPart -Operation 'source-gpt-online' -Commands @(
+                "select disk $($collisionDisk.Number)"
+                'online disk'
+            )
+            Update-HostStorageCache -ErrorAction SilentlyContinue
+            $releasedDisk = Get-Disk -Number $collisionDisk.Number -ErrorAction Stop
+            $sourceIdentityAfterRelease = Get-GaDiskIdentity -DiskNumber $collisionDisk.Number
+            if ($releasedDisk.IsOffline -or
+                [string]$releasedDisk.OfflineReason -eq 'Collision' -or
+                $sourceIdentityAfterRelease.Value -ine $originalIdentity.Value) {
+                throw "Disk $($collisionDisk.Number) could not be onlined with its original GPT identity unchanged."
+            }
+
+            Log-Info "Disk $($collisionDisk.Number) collision released; source GPT identity remains $($originalIdentity.Value)."
+            continue
         }
 
-        Set-Disk -Number $diskNumber -IsOffline $false -ErrorAction Stop
-        Set-Disk -Number $diskNumber -IsReadOnly $false -ErrorAction Stop
-        Update-HostStorageCache -ErrorAction SilentlyContinue
-        $updatedCollisionDisk = Get-Disk -Number $diskNumber -ErrorAction Stop
-        $temporaryIdentityVerified = if ($partitionStyle -eq 'GPT') {
-            [string]$updatedCollisionDisk.Guid -ieq [string]$identityRecord.TemporaryGuid
+        do {
+            $temporaryValue = ([Convert]::ToUInt32(([guid]::NewGuid().ToString('N').Substring(0, 8)), 16)).ToString('X8')
+        } while ($temporaryValue -eq '00000000' -or $temporaryValue -ieq $originalIdentity.Value)
+
+        $record = [pscustomobject]@{
+            DiskNumber = [int]$collisionDisk.Number
+            PartitionStyle = $originalIdentity.PartitionStyle
+            OriginalValue = $originalIdentity.Value
+            OriginalDiskPartValue = $originalIdentity.DiskPartValue
+            TemporaryValue = $temporaryValue
+            TemporaryDiskPartValue = $temporaryValue
         }
-        else {
-            [uint32]$updatedCollisionDisk.Signature -eq [uint32]$identityRecord.TemporarySignature
-        }
-        if (-not $temporaryIdentityVerified -or $updatedCollisionDisk.IsOffline) {
-            throw "Temporary identity activation could not be verified for collision Disk $diskNumber."
-        }
-        Log-Info "Disk $diskNumber temporary identity applied and disk brought online. Original identity will be restored during cleanup."
+        $collisionDiskRecords += $record
+
+        Log-Warning "Disk $($record.DiskNumber) is offline due to an identity collision. Applying a temporary MBR identity for this repair run."
+        Set-GaTemporarySourceIdentity -Record $record
+        Log-Info "Disk $($record.DiskNumber) is online with a verified temporary MBR identity."
     }
+
     $attachedDisks = @($attachedDisks | ForEach-Object { Get-Disk -Number $_.Number -ErrorAction Stop })
     $attachedDiskNumbers = @($attachedDisks | Select-Object -ExpandProperty Number)
     Log-Info "Attached repair candidate disk numbers: $($attachedDiskNumbers -join ', ')"
+
+    $partitionlist = @(Get-Disk-Partitions)
+    if ($partitionlist.Count -eq 0) {
+        throw 'Get-Disk-Partitions returned no partitions from Azure virtual disks.'
+    }
+
+    $discoveredDiskNumbers = @($partitionlist | Select-Object -ExpandProperty DiskNumber -Unique)
+    Log-Info "Get-Disk-Partitions discovered disk numbers: $($discoveredDiskNumbers -join ', ')"
+    $targetDiskGroups = @($partitionlist |
+        Where-Object {
+            [int]$_.DiskNumber -in $attachedDiskNumbers -and
+            [int]$_.DiskNumber -notin $protectedDiskNumbers
+        } |
+        Group-Object DiskNumber)
+    if ($targetDiskGroups.Count -eq 0) {
+        throw 'REPAIR-ONLY SCRIPT: The shared partition helper returned no partitions from an attached repair disk.'
+    }
 
     # Pause indexing while attached hives are modified. Defender remains running.
     Log-Info "Stopping Windows Search temporarily to reduce attached-disk file locks..."
@@ -419,25 +554,11 @@ try {
         }
     }
 
-    [System.GC]::Collect()
-    [System.GC]::WaitForPendingFinalizers()
-
-    # Cycle only verified attached Microsoft virtual disks to release file handles.
-    Log-Info "Cycling attached disks offline/online to release file locks..."
-    $attachedDisks | Where-Object { -not $_.IsOffline } | ForEach-Object {
-        $dnum = $_.Number
-        Log-Info "Cycling disk $dnum offline/online..."
-        Set-Disk -Number $dnum -IsOffline $true -ErrorAction Stop
-        Start-Sleep -Seconds 2
-        Set-Disk -Number $dnum -IsOffline $false -ErrorAction Stop
-        Set-Disk -Number $dnum -IsReadOnly $false -ErrorAction Stop
-    }
-    Start-Sleep -Seconds 3
-
     # Step 1 - Find one validated Windows volume on each attached physical disk.
     $targetWindowsVolumes = @()
     $efiGptType = 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'
-    foreach ($diskNumber in $attachedDiskNumbers) {
+    foreach ($diskGroup in $targetDiskGroups) {
+        $diskNumber = [int]$diskGroup.Name
         $diskPartitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction Stop)
         if ($diskPartitions.Count -eq 0) {
             Log-Warning "Attached repair Disk $diskNumber has no partitions."
@@ -847,34 +968,54 @@ finally {
         }
     }
 
-    foreach ($identityRecord in @($temporaryDiskIdentities)) {
+    $identityRestorationFailed = $false
+
+    if ($repairDiskIdentityRecord) {
+        foreach ($diskNumber in @($gptCollisionDiskNumbers | Sort-Object -Unique)) {
+            try {
+                Invoke-GaDiskPart -Operation 'source-before-repair-host-restore' -Commands @(
+                    "select disk $diskNumber"
+                    'offline disk'
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                $sourceDisk = Get-Disk -Number $diskNumber -ErrorAction Stop
+                $sourceIdentity = Get-GaDiskIdentity -DiskNumber $diskNumber
+                if (-not $sourceDisk.IsOffline -or $sourceIdentity.Value -ine $repairDiskIdentityRecord.OriginalValue) {
+                    throw "Source Disk $diskNumber was not offline with its unchanged original GPT identity."
+                }
+                Log-Info "Source Disk $diskNumber is offline with its original GPT identity verified before repair host restoration."
+            }
+            catch {
+                $identityRestorationFailed = $true
+                Log-Error "CRITICAL: Could not safely offline and verify source Disk ${diskNumber}: $($_.Exception.Message)"
+            }
+        }
+
+        if (-not $identityRestorationFailed) {
+            try {
+                Restore-GaRepairDiskIdentity -Record $repairDiskIdentityRecord
+                Log-Info 'Repair VM OS disk GPT identity restored and verified.'
+            }
+            catch {
+                $identityRestorationFailed = $true
+                Log-Error "CRITICAL: Failed to restore the repair VM OS disk identity: $($_.Exception.Message)"
+            }
+        }
+    }
+
+    foreach ($identityRecord in @($collisionDiskRecords | Sort-Object DiskNumber -Descending)) {
         try {
-            $diskNumber = [int]$identityRecord.DiskNumber
-            Log-Info "Restoring original $($identityRecord.PartitionStyle) identity on Disk $diskNumber."
-            Set-Disk -Number $diskNumber -IsOffline $true -ErrorAction Stop
-            if ($identityRecord.PartitionStyle -eq 'GPT') {
-                Set-Disk -Number $diskNumber -Guid $identityRecord.OriginalGuid -ErrorAction Stop
-            }
-            else {
-                Set-Disk -Number $diskNumber -Signature ([uint32]$identityRecord.OriginalSignature) -ErrorAction Stop
-            }
-            Update-HostStorageCache -ErrorAction SilentlyContinue
-            $restoredDisk = Get-Disk -Number $diskNumber -ErrorAction Stop
-            $identityRestored = if ($identityRecord.PartitionStyle -eq 'GPT') {
-                [string]$restoredDisk.Guid -ieq [string]$identityRecord.OriginalGuid
-            }
-            else {
-                [uint32]$restoredDisk.Signature -eq [uint32]$identityRecord.OriginalSignature
-            }
-            if (-not $identityRestored) {
-                throw "Original disk identity verification failed."
-            }
-            Log-Info "Original $($identityRecord.PartitionStyle) identity restored and verified on Disk $diskNumber; disk left offline for repair restore."
+            Restore-GaOriginalSourceIdentity -Record $identityRecord
+            Log-Info "Disk $($identityRecord.DiskNumber) is offline with its verified original MBR identity restored."
         }
         catch {
+            $identityRestorationFailed = $true
             Log-Error "CRITICAL: Failed to restore original identity on Disk $($identityRecord.DiskNumber): $($_.Exception.Message)"
-            $script_final_status = $STATUS_ERROR
         }
+    }
+
+    if ($identityRestorationFailed) {
+        $script_final_status = $STATUS_ERROR
     }
 
     # Log local execution context only; this script performs no telemetry upload.

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -98,6 +98,9 @@ if (-not (Test-Path -Path $diskPartitionsPath -PathType Leaf)) {
 
 # Log Configuration
 $logDir = [Environment]::GetFolderPath('Desktop')
+if ([string]::IsNullOrWhiteSpace($logDir)) {
+    $logDir = Join-Path $env:PUBLIC 'Desktop'
+}
 if (-not (Test-Path $logDir)) { $null = New-Item -ItemType Directory -Path $logDir -Force }
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 $logFile = "$logDir\GA_offlinefixer_$timestamp.log"

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -20,18 +20,18 @@
 
 .NOTES
     Name:    GA_offlinefixer.ps1
-    Version: 1.4
+    Version: 1.3
     Original Author: Daniel Munoz L (damunozl@microsoft.com)
     Modified by: Tony.Mocanu@Microsoft.com
 
 .VERSION
-    v1.4: [August 2026] - Addressed production review findings and aligned disk safety,
+    v1.3: [August 2026] - Addressed production review findings and aligned disk safety,
                         backup verification, rollback accounting, and rescue service restoration
                         with win-LKGC and win-sac-onLatest.
                         - Uses a PowerShell 3-compatible streaming SHA-256 implementation.
                         - Emits structured telemetry only through the local VMRepair logger.
                         - Performs no IMDS lookup or other telemetry network request.
-    v1.3: [August 2026] - Copies only the newest versioned GuestAgent installation folder.
+                        - Copies only the newest versioned GuestAgent installation folder.
                         - Uses the WindowsAzureGuestAgent ImagePath folder as a fallback.
                         - Preserves unrelated content in the target WindowsAzure folder.
                         - Stages and validates replacement files before moving the existing Agent folder.
@@ -186,7 +186,7 @@ if ($script:_origLogOutput) {
     }
 }
 
-$script:RepairScriptVersion = '1.4'
+$script:RepairScriptVersion = '1.3'
 $script:ExecutionStarted = Get-Date
 $script:OperationCount = 0
 

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -11,8 +11,9 @@
     4. Identifies the primary and backup ControlSets (001/002) from the Select key.
     5. Exports healthy service keys (WindowsAzureGuestAgent, WindowsAzureTelemetryService, RdAgent)
        from the rescue VM and injects them into both ControlSets on the target hive.
-    6. Verifies the ImagePath value was written correctly.
-    7. Copies the latest GuestAgent installation folder from the rescue VM to the attached disk.
+     6. Verifies both required services use automatic startup and have non-empty ImagePath values.
+     7. Copies the latest GuestAgent installation folder, or the documented ImagePath folder fallback,
+         and verifies the exact executables referenced by both required services.
     8. Releases handles and safely unloads the registry hive (with retry logic).
 
 .NOTES
@@ -73,16 +74,17 @@ Get-ChildItem F:\WindowsAzure\GuestAgent_* | Rename-Item -NewName { $_.Name + '_
 .VERIFICATION
     1. Check the log file for success:
 Get-ChildItem "$env:USERPROFILE\Desktop\GA_offlinefixer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1 | Get-Content
-    Expected: "VMAgent Fix completed and verified successfully." and return code 0 ($STATUS_SUCCESS).
+    Expected: "VMAgent offline repair completed" and return code 0 ($STATUS_SUCCESS).
+    This verifies only the offline registry and file repair. Agent readiness must be verified after restore and boot.
     2. Reload the SYSTEM hive and verify agent service keys exist (replace F with disk letter):
 reg load HKLM\VERIFY F:\Windows\System32\config\SYSTEM
 Get-ItemProperty -Path "HKLM:\VERIFY\ControlSet001\Services\WindowsAzureGuestAgent" -Name ImagePath
 Get-ItemProperty -Path "HKLM:\VERIFY\ControlSet001\Services\RdAgent" -Name ImagePath
 reg unload HKLM\VERIFY
-    Expected: ImagePath values are populated for both services.
+    Expected: ImagePath values are populated and Start is 2 for both services.
     3. Verify GuestAgent binaries were copied to the target disk:
 Get-ChildItem F:\WindowsAzure\GuestAgent_*
-    Expected: One or more GuestAgent folders present.
+    Expected: The exact executables referenced by both service ImagePath values are present and non-empty.
 #>
 
 # Initialization (path-validated)
@@ -196,6 +198,30 @@ function Invoke-CriticalCommand {
         ExitCode = $exitCode
         Output = @($output)
     }
+}
+
+function Get-GaServiceExecutablePath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ImagePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TargetDriveLetter
+    )
+
+    $expandedImagePath = [Environment]::ExpandEnvironmentVariables($ImagePath).Trim()
+    $executablePath = if ($expandedImagePath.StartsWith('"')) {
+        ($expandedImagePath -split '"')[1]
+    }
+    else {
+        ($expandedImagePath -split '\s+')[0]
+    }
+
+    if ([string]::IsNullOrWhiteSpace($executablePath) -or $executablePath -notmatch '^[A-Za-z]:\\') {
+        throw "Service ImagePath '$ImagePath' does not contain an absolute executable path."
+    }
+
+    return ($executablePath -replace '^[A-Za-z]:', "${TargetDriveLetter}:")
 }
 
 function Get-AvailableTempDriveLetter {
@@ -781,15 +807,23 @@ try {
                 }
             }
 
-            # Step 6 - Verify the ImagePath value was written correctly
-            $wagaPath = "HKLM\$hiveName\$primarySet\Services\WindowsAzureGuestAgent"
-            $afterImagePath = (Get-ItemProperty -Path "Registry::$wagaPath" -ErrorAction SilentlyContinue).ImagePath
-            if ([string]::IsNullOrWhiteSpace($afterImagePath)) {
-                Log-Warning "Verification Warning on $($diskb): VMAgent ImagePath is empty after injection."
+            # Step 6 - Validate the required service configuration written to the target hive.
+            $requiredAgentServices = @('WindowsAzureGuestAgent', 'RdAgent')
+            $targetServiceConfigurations = @{}
+            foreach ($requiredService in $requiredAgentServices) {
+                $servicePath = "Registry::HKLM\$hiveName\$primarySet\Services\$requiredService"
+                $serviceConfiguration = Get-ItemProperty -Path $servicePath -ErrorAction Stop
+                if ([string]::IsNullOrWhiteSpace([string]$serviceConfiguration.ImagePath)) {
+                    throw "Required service '$requiredService' has an empty ImagePath in $primarySet."
+                }
+                if ([int]$serviceConfiguration.Start -ne 2) {
+                    throw "Required service '$requiredService' is not configured for automatic startup in ${primarySet} (Start=$($serviceConfiguration.Start))."
+                }
+
+                $targetServiceConfigurations[$requiredService] = $serviceConfiguration
+                Log-Info "Validated $requiredService configuration in ${primarySet}: Start=2, ImagePath=$($serviceConfiguration.ImagePath)"
             }
-            else {
-                Log-Info "Verification Success on $($diskb):: ImagePath is now $afterImagePath"
-            }
+            $afterImagePath = [string]$targetServiceConfigurations['WindowsAzureGuestAgent'].ImagePath
 
             # Step 7 - Copy only the current VM Agent installation folder.
             $sourcePath = "C:\WindowsAzure"
@@ -815,7 +849,7 @@ try {
                 Log-Info "Selected latest VM Agent installation folder $($sourceAgentFolder.Name)."
             }
             else {
-                $expandedImagePath = [Environment]::ExpandEnvironmentVariables([string]$afterImagePath).Trim()
+                $expandedImagePath = [Environment]::ExpandEnvironmentVariables($afterImagePath).Trim()
                 $imageExecutable = if ($expandedImagePath.StartsWith('"')) {
                     ($expandedImagePath -split '"')[1]
                 }
@@ -852,14 +886,18 @@ try {
             if ($restoreCopyResult.ExitCode -ge 8) {
                 throw "Failed to copy VM Agent folder to $($diskb): $($restoreCopyResult.Output -join '; ')"
             }
-            $sourceAgentFile = Get-ChildItem -LiteralPath $sourceAgentFolder.FullName -File -Recurse -Force -ErrorAction Stop |
-                Select-Object -First 1
-            if (-not $sourceAgentFile) {
-                throw "Source VM Agent folder '$($sourceAgentFolder.FullName)' contains no files."
-            }
-            $relativeAgentFile = $sourceAgentFile.FullName.Substring($sourceAgentFolder.FullName.Length).TrimStart('\')
-            if (-not (Test-Path -LiteralPath (Join-Path $targetAgentFolder $relativeAgentFile) -PathType Leaf)) {
-                throw "VM Agent folder copy verification failed for '$relativeAgentFile'."
+            foreach ($requiredService in $requiredAgentServices) {
+                $targetExecutable = Get-GaServiceExecutablePath `
+                    -ImagePath ([string]$targetServiceConfigurations[$requiredService].ImagePath) `
+                    -TargetDriveLetter $diskb
+                if (-not (Test-Path -LiteralPath $targetExecutable -PathType Leaf)) {
+                    throw "Required executable for service '$requiredService' was not found after copy: $targetExecutable"
+                }
+                $targetExecutableInfo = Get-Item -LiteralPath $targetExecutable -ErrorAction Stop
+                if ($targetExecutableInfo.Length -le 0) {
+                    throw "Required executable for service '$requiredService' is empty: $targetExecutable"
+                }
+                Log-Info "Validated $requiredService executable at $targetExecutable ($($targetExecutableInfo.Length) bytes)."
             }
 
             $diskChangesCompleted = $true
@@ -933,7 +971,7 @@ try {
 
     Log-Info "Processing summary: processed=$processedCount skipped=$skippedCount failed=$failedCount changed=$changedCount"
     if ($fixedDisks.Count -gt 0) {
-        $successMessage = "VMAgent Fix completed and verified successfully on drives: $($fixedDisks -join ', ') | Host=$($vmMetadata.HostName)"
+        $successMessage = "VMAgent offline repair completed on drives: $($fixedDisks -join ', '). Agent readiness must be verified after restore and boot. | Host=$($vmMetadata.HostName)"
         $script_final_status = $STATUS_SUCCESS
     }
     else {

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -8,7 +8,7 @@
     1. Uses the shared repair-library partition helper to locate the faulty OS drive.
     2. Loads the SYSTEM registry hive from the target disk into HKLM\BROKENSYSTEM.
     3. Creates and verifies a binary backup of the SYSTEM hive before loading it.
-    4. Identifies the primary and backup ControlSets (001/002) from the Select key.
+    4. Identifies and validates the existing boot-referenced ControlSets from the Select key.
     5. Exports healthy service keys (WindowsAzureGuestAgent, WindowsAzureTelemetryService, RdAgent)
        from the rescue VM and injects them into both ControlSets on the target hive.
      6. Verifies both required services use automatic startup and have non-empty ImagePath values.
@@ -20,11 +20,17 @@
 
 .NOTES
     Name:    GA_offlinefixer.ps1
-    Version: 1.3
+    Version: 1.4
     Original Author: Daniel Munoz L (damunozl@microsoft.com)
     Modified by: Tony.Mocanu@Microsoft.com
 
 .VERSION
+    v1.4: [August 2026] - Addressed production review findings and aligned disk safety,
+                        backup verification, rollback accounting, and rescue service restoration
+                        with win-LKGC and win-sac-onLatest.
+                        - Uses a PowerShell 3-compatible streaming SHA-256 implementation.
+                        - Emits structured telemetry only through the local VMRepair logger.
+                        - Performs no IMDS lookup or other telemetry network request.
     v1.3: [August 2026] - Copies only the newest versioned GuestAgent installation folder.
                         - Uses the WindowsAzureGuestAgent ImagePath folder as a fallback.
                         - Preserves unrelated content in the target WindowsAzure folder.
@@ -45,7 +51,7 @@
                         - No longer stops Windows Defender on the rescue VM.
                         - Makes fallback hive copy-back part of per-disk success accounting.
                         - Removes the unnecessary Azure Instance Metadata Service request.
-                        - Validates WindowsAzure xcopy source and destination content.
+                        - Validates the WindowsAzure robocopy source and staged destination content.
                         - Updated the script (current)
                         - Aligned nested VM detection with win-LKGC guard pattern.
                         - Skips Get-VM safely when Hyper-V module is unavailable.
@@ -79,8 +85,9 @@ Get-ChildItem "$env:USERPROFILE\Desktop\GA_offlinefixer_*.log" | Sort-Object Las
     This verifies only the offline registry and file repair. Agent readiness must be verified after restore and boot.
     2. Reload the SYSTEM hive and verify agent service keys exist (replace F with disk letter):
 reg load HKLM\VERIFY F:\Windows\System32\config\SYSTEM
-Get-ItemProperty -Path "HKLM:\VERIFY\ControlSet001\Services\WindowsAzureGuestAgent" -Name ImagePath
-Get-ItemProperty -Path "HKLM:\VERIFY\ControlSet001\Services\RdAgent" -Name ImagePath
+$defaultSet = 'ControlSet{0:D3}' -f (Get-ItemProperty -Path 'HKLM:\VERIFY\Select').Default
+Get-ItemProperty -Path "HKLM:\VERIFY\$defaultSet\Services\WindowsAzureGuestAgent" -Name Start, ImagePath
+Get-ItemProperty -Path "HKLM:\VERIFY\$defaultSet\Services\RdAgent" -Name Start, ImagePath
 reg unload HKLM\VERIFY
     Expected: ImagePath values are populated and Start is 2 for both services.
     3. Verify GuestAgent binaries were copied to the target disk:
@@ -151,31 +158,63 @@ $script:_origLogError   = (Get-Command Log-Error   -ErrorAction SilentlyContinue
 $script:_origLogOutput  = (Get-Command Log-Output  -ErrorAction SilentlyContinue).ScriptBlock
 
 if ($script:_origLogInfo) {
-    function Log-Info {
+    function Write-GaInfo {
         param([string]$Message)
         & $script:_origLogInfo $Message
         Write-DesktopLogLine "[INFO] $Message"
     }
 }
 if ($script:_origLogWarning) {
-    function Log-Warning {
+    function Write-GaWarning {
         param([string]$Message)
         & $script:_origLogWarning $Message
         Write-DesktopLogLine "[WARN] $Message"
     }
 }
 if ($script:_origLogError) {
-    function Log-Error {
+    function Write-GaError {
         param([string]$Message)
         & $script:_origLogError $Message
         Write-DesktopLogLine "[ERROR] $Message"
     }
 }
 if ($script:_origLogOutput) {
-    function Log-Output {
+    function Write-GaOutput {
         param([string]$Message)
         & $script:_origLogOutput $Message
         Write-DesktopLogLine "[OUTPUT] $Message"
+    }
+}
+
+$script:RepairScriptVersion = '1.4'
+$script:ExecutionStarted = Get-Date
+$script:OperationCount = 0
+
+function Write-GaTelemetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Start', 'Operation', 'Success', 'Error')]
+        [string]$Event,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message,
+
+        [hashtable]$Properties = @{}
+    )
+
+    $payload = [ordered]@{
+        Event = $Event
+        Message = $Message
+        TimestampUtc = (Get-Date).ToUniversalTime().ToString('o')
+        RepairScriptVersion = $script:RepairScriptVersion
+        Properties = $Properties
+    }
+    $json = $payload | ConvertTo-Json -Compress -Depth 8
+    if ($Event -eq 'Error') {
+        Write-GaError "[Telemetry] $json" | Out-Null
+    }
+    else {
+        Write-GaInfo "[Telemetry] $json" | Out-Null
     }
 }
 
@@ -186,18 +225,45 @@ function Invoke-CriticalCommand {
         [Parameter(Mandatory=$true)][string]$Description
     )
 
+    $script:OperationCount++
     $output = & $Command @Arguments 2>&1
     $exitCode = $LASTEXITCODE
 
     if ($output) {
         foreach ($line in @($output)) {
-            Log-Info "$Description :: $line"
+            Write-GaInfo "$Description :: $line"
         }
+    }
+
+    Write-GaTelemetry -Event Operation -Message $Description -Properties @{
+        Command = $Command
+        ExitCode = "$exitCode"
+        Success = ($exitCode -eq 0)
     }
 
     return [PSCustomObject]@{
         ExitCode = $exitCode
         Output = @($output)
+    }
+}
+
+function Get-GaFileSha256 {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$LiteralPath
+    )
+
+    $stream = $null
+    $sha256 = $null
+    try {
+        $stream = [System.IO.File]::Open($LiteralPath, [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read)
+        $sha256 = [System.Security.Cryptography.SHA256]::Create()
+        return ([System.BitConverter]::ToString($sha256.ComputeHash($stream))).Replace('-', '')
+    }
+    finally {
+        if ($sha256) { $sha256.Dispose() }
+        if ($stream) { $stream.Dispose() }
     }
 }
 
@@ -250,7 +316,7 @@ function Invoke-GaDiskPart {
 
     $output = $Commands | diskpart.exe 2>&1
     foreach ($line in @($output)) {
-        if ($line) { Log-Info "diskpart $Operation :: $line" }
+        if ($line) { Write-GaInfo "diskpart $Operation :: $line" }
     }
 }
 
@@ -384,7 +450,7 @@ try {
         }
     }
     catch {
-        Log-Warning "OS metadata discovery failed: $($_.Exception.Message)"
+        Write-GaWarning "OS metadata discovery failed: $($_.Exception.Message)"
     }
 
     # Create metadata context string for logging
@@ -392,8 +458,18 @@ try {
     if ($vmMetadata.OSVersion) { $metadataContext += " OS:$($vmMetadata.OSVersion)" }
     $metadataContext += "]"
 
-    Log-Info "Starting VMAgent Offline Fixer... $metadataContext"
-    Log-Info "Desktop log file path: $logFile"
+    Write-GaInfo "Starting VMAgent Offline Fixer... $metadataContext"
+    Write-GaInfo "Desktop log file path: $logFile"
+    Write-GaInfo "[script_start] Script=GA_offlinefixer Version=$($script:RepairScriptVersion)"
+    Write-GaTelemetry -Event Start -Message 'Starting VMAgent offline repair' -Properties @{
+        ScriptName = 'GA_offlinefixer.ps1'
+        ScriptVersion = $script:RepairScriptVersion
+        ExecutionMode = 'REPAIR_VM_ONLY'
+        HostName = $vmMetadata.HostName
+        OSVersion = $vmMetadata.OSVersion
+        DesktopLog = $logFile
+        NetworkTelemetry = $false
+    }
     # Stop nested guest VM if running
     # Guard Get-VM if Hyper-V module is not available
     try {
@@ -401,25 +477,25 @@ try {
             $guestHyperVVirtualMachine = Get-VM -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
             if ($guestHyperVVirtualMachine) {
                 if ($guestHyperVVirtualMachine.State -eq 'Running') {
-                    Log-Info "Stopping nested guest VM $($guestHyperVVirtualMachine.VMName)"
+                    Write-GaInfo "Stopping nested guest VM $($guestHyperVVirtualMachine.VMName)"
                     try {
                         Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
                     }
                     catch {
-                        Log-Warning "Failed to stop nested guest VM, will continue but may have limited success"
+                        Write-GaWarning "Failed to stop nested guest VM, will continue but may have limited success"
                     }
                 }
             }
         } else {
-            Log-Info "Hyper-V PowerShell module is not available on this host. Skipping nested VM validation."
+            Write-GaInfo "Hyper-V PowerShell module is not available on this host. Skipping nested VM validation."
         }
     }
     catch {
-        Log-Warning "Nested VM check encountered an error but will be skipped: $($_.Exception.Message)"
+        Write-GaWarning "Nested VM check encountered an error but will be skipped: $($_.Exception.Message)"
     }
 
     # Clean up stale hive mounts from previous failed runs
-    Log-Info "Cleaning up any stale registry hive mounts..."
+    Write-GaInfo "Cleaning up any stale registry hive mounts..."
     $staleHivePaths = @(
         & reg.exe query HKLM 2>$null
         & reg.exe query HKU 2>$null
@@ -428,15 +504,15 @@ try {
         $_ -match '^HKEY_USERS\\(?:BROKENSYSTEM|BROKENSYS|BROKENSW)(?:_[C-Z])?$'
     }
     foreach ($staleHivePath in $staleHivePaths) {
-        Log-Info "Unloading stale repair hive $staleHivePath..."
+        Write-GaInfo "Unloading stale repair hive $staleHivePath..."
         & reg.exe unload $staleHivePath 2>$null
     }
 
     # Log any externally loaded hives (diagnostic)
     $hklmKeys = & reg.exe query HKLM 2>$null | Where-Object { $_ -match 'BROKEN|OFFLINE|SYSTEM_' }
     $hkuKeys = & reg.exe query HKU 2>$null | Where-Object { $_ -match 'BROKEN|OFFLINE|SYSTEM_' }
-    if ($hklmKeys) { Log-Info "Loaded HKLM hives: $($hklmKeys -join ', ')" }
-    if ($hkuKeys) { Log-Info "Loaded HKU hives: $($hkuKeys -join ', ')" }
+    if ($hklmKeys) { Write-GaInfo "Loaded HKLM hives: $($hklmKeys -join ', ')" }
+    if ($hkuKeys) { Write-GaInfo "Loaded HKU hives: $($hkuKeys -join ', ')" }
 
     # Identify the rescue OS disk before stopping services or touching any disk.
     $rescueDrive = $env:SystemDrive -replace ':', ''
@@ -446,7 +522,7 @@ try {
     }
     $rescueDiskNum = [int]$rescueOsPartition.DiskNumber
     $repairDiskIdentity = Get-GaDiskIdentity -DiskNumber $rescueDiskNum
-    Log-Info "Rescue VM OS disk identified as physical Disk $rescueDiskNum ($($repairDiskIdentity.PartitionStyle))."
+    Write-GaInfo "Rescue VM OS disk identified as physical Disk $rescueDiskNum ($($repairDiskIdentity.PartitionStyle))."
 
     # Azure rescue VMs can place the pagefile on a separate temporary resource disk.
     # Windows treats that disk as critical even though it is not the rescue OS disk.
@@ -466,7 +542,7 @@ try {
         }
     }
     $protectedDiskNumbers = @($protectedDiskNumbers | Sort-Object -Unique)
-    Log-Info "Protected rescue disk numbers excluded from repair: $($protectedDiskNumbers -join ', ')."
+    Write-GaInfo "Protected rescue disk numbers excluded from repair: $($protectedDiskNumbers -join ', ')."
 
     $azureVirtualDiskNumbers = @(Get-CimInstance -ClassName Win32_DiskDrive -ErrorAction Stop |
         Where-Object { $_.Model -like 'Microsoft Virtual Disk*' } |
@@ -499,7 +575,7 @@ try {
                     TemporaryDiskPartValue = $temporaryRepairGuid
                 }
 
-                Log-Warning 'Temporarily changing only the repair VM OS disk GPT identity. The attached source disk GUID will remain unchanged.'
+                Write-GaWarning 'Temporarily changing only the repair VM OS disk GPT identity. The attached source disk GUID will remain unchanged.'
                 Set-GaTemporaryRepairDiskIdentity -Record $repairDiskIdentityRecord
             }
 
@@ -517,7 +593,7 @@ try {
                 throw "Disk $($collisionDisk.Number) could not be onlined with its original GPT identity unchanged."
             }
 
-            Log-Info "Disk $($collisionDisk.Number) collision released; source GPT identity remains $($originalIdentity.Value)."
+            Write-GaInfo "Disk $($collisionDisk.Number) collision released; source GPT identity remains $($originalIdentity.Value)."
             continue
         }
 
@@ -535,14 +611,14 @@ try {
         }
         $collisionDiskRecords += $record
 
-        Log-Warning "Disk $($record.DiskNumber) is offline due to an identity collision. Applying a temporary MBR identity for this repair run."
+        Write-GaWarning "Disk $($record.DiskNumber) is offline due to an identity collision. Applying a temporary MBR identity for this repair run."
         Set-GaTemporarySourceIdentity -Record $record
-        Log-Info "Disk $($record.DiskNumber) is online with a verified temporary MBR identity."
+        Write-GaInfo "Disk $($record.DiskNumber) is online with a verified temporary MBR identity."
     }
 
     $attachedDisks = @($attachedDisks | ForEach-Object { Get-Disk -Number $_.Number -ErrorAction Stop })
     $attachedDiskNumbers = @($attachedDisks | Select-Object -ExpandProperty Number)
-    Log-Info "Attached repair candidate disk numbers: $($attachedDiskNumbers -join ', ')"
+    Write-GaInfo "Attached repair candidate disk numbers: $($attachedDiskNumbers -join ', ')"
 
     $partitionlist = @(Get-Disk-Partitions)
     if ($partitionlist.Count -eq 0) {
@@ -550,7 +626,7 @@ try {
     }
 
     $discoveredDiskNumbers = @($partitionlist | Select-Object -ExpandProperty DiskNumber -Unique)
-    Log-Info "Get-Disk-Partitions discovered disk numbers: $($discoveredDiskNumbers -join ', ')"
+    Write-GaInfo "Get-Disk-Partitions discovered disk numbers: $($discoveredDiskNumbers -join ', ')"
     $targetDiskGroups = @($partitionlist |
         Where-Object {
             [int]$_.DiskNumber -in $attachedDiskNumbers -and
@@ -562,17 +638,17 @@ try {
     }
 
     # Pause indexing while attached hives are modified. Defender remains running.
-    Log-Info "Stopping Windows Search temporarily to reduce attached-disk file locks..."
+    Write-GaInfo "Stopping Windows Search temporarily to reduce attached-disk file locks..."
     foreach ($svc in @('WSearch')) {
         try {
             $svcObj = Get-Service -Name $svc -ErrorAction Stop
             if ($svcObj) {
                 $serviceStates[$svc] = [string]$svcObj.Status
-                Log-Info "Captured original state of $svc : $($svcObj.Status)"
+                Write-GaInfo "Captured original state of $svc : $($svcObj.Status)"
                 if ($svcObj.Status -ne 'Stopped') {
                     Stop-Service -Name $svc -ErrorAction Stop
                     $svcObj.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(30))
-                    Log-Info "$svc stopped temporarily."
+                    Write-GaInfo "$svc stopped temporarily."
                 }
             }
         }
@@ -588,7 +664,7 @@ try {
         $diskNumber = [int]$diskGroup.Name
         $diskPartitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction Stop)
         if ($diskPartitions.Count -eq 0) {
-            Log-Warning "Attached repair Disk $diskNumber has no partitions."
+            Write-GaWarning "Attached repair Disk $diskNumber has no partitions."
             $skippedCount++
             continue
         }
@@ -672,11 +748,11 @@ try {
 
         if ($targetVolume) {
             $targetWindowsVolumes += $targetVolume
-            Log-Info "Validated Windows target on Disk $diskNumber Partition $($targetVolume.PartitionNumber) at $($targetVolume.DriveLetter):."
+            Write-GaInfo "Validated Windows target on Disk $diskNumber Partition $($targetVolume.PartitionNumber) at $($targetVolume.DriveLetter):."
         }
         else {
             $skippedCount++
-            Log-Warning "Disk $diskNumber has no partition containing both a Windows loader and SYSTEM hive."
+            Write-GaWarning "Disk $diskNumber has no partition containing both a Windows loader and SYSTEM hive."
         }
     }
 
@@ -690,7 +766,12 @@ try {
     foreach ($targetVolume in $targetWindowsVolumes) {
         $processedCount++
         $diskb = [string]$targetVolume.DriveLetter
-        Log-Info "Processing validated target Disk $($targetVolume.DiskNumber) on letter $($diskb):"
+        Write-GaInfo "Processing validated target Disk $($targetVolume.DiskNumber) on letter $($diskb):"
+        Write-GaTelemetry -Event Operation -Message 'Starting Guest Agent repair on validated disk' -Properties @{
+            DiskNumber = "$($targetVolume.DiskNumber)"
+            PartitionNumber = "$($targetVolume.PartitionNumber)"
+            DriveLetter = $diskb
+        }
         # Step 2 - Load the SYSTEM registry hive from the target disk
         $hiveName = "BROKENSYSTEM_$diskb"
         $hiveSource = "$($diskb):\Windows\System32\config\SYSTEM"
@@ -699,33 +780,37 @@ try {
         $restoreHiveBackup = $false
         $diskProcessedSuccessfully = $false
         $diskChangesCompleted = $false
+        $targetAgentFolder = $null
+        $targetAgentBackup = $null
+        $existingAgentMoved = $false
+        $agentFolderActivated = $false
         & reg.exe unload "HKLM\$hiveName" 2>$null
         [System.GC]::Collect()
         Start-Sleep -Seconds 1
 
         try {
             $backupFile = "$($diskb):\SYSTEM_before_GA_changes_$diskb.hiv"
-            Log-Info "Creating binary SYSTEM hive backup at $backupFile..."
+            Write-GaInfo "Creating binary SYSTEM hive backup at $backupFile..."
             Copy-Item -LiteralPath $hiveSource -Destination $backupFile -Force -ErrorAction Stop
-            $sourceHiveHash = (Get-FileHash -LiteralPath $hiveSource -Algorithm SHA256 -ErrorAction Stop).Hash
-            $backupHiveHash = (Get-FileHash -LiteralPath $backupFile -Algorithm SHA256 -ErrorAction Stop).Hash
+            $sourceHiveHash = Get-GaFileSha256 -LiteralPath $hiveSource
+            $backupHiveHash = Get-GaFileSha256 -LiteralPath $backupFile
             if ($sourceHiveHash -ne $backupHiveHash) {
                 throw "Source and backup SHA256 hashes differ."
             }
-            Log-Info "Binary SYSTEM hive backup created and verified for $($diskb):."
+            Write-GaInfo "Binary SYSTEM hive backup created and verified for $($diskb):."
         }
         catch {
-            Log-Error "Failed to create and verify SYSTEM hive backup for $($diskb):: $($_.Exception.Message)"
+            Write-GaError "Failed to create and verify SYSTEM hive backup for $($diskb):: $($_.Exception.Message)"
             $failedDisks += $diskb
             $failedCount++
             continue
         }
 
-        Log-Info "Loading SYSTEM hive from $($diskb): as $hiveName..."
+        Write-GaInfo "Loading SYSTEM hive from $($diskb): as $hiveName..."
         $loadResult = & reg.exe load "HKLM\$hiveName" $hiveSource 2>&1
         if ($LASTEXITCODE -ne 0) {
             # Retry once after a short wait
-            Log-Warning "First reg load attempt failed for $($diskb):, retrying in 5 seconds..."
+            Write-GaWarning "First reg load attempt failed for $($diskb):, retrying in 5 seconds..."
             Start-Sleep -Seconds 5
             [System.GC]::Collect()
             [System.GC]::WaitForPendingFinalizers()
@@ -733,24 +818,24 @@ try {
         }
         if ($LASTEXITCODE -ne 0) {
             # Fallback: use esentutl.exe /y to copy locked hive via Windows Backup API semantics
-            Log-Warning "Direct load failed. Trying esentutl copy fallback for $($diskb):..."
+            Write-GaWarning "Direct load failed. Trying esentutl copy fallback for $($diskb):..."
             $hiveCopy = "$env:TEMP\SYSTEM_COPY_$diskb"
             try {
                 $esentResult = & esentutl.exe /y $hiveSource /d $hiveCopy /o 2>&1
                 if ($LASTEXITCODE -eq 0 -and (Test-Path $hiveCopy)) {
-                    Log-Info "Hive copied successfully to $hiveCopy via esentutl"
+                    Write-GaInfo "Hive copied successfully to $hiveCopy via esentutl"
                     $loadResult = & reg.exe load "HKLM\$hiveName" $hiveCopy 2>&1
                 }
                 else {
-                    Log-Warning "esentutl copy failed for $($diskb): $esentResult"
+                    Write-GaWarning "esentutl copy failed for $($diskb): $esentResult"
                 }
             }
             catch {
-                Log-Warning "esentutl fallback failed for $($diskb):: $($_.Exception.Message)"
+                Write-GaWarning "esentutl fallback failed for $($diskb):: $($_.Exception.Message)"
             }
         }
         if ($LASTEXITCODE -ne 0) {
-            Log-Error "Failed to load Registry Hive from $($diskb): $loadResult"
+            Write-GaError "Failed to load Registry Hive from $($diskb): $loadResult"
             if ($hiveCopy -and (Test-Path $hiveCopy)) { Remove-Item $hiveCopy -Force -ErrorAction SilentlyContinue }
             $failedDisks += $diskb
             $failedCount++
@@ -759,14 +844,35 @@ try {
         Start-Sleep -Seconds 2
 
         try {
-            # Step 4 - Identify the primary and backup ControlSets from the Select key
+            # Step 4 - Identify existing boot-referenced ControlSets from the Select key.
             $selectPath = "Registry::HKLM\$hiveName\Select"
-            $defaultSetID = (Get-ItemProperty -path $selectPath).default
-            $primarySet = "ControlSet00$defaultSetID"
-            $otherSet = if ($primarySet -eq "ControlSet001") { "ControlSet002" } else { "ControlSet001" }
+            $selectConfiguration = Get-ItemProperty -Path $selectPath -ErrorAction Stop
+            $defaultSetID = [int]$selectConfiguration.Default
+            if ($defaultSetID -lt 1) {
+                throw "SYSTEM hive Select contains an invalid Default control-set reference: $defaultSetID."
+            }
 
-            Log-Info "Primary ControlSet identified: $primarySet"
-            # Step 5 - Export healthy service keys and inject into both ControlSets
+            $primarySet = 'ControlSet{0:D3}' -f $defaultSetID
+            $targetControlSets = @(@(
+                [int]$selectConfiguration.Current
+                [int]$selectConfiguration.Default
+                [int]$selectConfiguration.LastKnownGood
+            ) | Where-Object { $_ -gt 0 } | Sort-Object -Unique | ForEach-Object {
+                'ControlSet{0:D3}' -f $_
+            })
+            foreach ($targetControlSet in $targetControlSets) {
+                if (-not (Test-Path -Path "Registry::HKLM\$hiveName\$targetControlSet\Services")) {
+                    throw "SYSTEM hive Select references missing or incomplete $targetControlSet."
+                }
+            }
+
+            if ($primarySet -notin $targetControlSets) {
+                throw "Default control set $primarySet was not included in the validated repair targets."
+            }
+            Write-GaInfo "Validated boot-referenced ControlSets: $($targetControlSets -join ', ') (Default=$primarySet)"
+
+            # Step 5 - Export healthy service keys and inject into every boot-referenced ControlSet.
+            $requiredAgentServices = @('WindowsAzureGuestAgent', 'RdAgent')
             $services = @("WindowsAzureGuestAgent", "WindowsAzureTelemetryService", "RdAgent")
 
             foreach ($service in $services) {
@@ -774,7 +880,10 @@ try {
                 # Check if service key exists on the rescue VM before attempting export
                 $rescueServiceKey = "HKLM:\SYSTEM\CurrentControlSet\Services\$service"
                 if (-not (Test-Path -Path $rescueServiceKey)) {
-                    Log-Warning "Service '$service' not found on rescue VM registry - skipping (not present on this OS version)"
+                    if ($service -in $requiredAgentServices) {
+                        throw "Required service '$service' was not found in the rescue VM registry."
+                    }
+                    Write-GaWarning "Optional service '$service' was not found in the rescue VM registry; skipping it."
                     continue
                 }
                 # Export healthy key from the current Rescue VM
@@ -782,24 +891,13 @@ try {
 
                 if ($serviceExportResult.ExitCode -eq 0 -and (Test-Path $regFile)) {
                     $originalContent = Get-Content $regFile
-
-                    # Update Primary Set
-                    Log-Info "Updating $service in $primarySet on $($diskb):..."
-                    $content = $originalContent -replace 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet', "HKEY_LOCAL_MACHINE\$hiveName\$primarySet"
-                    $content | Set-Content $regFile
-                    $primaryImportResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("import", $regFile) -Description "reg import $service into $primarySet ($diskb)"
-                    if ($primaryImportResult.ExitCode -ne 0) {
-                        throw "Failed to import $service into $primarySet for $($diskb): $($primaryImportResult.Output -join '; ')"
-                    }
-
-                    # Update Secondary Set (if it exists on disk)
-                    if (Test-Path "Registry::HKLM\$hiveName\$otherSet") {
-                        Log-Info "Updating $service in backup $otherSet on $($diskb):..."
-                        $content = $originalContent -replace 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet', "HKEY_LOCAL_MACHINE\$hiveName\$otherSet"
+                    foreach ($targetControlSet in $targetControlSets) {
+                        Write-GaInfo "Updating $service in $targetControlSet on $($diskb):..."
+                        $content = $originalContent -replace 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet', "HKEY_LOCAL_MACHINE\$hiveName\$targetControlSet"
                         $content | Set-Content $regFile
-                        $secondaryImportResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("import", $regFile) -Description "reg import $service into $otherSet ($diskb)"
-                        if ($secondaryImportResult.ExitCode -ne 0) {
-                            throw "Failed to import $service into $otherSet for $($diskb): $($secondaryImportResult.Output -join '; ')"
+                        $importResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("import", $regFile) -Description "reg import $service into $targetControlSet ($diskb)"
+                        if ($importResult.ExitCode -ne 0) {
+                            throw "Failed to import $service into $targetControlSet for $($diskb): $($importResult.Output -join '; ')"
                         }
                     }
                     Remove-Item $regFile -Force
@@ -810,21 +908,24 @@ try {
                 }
             }
 
-            # Step 6 - Validate the required service configuration written to the target hive.
-            $requiredAgentServices = @('WindowsAzureGuestAgent', 'RdAgent')
+            # Step 6 - Validate required service configuration in every updated ControlSet.
             $targetServiceConfigurations = @{}
-            foreach ($requiredService in $requiredAgentServices) {
-                $servicePath = "Registry::HKLM\$hiveName\$primarySet\Services\$requiredService"
-                $serviceConfiguration = Get-ItemProperty -Path $servicePath -ErrorAction Stop
-                if ([string]::IsNullOrWhiteSpace([string]$serviceConfiguration.ImagePath)) {
-                    throw "Required service '$requiredService' has an empty ImagePath in $primarySet."
-                }
-                if ([int]$serviceConfiguration.Start -ne 2) {
-                    throw "Required service '$requiredService' is not configured for automatic startup in ${primarySet} (Start=$($serviceConfiguration.Start))."
-                }
+            foreach ($targetControlSet in $targetControlSets) {
+                foreach ($requiredService in $requiredAgentServices) {
+                    $servicePath = "Registry::HKLM\$hiveName\$targetControlSet\Services\$requiredService"
+                    $serviceConfiguration = Get-ItemProperty -Path $servicePath -ErrorAction Stop
+                    if ([string]::IsNullOrWhiteSpace([string]$serviceConfiguration.ImagePath)) {
+                        throw "Required service '$requiredService' has an empty ImagePath in $targetControlSet."
+                    }
+                    if ([int]$serviceConfiguration.Start -ne 2) {
+                        throw "Required service '$requiredService' is not configured for automatic startup in ${targetControlSet} (Start=$($serviceConfiguration.Start))."
+                    }
 
-                $targetServiceConfigurations[$requiredService] = $serviceConfiguration
-                Log-Info "Validated $requiredService configuration in ${primarySet}: Start=2, ImagePath=$($serviceConfiguration.ImagePath)"
+                    if ($targetControlSet -eq $primarySet) {
+                        $targetServiceConfigurations[$requiredService] = $serviceConfiguration
+                    }
+                    Write-GaInfo "Validated $requiredService in ${targetControlSet}: Start=2, ImagePath=$($serviceConfiguration.ImagePath)"
+                }
             }
             $afterImagePath = [string]$targetServiceConfigurations['WindowsAzureGuestAgent'].ImagePath
 
@@ -849,7 +950,7 @@ try {
             $sourceAgentFolder = $null
             if ($guestAgentCandidates.Count -gt 0) {
                 $sourceAgentFolder = $guestAgentCandidates[0].Directory
-                Log-Info "Selected latest VM Agent installation folder $($sourceAgentFolder.Name)."
+                Write-GaInfo "Selected latest VM Agent installation folder $($sourceAgentFolder.Name)."
             }
             else {
                 $expandedImagePath = [Environment]::ExpandEnvironmentVariables($afterImagePath).Trim()
@@ -863,7 +964,7 @@ try {
                     $imageFolder = Split-Path -Parent $imageExecutable
                     if (Test-Path -LiteralPath $imageFolder -PathType Container) {
                         $sourceAgentFolder = Get-Item -LiteralPath $imageFolder -ErrorAction Stop
-                        Log-Warning "No versioned GuestAgent folder was found; using ImagePath folder '$imageFolder'."
+                        Write-GaWarning "No versioned GuestAgent folder was found; using ImagePath folder '$imageFolder'."
                     }
                 }
             }
@@ -875,11 +976,9 @@ try {
             $null = New-Item -Path $destPath -ItemType Directory -Force
             $targetAgentFolder = Join-Path $destPath $sourceAgentFolder.Name
             $stagingAgentFolder = Join-Path $destPath ('.GA_repair_{0}_{1}' -f $sourceAgentFolder.Name, [guid]::NewGuid().ToString('N'))
-            $targetAgentBackup = $null
-            $existingAgentMoved = $false
 
             try {
-                Log-Info "Staging VM Agent folder $($sourceAgentFolder.FullName) at $stagingAgentFolder..."
+                Write-GaInfo "Staging VM Agent folder $($sourceAgentFolder.FullName) at $stagingAgentFolder..."
                 $restoreCopyResult = Invoke-CriticalCommand -Command "robocopy.exe" -Arguments @(
                     $sourceAgentFolder.FullName, $stagingAgentFolder, '/E', '/COPY:DAT', '/DCOPY:DAT',
                     '/XJ', '/R:2', '/W:2', '/NFL', '/NDL', '/NJH', '/NJS', '/NP'
@@ -906,19 +1005,20 @@ try {
                     if ($stagedExecutableInfo.Length -le 0) {
                         throw "Required executable for service '$requiredService' is empty in the staged copy: $stagedExecutable"
                     }
-                    Log-Info "Validated staged $requiredService executable ($($stagedExecutableInfo.Length) bytes)."
+                    Write-GaInfo "Validated staged $requiredService executable ($($stagedExecutableInfo.Length) bytes)."
                 }
 
                 if (Test-Path -LiteralPath $targetAgentFolder) {
                     $null = New-Item -Path $backupPath -ItemType Directory -Force
                     $targetAgentBackup = Join-Path $backupPath "$($sourceAgentFolder.Name)_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
-                    Log-Info "Moving existing $($sourceAgentFolder.Name) folder to $targetAgentBackup..."
+                    Write-GaInfo "Moving existing $($sourceAgentFolder.Name) folder to $targetAgentBackup..."
                     Move-Item -LiteralPath $targetAgentFolder -Destination $targetAgentBackup -ErrorAction Stop
                     $existingAgentMoved = $true
                 }
 
                 Move-Item -LiteralPath $stagingAgentFolder -Destination $targetAgentFolder -ErrorAction Stop
-                Log-Info "Activated validated VM Agent folder at $targetAgentFolder."
+                $agentFolderActivated = $true
+                Write-GaInfo "Activated validated VM Agent folder at $targetAgentFolder."
             }
             catch {
                 $activationError = $_
@@ -930,7 +1030,8 @@ try {
                         Remove-Item -LiteralPath $targetAgentFolder -Recurse -Force -ErrorAction Stop
                     }
                     Move-Item -LiteralPath $targetAgentBackup -Destination $targetAgentFolder -ErrorAction Stop
-                    Log-Warning "Restored the original VM Agent folder after replacement failed."
+                    $agentFolderActivated = $false
+                    Write-GaWarning "Restored the original VM Agent folder after replacement failed."
                 }
                 throw $activationError
             }
@@ -938,13 +1039,13 @@ try {
             $diskChangesCompleted = $true
         }
         catch {
-            Log-Error "Failed to process $($diskb):: $($_.Exception.Message)"
+            Write-GaError "Failed to process $($diskb):: $($_.Exception.Message)"
             $restoreHiveBackup = $true
             $diskProcessedSuccessfully = $false
         }
         finally {
             # Step 8 - Release handles and safely unload the registry hive
-            Log-Info "Unloading registry hive $hiveName..."
+            Write-GaInfo "Unloading registry hive $hiveName..."
             [System.GC]::Collect()
             [System.GC]::WaitForPendingFinalizers()
             Start-Sleep -Seconds 3
@@ -953,56 +1054,56 @@ try {
             for ($i=1; $i -le 3; $i++) {
                 $unloadResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("unload", "HKLM\$hiveName") -Description "reg unload $hiveName attempt $i"
                 if ($unloadResult.ExitCode -eq 0) { $unloaded = $true; break }
-                Log-Warning "Unload attempt $i for $hiveName failed, retrying..."
+                Write-GaWarning "Unload attempt $i for $hiveName failed, retrying..."
                 Start-Sleep -Seconds 5
             }
             if (-not $unloaded) {
-                Log-Error "Could not unload $hiveName hive - marking Disk $diskb as failed."
+                Write-GaError "Could not unload $hiveName hive - marking Disk $diskb as failed."
                 $failedDisks += $diskb
             }
 
             if ($restoreHiveBackup -and $backupFile -and (Test-Path -LiteralPath $backupFile)) {
                 if ($unloaded) {
-                    Log-Warning "Repair processing failed; restoring the original SYSTEM hive from $backupFile."
+                    Write-GaWarning "Repair processing failed; restoring the original SYSTEM hive from $backupFile."
                     try {
-                        $expectedHiveHash = (Get-FileHash -LiteralPath $backupFile -Algorithm SHA256 -ErrorAction Stop).Hash
+                        $expectedHiveHash = Get-GaFileSha256 -LiteralPath $backupFile
                         Copy-Item -LiteralPath $backupFile -Destination $hiveSource -Force -ErrorAction Stop
-                        $actualHiveHash = (Get-FileHash -LiteralPath $hiveSource -Algorithm SHA256 -ErrorAction Stop).Hash
+                        $actualHiveHash = Get-GaFileSha256 -LiteralPath $hiveSource
                         if ($actualHiveHash -ne $expectedHiveHash) {
                             throw "SYSTEM hive rollback verification failed: backup and restored hashes differ."
                         }
-                        Log-Info "Original SYSTEM hive restored and verified for $($diskb):."
+                        Write-GaInfo "Original SYSTEM hive restored and verified for $($diskb):."
                     }
                     catch {
-                        Log-Error "Failed to restore the original SYSTEM hive on $($diskb):: $($_.Exception.Message)"
+                        Write-GaError "Failed to restore the original SYSTEM hive on $($diskb):: $($_.Exception.Message)"
                         $failedDisks += $diskb
                     }
                 }
                 else {
-                    Log-Error "Original SYSTEM hive for $($diskb): cannot be restored because $hiveName did not unload."
+                    Write-GaError "Original SYSTEM hive for $($diskb): cannot be restored because $hiveName did not unload."
                     $failedDisks += $diskb
                 }
             }
             # If direct loading failed, persist the fallback hive only after every repair check passed.
             elseif ($hiveCopy -and (Test-Path $hiveCopy)) {
                 if ($unloaded) {
-                    Log-Info "Copying modified hive back to $hiveSource..."
+                    Write-GaInfo "Copying modified hive back to $hiveSource..."
                     try {
-                        $expectedHiveHash = (Get-FileHash -LiteralPath $hiveCopy -Algorithm SHA256 -ErrorAction Stop).Hash
+                        $expectedHiveHash = Get-GaFileSha256 -LiteralPath $hiveCopy
                         Copy-Item -LiteralPath $hiveCopy -Destination $hiveSource -Force -ErrorAction Stop
-                        $actualHiveHash = (Get-FileHash -LiteralPath $hiveSource -Algorithm SHA256 -ErrorAction Stop).Hash
+                        $actualHiveHash = Get-GaFileSha256 -LiteralPath $hiveSource
                         if ($actualHiveHash -ne $expectedHiveHash) {
                             throw "Hive copy-back verification failed: source and destination SHA256 hashes differ."
                         }
-                        Log-Info "Successfully copied and verified the modified hive back to $($diskb):"
+                        Write-GaInfo "Successfully copied and verified the modified hive back to $($diskb):"
                     }
                     catch {
-                        Log-Error "Failed to copy modified hive back to $($diskb):: $($_.Exception.Message)"
+                        Write-GaError "Failed to copy modified hive back to $($diskb):: $($_.Exception.Message)"
                         $failedDisks += $diskb
                     }
                 }
                 else {
-                    Log-Error "Modified fallback hive for $($diskb): cannot be copied back because $hiveName did not unload."
+                    Write-GaError "Modified fallback hive for $($diskb): cannot be copied back because $hiveName did not unload."
                     $failedDisks += $diskb
                 }
             }
@@ -1012,6 +1113,29 @@ try {
             }
 
             $diskProcessedSuccessfully = $diskChangesCompleted -and ($diskb -notin $failedDisks)
+            if (-not $diskProcessedSuccessfully -and $agentFolderActivated -and $targetAgentFolder) {
+                try {
+                    if (Test-Path -LiteralPath $targetAgentFolder) {
+                        Remove-Item -LiteralPath $targetAgentFolder -Recurse -Force -ErrorAction Stop
+                    }
+                    if ($existingAgentMoved -and $targetAgentBackup) {
+                        if (-not (Test-Path -LiteralPath $targetAgentBackup -PathType Container)) {
+                            throw "Original VM Agent backup is missing: $targetAgentBackup"
+                        }
+                        Move-Item -LiteralPath $targetAgentBackup -Destination $targetAgentFolder -ErrorAction Stop
+                        Write-GaWarning "Restored the original VM Agent folder because registry persistence did not complete."
+                    }
+                    else {
+                        Write-GaWarning "Removed the newly introduced VM Agent folder because registry persistence did not complete."
+                    }
+                    $agentFolderActivated = $false
+                }
+                catch {
+                    Write-GaError "Failed to roll back the VM Agent folder on $($diskb):: $($_.Exception.Message)"
+                    if ($diskb -notin $failedDisks) { $failedDisks += $diskb }
+                }
+            }
+
             if ($diskProcessedSuccessfully) {
                 $fixedDisks += $diskb
                 $changedCount++
@@ -1026,11 +1150,11 @@ try {
     }
 
     if ($failedDisks.Count -gt 0) {
-        Log-Error "Processing failed on disks: $($failedDisks -join ', ')"
+        Write-GaError "Processing failed on disks: $($failedDisks -join ', ')"
         throw "One or more disks failed backup, hive processing, unload, or copy-back validation: $($failedDisks -join ', '). Please review logs."
     }
 
-    Log-Info "Processing summary: processed=$processedCount skipped=$skippedCount failed=$failedCount changed=$changedCount"
+    Write-GaInfo "Processing summary: processed=$processedCount skipped=$skippedCount failed=$failedCount changed=$changedCount"
     if ($fixedDisks.Count -gt 0) {
         $successMessage = "VMAgent offline repair completed on drives: $($fixedDisks -join ', '). Agent readiness must be verified after restore and boot. | Host=$($vmMetadata.HostName)"
         $script_final_status = $STATUS_SUCCESS
@@ -1042,13 +1166,16 @@ try {
 }
 catch {
     $errorMessage = $_.Exception.Message
-    Log-Error "SCRIPT FAILED: $errorMessage"
+    Write-GaError "SCRIPT FAILED: $errorMessage"
+    Write-GaTelemetry -Event Error -Message 'VMAgent offline repair failed' -Properties @{
+        Error = $errorMessage
+    }
     $script_final_status = $STATUS_ERROR
 }
 finally {
     foreach ($mount in @($temporaryOsMounts | Sort-Object DiskNumber, PartitionNumber -Unique)) {
         try {
-            Log-Info "Removing temporary OS letter $($mount.DriveLetter): from Disk $($mount.DiskNumber) Partition $($mount.PartitionNumber)."
+            Write-GaInfo "Removing temporary OS letter $($mount.DriveLetter): from Disk $($mount.DiskNumber) Partition $($mount.PartitionNumber)."
             Invoke-GaDiskPart -Operation 'os-cleanup' -Commands @(
                 "select disk $($mount.DiskNumber)"
                 "select partition $($mount.PartitionNumber)"
@@ -1059,10 +1186,10 @@ finally {
             if ([string]$cleanedPartition.DriveLetter -ieq [string]$mount.DriveLetter) {
                 throw "Temporary drive letter removal could not be verified."
             }
-            Log-Info "Temporary OS letter $($mount.DriveLetter): removal verified."
+            Write-GaInfo "Temporary OS letter $($mount.DriveLetter): removal verified."
         }
         catch {
-            Log-Error "Failed to remove temporary OS letter $($mount.DriveLetter): $($_.Exception.Message)"
+            Write-GaError "Failed to remove temporary OS letter $($mount.DriveLetter): $($_.Exception.Message)"
             $script_final_status = $STATUS_ERROR
         }
     }
@@ -1082,22 +1209,22 @@ finally {
                 if (-not $sourceDisk.IsOffline -or $sourceIdentity.Value -ine $repairDiskIdentityRecord.OriginalValue) {
                     throw "Source Disk $diskNumber was not offline with its unchanged original GPT identity."
                 }
-                Log-Info "Source Disk $diskNumber is offline with its original GPT identity verified before repair host restoration."
+                Write-GaInfo "Source Disk $diskNumber is offline with its original GPT identity verified before repair host restoration."
             }
             catch {
                 $identityRestorationFailed = $true
-                Log-Error "CRITICAL: Could not safely offline and verify source Disk ${diskNumber}: $($_.Exception.Message)"
+                Write-GaError "CRITICAL: Could not safely offline and verify source Disk ${diskNumber}: $($_.Exception.Message)"
             }
         }
 
         if (-not $identityRestorationFailed) {
             try {
                 Restore-GaRepairDiskIdentity -Record $repairDiskIdentityRecord
-                Log-Info 'Repair VM OS disk GPT identity restored and verified.'
+                Write-GaInfo 'Repair VM OS disk GPT identity restored and verified.'
             }
             catch {
                 $identityRestorationFailed = $true
-                Log-Error "CRITICAL: Failed to restore the repair VM OS disk identity: $($_.Exception.Message)"
+                Write-GaError "CRITICAL: Failed to restore the repair VM OS disk identity: $($_.Exception.Message)"
             }
         }
     }
@@ -1105,11 +1232,11 @@ finally {
     foreach ($identityRecord in @($collisionDiskRecords | Sort-Object DiskNumber -Descending)) {
         try {
             Restore-GaOriginalSourceIdentity -Record $identityRecord
-            Log-Info "Disk $($identityRecord.DiskNumber) is offline with its verified original MBR identity restored."
+            Write-GaInfo "Disk $($identityRecord.DiskNumber) is offline with its verified original MBR identity restored."
         }
         catch {
             $identityRestorationFailed = $true
-            Log-Error "CRITICAL: Failed to restore original identity on Disk $($identityRecord.DiskNumber): $($_.Exception.Message)"
+            Write-GaError "CRITICAL: Failed to restore original identity on Disk $($identityRecord.DiskNumber): $($_.Exception.Message)"
         }
     }
 
@@ -1119,15 +1246,15 @@ finally {
 
     # Log local execution context only; this script performs no telemetry upload.
     if ($vmMetadata.OSVersion) {
-        Log-Info "Execution Context - Host: $($vmMetadata.HostName), OS: $($vmMetadata.OSVersion)"
+        Write-GaInfo "Execution Context - Host: $($vmMetadata.HostName), OS: $($vmMetadata.OSVersion)"
     }
 
     # Restore original service states
-    Log-Info "Restoring original service states..."
+    Write-GaInfo "Restoring original service states..."
     foreach ($svc in $serviceStates.Keys) {
         try {
             $originalState = $serviceStates[$svc]
-            Log-Info "Restoring $svc to state: $originalState"
+            Write-GaInfo "Restoring $svc to state: $originalState"
             if ($originalState -eq 'Running') {
                 Start-Service -Name $svc -ErrorAction Stop
                 $restoredService = Get-Service -Name $svc -ErrorAction Stop
@@ -1140,20 +1267,39 @@ finally {
             if ($restoredState -ne $originalState) {
                 throw "$svc restoration verification failed: expected $originalState, found $restoredState."
             }
-            Log-Info "$svc restored and verified in state $restoredState."
+            Write-GaInfo "$svc restored and verified in state $restoredState."
         }
         catch {
-            Log-Error "Failed to restore $svc to state $originalState : $($_.Exception.Message)"
+            Write-GaError "Failed to restore $svc to state $originalState : $($_.Exception.Message)"
             $script_final_status = $STATUS_ERROR
         }
     }
 
     if ($script_final_status -eq $STATUS_SUCCESS -and $successMessage) {
-        Log-Output $successMessage
+        Write-GaOutput $successMessage
     }
 
-    Log-Info "Execution ended at $(Get-Date)"
-    Log-Info "Desktop log file path: $logFile"
+    $durationSeconds = [math]::Round(((Get-Date) - $script:ExecutionStarted).TotalSeconds, 3)
+    $finalTelemetryProperties = @{
+        FinalStatus = "$script_final_status"
+        DurationSeconds = "$durationSeconds"
+        Operations = "$($script:OperationCount)"
+        DisksProcessed = "$processedCount"
+        DisksChanged = "$changedCount"
+        DisksSkipped = "$skippedCount"
+        DisksFailed = "$failedCount"
+    }
+    if ($script_final_status -eq $STATUS_SUCCESS) {
+        Write-GaTelemetry -Event Success -Message 'VMAgent offline repair completed successfully' -Properties $finalTelemetryProperties
+    }
+    else {
+        Write-GaTelemetry -Event Error -Message 'VMAgent offline repair completed with errors' -Properties $finalTelemetryProperties
+    }
+
+    Write-GaInfo "[final_status] Status=$script_final_status"
+    Write-GaInfo "Summary: processed=$processedCount changed=$changedCount skipped=$skippedCount failed=$failedCount operations=$($script:OperationCount)"
+    Write-GaInfo "Execution ended at $(Get-Date)"
+    Write-GaInfo "Desktop log file path: $logFile"
 }
 
 return $script_final_status

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -23,15 +23,15 @@
     Modified by: Tony.Mocanu@Microsoft.com
 
 .VERSION
-    v1.3: [May 2026] - Updated the script (current)
+    v1.4: [May 2026] - Updated the script (current)
                        - Aligned nested VM detection with win-LKGC guard pattern.
                        - Skips Get-VM safely when Hyper-V module is unavailable.
-    v1.2: [May 2026] - Updated the script again (current)
+    v1.3: [May 2026] - Updated the script again (current)
                        - Fixed breaking exception when the Hyper-V module is not installed on the host.
                        - Added explicit checking via Get-Module before executing nested VM discovery.
-    v1.1: [May 2026] - Updated the script
+    v1.2: [May 2026] - Updated the script
                        - Included advanced Gen2 unlettered EFI fallback and dynamic drive-letter assignment.
-    v1.0: Initial commit. This was the version 1.0 of the script.
+    v0.1: Initial commit. This was the version 1.0 of the script.
 
 .SCENARIO_RECREATION
     To recreate a testable broken Guest Agent scenario on a rescue VM with an attached OS disk:
@@ -78,9 +78,50 @@ $logFile = "$logDir\GA_offlinefixer_$timestamp.log"
 
 # Status Tracking
 $script_final_status = $STATUS_ERROR
+$serviceStates = @{}  # Track original service states for restoration
+
+# VM Metadata Capture for Telemetry
+$vmMetadata = @{
+    OSVersion = $null
+    VMSku = $null
+    Region = $null
+    HostName = $env:COMPUTERNAME
+}
 
 try {
-    Log-Info "Starting VMAgent Offline Fixer..." | Tee-Object -FilePath $logFile -Append
+    # Capture OS version from rescue VM
+    try {
+        $osInfo = Get-WmiObject -Class Win32_OperatingSystem -ErrorAction SilentlyContinue
+        if ($osInfo) {
+            $vmMetadata.OSVersion = "$($osInfo.Caption) $($osInfo.Version)"
+        }
+    }
+    catch {
+        # Silent fail - metadata is optional
+    }
+
+    # Attempt to capture Azure VM metadata from Instance Metadata Service
+    try {
+        $imdHeaders = @{Metadata = $true }
+        $imdUri = "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
+        $imdResponse = Invoke-RestMethod -Uri $imdUri -Headers $imdHeaders -ErrorAction SilentlyContinue
+        if ($imdResponse) {
+            $vmMetadata.VMSku = $imdResponse.compute.vmSize
+            $vmMetadata.Region = $imdResponse.compute.location
+        }
+    }
+    catch {
+        # Silent fail - metadata is optional, may not be available in all environments
+    }
+
+    # Create metadata context string for logging
+    $metadataContext = "[Host:$($vmMetadata.HostName)"
+    if ($vmMetadata.Region) { $metadataContext += " Region:$($vmMetadata.Region)" }
+    if ($vmMetadata.VMSku) { $metadataContext += " SKU:$($vmMetadata.VMSku)" }
+    if ($vmMetadata.OSVersion) { $metadataContext += " OS:$($vmMetadata.OSVersion)" }
+    $metadataContext += "]"
+
+    Log-Info "Starting VMAgent Offline Fixer... $metadataContext" | Tee-Object -FilePath $logFile -Append
 
     # Stop nested guest VM if running
     # Guard Get-VM if Hyper-V module is not available
@@ -127,8 +168,19 @@ try {
 
     # Stop services that scan/index attached disks and lock hive files
     Log-Info "Stopping services that may lock disk files..." | Tee-Object -FilePath $logFile -Append
-    Stop-Service WSearch -Force -ErrorAction SilentlyContinue 2>$null
-    Stop-Service WinDefend -Force -ErrorAction SilentlyContinue 2>$null
+    foreach ($svc in @('WSearch', 'WinDefend')) {
+        try {
+            $svcObj = Get-Service -Name $svc -ErrorAction SilentlyContinue
+            if ($svcObj) {
+                $serviceStates[$svc] = $svcObj.Status
+                Log-Info "Captured original state of $svc : $($svcObj.Status)" | Tee-Object -FilePath $logFile -Append
+                Stop-Service -Name $svc -Force -ErrorAction SilentlyContinue
+            }
+        }
+        catch {
+            Log-Warning "Failed to capture state of $svc : $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+        }
+    }
 
     [System.GC]::Collect()
     [System.GC]::WaitForPendingFinalizers()
@@ -150,6 +202,7 @@ try {
     $partitionlist = Get-Disk-Partitions
     $rescueDrive = $env:SystemDrive -replace ':', ''
     $fixedDisks = @()
+    $failedDisks = @()  # Track disks that failed copy-back
 
     foreach ($partition in $partitionlist) {
         if (-not $partition.DriveLetter) { continue }
@@ -167,6 +220,7 @@ try {
         $hiveName = "BROKENSYSTEM_$diskb"
         $hiveSource = "$($diskb):\Windows\System32\config\SYSTEM"
         $hiveCopy = $null
+        $diskProcessedSuccessfully = $false
         & reg.exe unload "HKLM\$hiveName" 2>$null
         [System.GC]::Collect()
         Start-Sleep -Seconds 1
@@ -283,10 +337,12 @@ try {
                 Remove-Item $logsPath -Recurse -Force -ErrorAction SilentlyContinue
             }
 
+            $diskProcessedSuccessfully = $true
             $fixedDisks += $diskb
         }
         catch {
             Log-Error "Failed to process $($diskb):: $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+            $diskProcessedSuccessfully = $false
         }
         finally {
             # Step 8 - Release handles and safely unload the registry hive
@@ -312,18 +368,34 @@ try {
                     Log-Info "Copying modified hive back to $hiveSource..." | Tee-Object -FilePath $logFile -Append
                     try {
                         Copy-Item -Path $hiveCopy -Destination $hiveSource -Force -ErrorAction Stop
+                        Log-Info "Successfully copied modified hive back to $($diskb):" | Tee-Object -FilePath $logFile -Append
                     }
                     catch {
                         Log-Error "Failed to copy modified hive back to $($diskb):: $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+                        $diskProcessedSuccessfully = $false
+                        $failedDisks += $diskb
                     }
                 }
                 Remove-Item $hiveCopy -Force -ErrorAction SilentlyContinue
             }
+
+            # Remove from fixed list if processing failed
+            if (-not $diskProcessedSuccessfully) {
+                $fixedDisks = @($fixedDisks | Where-Object { $_ -ne $diskb })
+                if ($diskb -notin $failedDisks) {
+                    $failedDisks += $diskb
+                }
+            }
         }
     }
 
+    if ($failedDisks.Count -gt 0) {
+        Log-Error "Copy-back operation failed on disks: $($failedDisks -join ', ')" | Tee-Object -FilePath $logFile -Append
+        throw "Hive copy-back failed on one or more disks: $($failedDisks -join ', '). Please review logs."
+    }
+
     if ($fixedDisks.Count -gt 0) {
-        Log-Output "VMAgent Fix completed and verified successfully on drives: $($fixedDisks -join ', ')" | Tee-Object -FilePath $logFile -Append
+        Log-Output "VMAgent Fix completed and verified successfully on drives: $($fixedDisks -join ', ') | Metadata: Host=$($vmMetadata.HostName), Region=$($vmMetadata.Region), SKU=$($vmMetadata.VMSku)" | Tee-Object -FilePath $logFile -Append
         $script_final_status = $STATUS_SUCCESS
     }
     else {
@@ -337,6 +409,27 @@ catch {
     $script_final_status = $STATUS_ERROR
 }
 finally {
+    # Log execution metadata for Application Insights correlation
+    if ($vmMetadata.Region -or $vmMetadata.VMSku -or $vmMetadata.OSVersion) {
+        Log-Info "Execution Context - Host: $($vmMetadata.HostName), Region: $($vmMetadata.Region), SKU: $($vmMetadata.VMSku), OS: $($vmMetadata.OSVersion)" | Tee-Object -FilePath $logFile -Append
+    }
+
+    # Restore original service states
+    Log-Info "Restoring original service states..." | Tee-Object -FilePath $logFile -Append
+    foreach ($svc in $serviceStates.Keys) {
+        try {
+            $originalState = $serviceStates[$svc]
+            Log-Info "Restoring $svc to state: $originalState" | Tee-Object -FilePath $logFile -Append
+            if ($originalState -eq 'Running') {
+                Start-Service -Name $svc -ErrorAction SilentlyContinue
+            }
+            # If original state was Stopped, service remains stopped (already stopped)
+        }
+        catch {
+            Log-Warning "Failed to restore $svc to state $originalState : $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+        }
+    }
+
     Log-Info "Execution ended at $(Get-Date)" | Tee-Object -FilePath $logFile -Append
 }
 

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -18,7 +18,7 @@
 
 .NOTES
     Name:    GA_offlinefixer.ps1
-    Version: 1.3
+    Version: 1.4
     Original Author: Daniel Munoz L (damunozl@microsoft.com)
     Modified by: Tony.Mocanu@Microsoft.com
 
@@ -26,6 +26,7 @@
     v1.4: [May 2026] - Updated the script (current)
                        - Aligned nested VM detection with win-LKGC guard pattern.
                        - Skips Get-VM safely when Hyper-V module is unavailable.
+                       - Fixed relative path evaluation bug for helper files.
     v1.3: [May 2026] - Updated the script again (current)
                        - Fixed breaking exception when the Hyper-V module is not installed on the host.
                        - Added explicit checking via Get-Module before executing nested VM discovery.
@@ -67,8 +68,8 @@ Get-ChildItem F:\WindowsAzure\GuestAgent_*
 #>
 
 # Initialization
-$initScriptPath = Join-Path $PSScriptRoot "src\windows\common\setup\init.ps1"
-$diskHelperPath = Join-Path $PSScriptRoot "src\windows\common\helpers\Get-Disk-Partitions-v2.ps1"
+$initScriptPath = Join-Path $PSScriptRoot "common\setup\init.ps1"
+$diskHelperPath = Join-Path $PSScriptRoot "common\helpers\Get-Disk-Partitions-v2.ps1"
 
 if (-not (Test-Path -Path $initScriptPath)) {
     Write-Error "Required helper script not found: $initScriptPath"
@@ -492,4 +493,3 @@ finally {
 }
 
 return $script_final_status
-

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -13,8 +13,10 @@
        from the rescue VM and injects them into both ControlSets on the target hive.
      6. Verifies both required services use automatic startup and have non-empty ImagePath values.
      7. Copies the latest GuestAgent installation folder, or the documented ImagePath folder fallback,
-         and verifies the exact executables referenced by both required services.
+         into a staging directory and verifies the exact executables referenced by both required services.
+         The existing Agent folder is restored if activation fails.
     8. Releases handles and safely unloads the registry hive (with retry logic).
+         If processing fails, restores and hash-verifies the original SYSTEM hive.
 
 .NOTES
     Name:    GA_offlinefixer.ps1
@@ -26,6 +28,8 @@
     v1.3: [August 2026] - Copies only the newest versioned GuestAgent installation folder.
                         - Uses the WindowsAzureGuestAgent ImagePath folder as a fallback.
                         - Preserves unrelated content in the target WindowsAzure folder.
+                        - Stages and validates replacement files before moving the existing Agent folder.
+                        - Rolls back the Agent folder and SYSTEM hive after partial repair failures.
                         - Bounds file-copy retries to avoid client repair jobs appearing stuck.
                         - Unloads only stale repair hives that actually exist.
                         - Uses the same partition discovery and collision handling as win-sac-onLatest.
@@ -54,19 +58,16 @@
     v0.1: Initial commit. This was the version 1.0 of the script.
 
 .SCENARIO_RECREATION
-    To recreate a testable broken Guest Agent scenario on a rescue VM with an attached OS disk:
-    1. Create a test VM in Azure and attach its OS disk to a rescue VM.
-    2. Load the SYSTEM hive from the attached disk (replace F with actual drive letter):
-reg load HKLM\TESTBREAK F:\Windows\System32\config\SYSTEM
-    3. Delete or corrupt the Guest Agent service keys:
-Remove-Item -Path "HKLM:\TESTBREAK\ControlSet001\Services\WindowsAzureGuestAgent" -Recurse -Force
-Remove-Item -Path "HKLM:\TESTBREAK\ControlSet001\Services\RdAgent" -Recurse -Force
-    4. Unload the hive:
-reg unload HKLM\TESTBREAK
-    5. Optionally rename/remove GuestAgent binary folders on the target disk:
-Get-ChildItem F:\WindowsAzure\GuestAgent_* | Rename-Item -NewName { $_.Name + '_BACKUP' }
-    6. Run the script. It should restore service keys from the rescue VM and copy binaries.
-    7. Verify via the .VERIFICATION steps below.
+    Use only on a disposable test VM with a snapshot or recoverable OS disk.
+    Run GA_offlinefixer_testbreaker.ps1 on the healthy test VM before detaching its OS disk:
+.\GA_offlinefixer_testbreaker.ps1 -Mode Break -ConfirmDestructiveTest
+    The breaker exports both required service keys and moves C:\WindowsAzure into a timestamped
+    backup. It intentionally preserves the Agent SOFTWARE keys and C:\Packages because those
+    artifacts are outside this fixer's documented offline recovery scope.
+    To undo the test without running the offline fixer:
+.\GA_offlinefixer_testbreaker.ps1 -Mode Restore -BackupPath 'C:\GAOfflineRepairTestBackups\<timestamp>'
+    After creating the test state, shut down the VM, run the offline fixer through VM Repair,
+    restore the repaired OS disk, boot the VM, and complete the .VERIFICATION checks below.
 
 .EXAMPLE
     az vm repair run -g <rg> -n <vm> --run-id win-GA-fix --run-on-repair
@@ -694,6 +695,8 @@ try {
         $hiveName = "BROKENSYSTEM_$diskb"
         $hiveSource = "$($diskb):\Windows\System32\config\SYSTEM"
         $hiveCopy = $null
+        $backupFile = $null
+        $restoreHiveBackup = $false
         $diskProcessedSuccessfully = $false
         $diskChangesCompleted = $false
         & reg.exe unload "HKLM\$hiveName" 2>$null
@@ -871,39 +874,72 @@ try {
 
             $null = New-Item -Path $destPath -ItemType Directory -Force
             $targetAgentFolder = Join-Path $destPath $sourceAgentFolder.Name
-            if (Test-Path -LiteralPath $targetAgentFolder) {
-                $null = New-Item -Path $backupPath -ItemType Directory -Force
-                $targetAgentBackup = Join-Path $backupPath "$($sourceAgentFolder.Name)_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
-                Log-Info "Moving existing $($sourceAgentFolder.Name) folder to $targetAgentBackup..."
-                Move-Item -LiteralPath $targetAgentFolder -Destination $targetAgentBackup -ErrorAction Stop
-            }
+            $stagingAgentFolder = Join-Path $destPath ('.GA_repair_{0}_{1}' -f $sourceAgentFolder.Name, [guid]::NewGuid().ToString('N'))
+            $targetAgentBackup = $null
+            $existingAgentMoved = $false
 
-            Log-Info "Copying VM Agent folder $($sourceAgentFolder.FullName) to $targetAgentFolder..."
-            $restoreCopyResult = Invoke-CriticalCommand -Command "robocopy.exe" -Arguments @(
-                $sourceAgentFolder.FullName, $targetAgentFolder, '/E', '/COPY:DAT', '/DCOPY:DAT',
-                '/XJ', '/R:2', '/W:2', '/NFL', '/NDL', '/NJH', '/NJS', '/NP'
-            ) -Description "robocopy VM Agent $($sourceAgentFolder.Name) ($diskb)"
-            if ($restoreCopyResult.ExitCode -ge 8) {
-                throw "Failed to copy VM Agent folder to $($diskb): $($restoreCopyResult.Output -join '; ')"
+            try {
+                Log-Info "Staging VM Agent folder $($sourceAgentFolder.FullName) at $stagingAgentFolder..."
+                $restoreCopyResult = Invoke-CriticalCommand -Command "robocopy.exe" -Arguments @(
+                    $sourceAgentFolder.FullName, $stagingAgentFolder, '/E', '/COPY:DAT', '/DCOPY:DAT',
+                    '/XJ', '/R:2', '/W:2', '/NFL', '/NDL', '/NJH', '/NJS', '/NP'
+                ) -Description "robocopy VM Agent $($sourceAgentFolder.Name) ($diskb)"
+                if ($restoreCopyResult.ExitCode -ge 8) {
+                    throw "Failed to stage VM Agent folder on $($diskb): $($restoreCopyResult.Output -join '; ')"
+                }
+
+                foreach ($requiredService in $requiredAgentServices) {
+                    $targetExecutable = Get-GaServiceExecutablePath `
+                        -ImagePath ([string]$targetServiceConfigurations[$requiredService].ImagePath) `
+                        -TargetDriveLetter $diskb
+                    $targetAgentPrefix = $targetAgentFolder.TrimEnd('\') + '\'
+                    if (-not $targetExecutable.StartsWith($targetAgentPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                        throw "Required service '$requiredService' points outside the selected Agent folder: $targetExecutable"
+                    }
+
+                    $relativeExecutable = $targetExecutable.Substring($targetAgentPrefix.Length)
+                    $stagedExecutable = Join-Path $stagingAgentFolder $relativeExecutable
+                    if (-not (Test-Path -LiteralPath $stagedExecutable -PathType Leaf)) {
+                        throw "Required executable for service '$requiredService' was not found in the staged copy: $stagedExecutable"
+                    }
+                    $stagedExecutableInfo = Get-Item -LiteralPath $stagedExecutable -ErrorAction Stop
+                    if ($stagedExecutableInfo.Length -le 0) {
+                        throw "Required executable for service '$requiredService' is empty in the staged copy: $stagedExecutable"
+                    }
+                    Log-Info "Validated staged $requiredService executable ($($stagedExecutableInfo.Length) bytes)."
+                }
+
+                if (Test-Path -LiteralPath $targetAgentFolder) {
+                    $null = New-Item -Path $backupPath -ItemType Directory -Force
+                    $targetAgentBackup = Join-Path $backupPath "$($sourceAgentFolder.Name)_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+                    Log-Info "Moving existing $($sourceAgentFolder.Name) folder to $targetAgentBackup..."
+                    Move-Item -LiteralPath $targetAgentFolder -Destination $targetAgentBackup -ErrorAction Stop
+                    $existingAgentMoved = $true
+                }
+
+                Move-Item -LiteralPath $stagingAgentFolder -Destination $targetAgentFolder -ErrorAction Stop
+                Log-Info "Activated validated VM Agent folder at $targetAgentFolder."
             }
-            foreach ($requiredService in $requiredAgentServices) {
-                $targetExecutable = Get-GaServiceExecutablePath `
-                    -ImagePath ([string]$targetServiceConfigurations[$requiredService].ImagePath) `
-                    -TargetDriveLetter $diskb
-                if (-not (Test-Path -LiteralPath $targetExecutable -PathType Leaf)) {
-                    throw "Required executable for service '$requiredService' was not found after copy: $targetExecutable"
+            catch {
+                $activationError = $_
+                if (Test-Path -LiteralPath $stagingAgentFolder) {
+                    Remove-Item -LiteralPath $stagingAgentFolder -Recurse -Force -ErrorAction SilentlyContinue
                 }
-                $targetExecutableInfo = Get-Item -LiteralPath $targetExecutable -ErrorAction Stop
-                if ($targetExecutableInfo.Length -le 0) {
-                    throw "Required executable for service '$requiredService' is empty: $targetExecutable"
+                if ($existingAgentMoved -and $targetAgentBackup) {
+                    if (Test-Path -LiteralPath $targetAgentFolder) {
+                        Remove-Item -LiteralPath $targetAgentFolder -Recurse -Force -ErrorAction Stop
+                    }
+                    Move-Item -LiteralPath $targetAgentBackup -Destination $targetAgentFolder -ErrorAction Stop
+                    Log-Warning "Restored the original VM Agent folder after replacement failed."
                 }
-                Log-Info "Validated $requiredService executable at $targetExecutable ($($targetExecutableInfo.Length) bytes)."
+                throw $activationError
             }
 
             $diskChangesCompleted = $true
         }
         catch {
             Log-Error "Failed to process $($diskb):: $($_.Exception.Message)"
+            $restoreHiveBackup = $true
             $diskProcessedSuccessfully = $false
         }
         finally {
@@ -925,13 +961,35 @@ try {
                 $failedDisks += $diskb
             }
 
-            # If we used the copy fallback, copy the modified hive back to the original location
-            if ($hiveCopy -and (Test-Path $hiveCopy)) {
+            if ($restoreHiveBackup -and $backupFile -and (Test-Path -LiteralPath $backupFile)) {
+                if ($unloaded) {
+                    Log-Warning "Repair processing failed; restoring the original SYSTEM hive from $backupFile."
+                    try {
+                        $expectedHiveHash = (Get-FileHash -LiteralPath $backupFile -Algorithm SHA256 -ErrorAction Stop).Hash
+                        Copy-Item -LiteralPath $backupFile -Destination $hiveSource -Force -ErrorAction Stop
+                        $actualHiveHash = (Get-FileHash -LiteralPath $hiveSource -Algorithm SHA256 -ErrorAction Stop).Hash
+                        if ($actualHiveHash -ne $expectedHiveHash) {
+                            throw "SYSTEM hive rollback verification failed: backup and restored hashes differ."
+                        }
+                        Log-Info "Original SYSTEM hive restored and verified for $($diskb):."
+                    }
+                    catch {
+                        Log-Error "Failed to restore the original SYSTEM hive on $($diskb):: $($_.Exception.Message)"
+                        $failedDisks += $diskb
+                    }
+                }
+                else {
+                    Log-Error "Original SYSTEM hive for $($diskb): cannot be restored because $hiveName did not unload."
+                    $failedDisks += $diskb
+                }
+            }
+            # If direct loading failed, persist the fallback hive only after every repair check passed.
+            elseif ($hiveCopy -and (Test-Path $hiveCopy)) {
                 if ($unloaded) {
                     Log-Info "Copying modified hive back to $hiveSource..."
                     try {
                         $expectedHiveHash = (Get-FileHash -LiteralPath $hiveCopy -Algorithm SHA256 -ErrorAction Stop).Hash
-                        Copy-Item -Path $hiveCopy -Destination $hiveSource -Force -ErrorAction Stop
+                        Copy-Item -LiteralPath $hiveCopy -Destination $hiveSource -Force -ErrorAction Stop
                         $actualHiveHash = (Get-FileHash -LiteralPath $hiveSource -Algorithm SHA256 -ErrorAction Stop).Hash
                         if ($actualHiveHash -ne $expectedHiveHash) {
                             throw "Hive copy-back verification failed: source and destination SHA256 hashes differ."
@@ -947,6 +1005,9 @@ try {
                     Log-Error "Modified fallback hive for $($diskb): cannot be copied back because $hiveName did not unload."
                     $failedDisks += $diskb
                 }
+            }
+
+            if ($hiveCopy -and (Test-Path -LiteralPath $hiveCopy)) {
                 Remove-Item $hiveCopy -Force -ErrorAction SilentlyContinue
             }
 

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -68,8 +68,19 @@ Get-ChildItem F:\WindowsAzure\GuestAgent_*
 #>
 
 # Initialization (path-validated)
-$initPath = Join-Path -Path $PSScriptRoot -ChildPath 'common\setup\init.ps1'
-$diskPartitionsPath = Join-Path -Path $PSScriptRoot -ChildPath 'common\helpers\Get-Disk-Partitions-v2.ps1'
+# $PSScriptRoot is empty when RunCommand executes scripts as a ScriptBlock (Invoke-Expression / [ScriptBlock]::Create).
+# Fall back to the call stack, which PowerShell still attributes to the originating file path.
+$resolvedScriptRoot = $PSScriptRoot
+if ([string]::IsNullOrEmpty($resolvedScriptRoot)) {
+    $resolvedScriptRoot = Split-Path -Parent (Get-PSCallStack | Where-Object { $_.ScriptName } | Select-Object -First 1).ScriptName
+}
+if ([string]::IsNullOrEmpty($resolvedScriptRoot)) {
+    Write-Error "Cannot determine script directory: PSScriptRoot is empty and call stack provides no path."
+    return 1
+}
+
+$initPath = Join-Path -Path $resolvedScriptRoot -ChildPath 'common\setup\init.ps1'
+$diskPartitionsPath = Join-Path -Path $resolvedScriptRoot -ChildPath 'common\helpers\Get-Disk-Partitions-v2.ps1'
 
 if (-not (Test-Path -Path $initPath -PathType Leaf)) {
     Write-Error "Missing required dependency: $initPath"

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -12,20 +12,24 @@
     5. Exports healthy service keys (WindowsAzureGuestAgent, WindowsAzureTelemetryService, RdAgent)
        from the rescue VM and injects them into both ControlSets on the target hive.
     6. Verifies the ImagePath value was written correctly.
-    7. Backs up the existing WindowsAzure folder (WindowsazurefaultyGAbackup), then replaces
-       it with the full rescue VM WindowsAzure copy.
+    7. Copies the latest GuestAgent installation folder from the rescue VM to the attached disk.
     8. Releases handles and safely unloads the registry hive (with retry logic).
 
 .NOTES
     Name:    GA_offlinefixer.ps1
-    Version: 1.4
+    Version: 1.3
     Original Author: Daniel Munoz L (damunozl@microsoft.com)
     Modified by: Tony.Mocanu@Microsoft.com
 
 .VERSION
-    v1.4: [August 2026] - Temporarily resolves attached-disk identity collisions and restores the
+    v1.3: [August 2026] - Copies only the newest versioned GuestAgent installation folder.
+                        - Uses the WindowsAzureGuestAgent ImagePath folder as a fallback.
+                        - Preserves unrelated content in the target WindowsAzure folder.
+                        - Bounds file-copy retries to avoid client repair jobs appearing stuck.
+                        - Unloads only stale repair hives that actually exist.
+                        - Temporarily resolves attached-disk identity collisions and restores the
                         - exact original MBR signature or GPT GUID before returning.
-    v1.3: [August 2026] - Identifies and excludes the rescue VM OS disk by physical disk number.
+                        - Identifies and excludes the rescue VM OS disk by physical disk number.
                         - Requires an attached Microsoft virtual disk before service or disk disruption.
                         - Groups candidates by physical disk and validates winload plus the SYSTEM hive.
                         - Temporarily mounts unlettered Windows partition candidates and cleans them up.
@@ -279,15 +283,16 @@ try {
 
     # Clean up stale hive mounts from previous failed runs
     Log-Info "Cleaning up any stale registry hive mounts..."
-    foreach ($staleKey in @("BROKENSYSTEM", "BROKENSW")) {
-        & reg.exe unload "HKLM\$staleKey" 2>$null
-        & reg.exe unload "HKU\$staleKey" 2>$null
+    $staleHivePaths = @(
+        & reg.exe query HKLM 2>$null
+        & reg.exe query HKU 2>$null
+    ) | Where-Object {
+        $_ -match '^HKEY_LOCAL_MACHINE\\(?:BROKENSYSTEM|BROKENSW)(?:_[C-Z])?$' -or
+        $_ -match '^HKEY_USERS\\(?:BROKENSYSTEM|BROKENSYS|BROKENSW)(?:_[C-Z])?$'
     }
-    'C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z' | ForEach-Object {
-        & reg.exe unload "HKLM\BROKENSYSTEM_$_" 2>$null
-        & reg.exe unload "HKLM\BROKENSW_$_" 2>$null
-        & reg.exe unload "HKU\BROKENSYS_$_" 2>$null
-        & reg.exe unload "HKU\BROKENSW_$_" 2>$null
+    foreach ($staleHivePath in $staleHivePaths) {
+        Log-Info "Unloading stale repair hive $staleHivePath..."
+        & reg.exe unload $staleHivePath 2>$null
     }
 
     # Log any externally loaded hives (diagnostic)
@@ -670,44 +675,75 @@ try {
                 Log-Info "Verification Success on $($diskb):: ImagePath is now $afterImagePath"
             }
 
-            # Step 7 - Backup existing WindowsAzure folder and replace with rescue VM copy
+            # Step 7 - Copy only the current VM Agent installation folder.
             $sourcePath = "C:\WindowsAzure"
             $destPath = "$($diskb):\WindowsAzure"
             $backupPath = "$($diskb):\WindowsazurefaultyGAbackup"
 
-            $sourceFiles = @(Get-ChildItem -LiteralPath $sourcePath -File -Recurse -Force -ErrorAction Stop)
-            if ($sourceFiles.Count -eq 0) {
-                throw "Rescue VM source folder '$sourcePath' contains no files. Refusing to replace the target WindowsAzure folder."
+            $guestAgentCandidates = @(Get-ChildItem -LiteralPath $sourcePath -Directory -Force -ErrorAction Stop |
+                ForEach-Object {
+                    if ($_.Name -match '^GuestAgent_(.+)$') {
+                        $parsedVersion = $null
+                        if ([version]::TryParse($matches[1], [ref]$parsedVersion)) {
+                            [pscustomobject]@{
+                                Directory = $_
+                                Version = $parsedVersion
+                            }
+                        }
+                    }
+                } | Sort-Object Version -Descending)
+
+            $sourceAgentFolder = $null
+            if ($guestAgentCandidates.Count -gt 0) {
+                $sourceAgentFolder = $guestAgentCandidates[0].Directory
+                Log-Info "Selected latest VM Agent installation folder $($sourceAgentFolder.Name)."
+            }
+            else {
+                $expandedImagePath = [Environment]::ExpandEnvironmentVariables([string]$afterImagePath).Trim()
+                $imageExecutable = if ($expandedImagePath.StartsWith('"')) {
+                    ($expandedImagePath -split '"')[1]
+                }
+                else {
+                    ($expandedImagePath -split '\s+')[0]
+                }
+                if (-not [string]::IsNullOrWhiteSpace($imageExecutable)) {
+                    $imageFolder = Split-Path -Parent $imageExecutable
+                    if (Test-Path -LiteralPath $imageFolder -PathType Container) {
+                        $sourceAgentFolder = Get-Item -LiteralPath $imageFolder -ErrorAction Stop
+                        Log-Warning "No versioned GuestAgent folder was found; using ImagePath folder '$imageFolder'."
+                    }
+                }
             }
 
-            if (Test-Path $destPath) {
-                Log-Info "Backing up existing WindowsAzure folder on $($diskb): to WindowsazurefaultyGAbackup..."
-                if (-not (Test-Path $backupPath)) { $null = New-Item -Path $backupPath -ItemType Directory -Force }
-                $backupCopyResult = Invoke-CriticalCommand -Command "xcopy" -Arguments @("$destPath", "$backupPath", "/E", "/Y", "/H", "/Q") -Description "xcopy backup WindowsAzure ($diskb)"
-                if ($backupCopyResult.ExitCode -ge 2) {
-                    throw "Failed to back up existing WindowsAzure folder on $($diskb): $($backupCopyResult.Output -join '; ')"
-                }
-                if (-not (Get-ChildItem -LiteralPath $backupPath -File -Recurse -Force -ErrorAction SilentlyContinue | Select-Object -First 1)) {
-                    throw "WindowsAzure backup on $($diskb): contains no files after xcopy."
-                }
-                Log-Info "Removing old WindowsAzure folder on $($diskb):..."
-                Remove-Item $destPath -Recurse -Force -ErrorAction SilentlyContinue
+            if (-not $sourceAgentFolder) {
+                throw "No GuestAgent installation folder was found under '$sourcePath' or through ImagePath '$afterImagePath'."
             }
 
-            Log-Info "Copying full WindowsAzure folder from rescue VM to $($diskb):..."
             $null = New-Item -Path $destPath -ItemType Directory -Force
-            $restoreCopyResult = Invoke-CriticalCommand -Command "xcopy" -Arguments @("$sourcePath", "$destPath", "/E", "/Y", "/H", "/Q") -Description "xcopy restore WindowsAzure ($diskb)"
-            if ($restoreCopyResult.ExitCode -ge 2) {
-                throw "Failed to copy WindowsAzure folder to $($diskb): $($restoreCopyResult.Output -join '; ')"
-            }
-            if (-not (Get-ChildItem -LiteralPath $destPath -File -Recurse -Force -ErrorAction SilentlyContinue | Select-Object -First 1)) {
-                throw "Target WindowsAzure folder on $($diskb): contains no files after xcopy."
+            $targetAgentFolder = Join-Path $destPath $sourceAgentFolder.Name
+            if (Test-Path -LiteralPath $targetAgentFolder) {
+                $null = New-Item -Path $backupPath -ItemType Directory -Force
+                $targetAgentBackup = Join-Path $backupPath "$($sourceAgentFolder.Name)_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+                Log-Info "Moving existing $($sourceAgentFolder.Name) folder to $targetAgentBackup..."
+                Move-Item -LiteralPath $targetAgentFolder -Destination $targetAgentBackup -ErrorAction Stop
             }
 
-            # Remove Logs folder from copied content (not relevant to the target VM)
-            $logsPath = "$destPath\Logs"
-            if (Test-Path $logsPath) {
-                Remove-Item $logsPath -Recurse -Force -ErrorAction SilentlyContinue
+            Log-Info "Copying VM Agent folder $($sourceAgentFolder.FullName) to $targetAgentFolder..."
+            $restoreCopyResult = Invoke-CriticalCommand -Command "robocopy.exe" -Arguments @(
+                $sourceAgentFolder.FullName, $targetAgentFolder, '/E', '/COPY:DAT', '/DCOPY:DAT',
+                '/XJ', '/R:2', '/W:2', '/NFL', '/NDL', '/NJH', '/NJS', '/NP'
+            ) -Description "robocopy VM Agent $($sourceAgentFolder.Name) ($diskb)"
+            if ($restoreCopyResult.ExitCode -ge 8) {
+                throw "Failed to copy VM Agent folder to $($diskb): $($restoreCopyResult.Output -join '; ')"
+            }
+            $sourceAgentFile = Get-ChildItem -LiteralPath $sourceAgentFolder.FullName -File -Recurse -Force -ErrorAction Stop |
+                Select-Object -First 1
+            if (-not $sourceAgentFile) {
+                throw "Source VM Agent folder '$($sourceAgentFolder.FullName)' contains no files."
+            }
+            $relativeAgentFile = $sourceAgentFile.FullName.Substring($sourceAgentFolder.FullName.Length).TrimStart('\')
+            if (-not (Test-Path -LiteralPath (Join-Path $targetAgentFolder $relativeAgentFile) -PathType Leaf)) {
+                throw "VM Agent folder copy verification failed for '$relativeAgentFile'."
             }
 
             $diskChangesCompleted = $true

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -336,6 +336,12 @@ try {
 
             foreach ($service in $services) {
                 $regFile = "$($diskb):\$service.reg"
+                # Check if service key exists on the rescue VM before attempting export
+                $rescueServiceKey = "HKLM:\SYSTEM\CurrentControlSet\Services\$service"
+                if (-not (Test-Path -Path $rescueServiceKey)) {
+                    Log-Warning "Service '$service' not found on rescue VM registry - skipping (not present on this OS version)"
+                    continue
+                }
                 # Export healthy key from the current Rescue VM
                 $serviceExportResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("export", "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\$service", "$regFile", "/y") -Description "reg export service $service"
                 

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -5,9 +5,9 @@
 .DESCRIPTION
     This script runs from a rescue VM to repair a broken Azure Guest Agent on an attached OS disk.
     It performs the following steps:
-    1. Enumerates attached partitions via Get-Disk-Partitions to locate the faulty OS drive.
+    1. Enumerates partitions only on validated attached repair disks to locate the faulty OS drive.
     2. Loads the SYSTEM registry hive from the target disk into HKLM\BROKENSYSTEM.
-    3. Creates a full backup of the loaded hive to the disk root (regbackupbeforeGAchanges).
+    3. Creates and verifies a binary backup of the SYSTEM hive before loading it.
     4. Identifies the primary and backup ControlSets (001/002) from the Select key.
     5. Exports healthy service keys (WindowsAzureGuestAgent, WindowsAzureTelemetryService, RdAgent)
        from the rescue VM and injects them into both ControlSets on the target hive.
@@ -27,6 +27,7 @@
                         - Preserves unrelated content in the target WindowsAzure folder.
                         - Bounds file-copy retries to avoid client repair jobs appearing stuck.
                         - Unloads only stale repair hives that actually exist.
+                        - Avoids broad helper disk onlining and full registry text exports.
                         - Temporarily resolves attached-disk identity collisions and restores the
                         - exact original MBR signature or GPT GUID before returning.
                         - Identifies and excludes the rescue VM OS disk by physical disk number.
@@ -96,21 +97,12 @@ if ([string]::IsNullOrEmpty($resolvedScriptRoot)) {
 }
 
 $initPath = Join-Path -Path $resolvedScriptRoot -ChildPath 'common\setup\init.ps1'
-$diskPartitionsPath = Join-Path -Path $resolvedScriptRoot -ChildPath 'common\helpers\Get-Disk-Partitions-v2.ps1'
-
 if (-not (Test-Path -Path $initPath -PathType Leaf)) {
     Write-Error "Missing required dependency: $initPath"
     return 1
 }
 
 . $initPath
-
-if (-not (Test-Path -Path $diskPartitionsPath -PathType Leaf)) {
-    Log-Error "Missing required dependency: $diskPartitionsPath"
-    return $STATUS_ERROR
-}
-
-. $diskPartitionsPath
 
 # Log Configuration (desktop log standard)
 $desktopPath = [Environment]::GetFolderPath('Desktop')
@@ -443,23 +435,15 @@ try {
     Start-Sleep -Seconds 3
 
     # Step 1 - Find one validated Windows volume on each attached physical disk.
-    $partitionlist = @(Get-Disk-Partitions)
-    if ($partitionlist.Count -eq 0) {
-        throw 'Get-Disk-Partitions returned no partitions from Azure virtual disks.'
-    }
-
-    $targetDiskGroups = @($partitionlist |
-        Where-Object { [int]$_.DiskNumber -in $attachedDiskNumbers -and [int]$_.DiskNumber -ne $rescueDiskNum } |
-        Group-Object DiskNumber)
-    if ($targetDiskGroups.Count -eq 0) {
-        throw 'REPAIR-ONLY SCRIPT: The partition helper returned no partitions from an attached repair disk.'
-    }
-
     $targetWindowsVolumes = @()
     $efiGptType = 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'
-    foreach ($diskGroup in $targetDiskGroups) {
-        $diskNumber = [int]$diskGroup.Name
+    foreach ($diskNumber in $attachedDiskNumbers) {
         $diskPartitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction Stop)
+        if ($diskPartitions.Count -eq 0) {
+            Log-Warning "Attached repair Disk $diskNumber has no partitions."
+            $skippedCount++
+            continue
+        }
         $targetVolume = $null
 
         foreach ($candidate in @($diskPartitions | Where-Object { $_.DriveLetter -and $_.DriveLetter -ne [char]0 })) {
@@ -568,6 +552,25 @@ try {
         & reg.exe unload "HKLM\$hiveName" 2>$null
         [System.GC]::Collect()
         Start-Sleep -Seconds 1
+
+        try {
+            $backupFile = "$($diskb):\SYSTEM_before_GA_changes_$diskb.hiv"
+            Log-Info "Creating binary SYSTEM hive backup at $backupFile..."
+            Copy-Item -LiteralPath $hiveSource -Destination $backupFile -Force -ErrorAction Stop
+            $sourceHiveHash = (Get-FileHash -LiteralPath $hiveSource -Algorithm SHA256 -ErrorAction Stop).Hash
+            $backupHiveHash = (Get-FileHash -LiteralPath $backupFile -Algorithm SHA256 -ErrorAction Stop).Hash
+            if ($sourceHiveHash -ne $backupHiveHash) {
+                throw "Source and backup SHA256 hashes differ."
+            }
+            Log-Info "Binary SYSTEM hive backup created and verified for $($diskb):."
+        }
+        catch {
+            Log-Error "Failed to create and verify SYSTEM hive backup for $($diskb):: $($_.Exception.Message)"
+            $failedDisks += $diskb
+            $failedCount++
+            continue
+        }
+
         Log-Info "Loading SYSTEM hive from $($diskb): as $hiveName..."
         $loadResult = & reg.exe load "HKLM\$hiveName" $hiveSource 2>&1
         if ($LASTEXITCODE -ne 0) {
@@ -606,14 +609,6 @@ try {
         Start-Sleep -Seconds 2
 
         try {
-            # Step 3 - Create a full backup of the loaded hive before making changes
-            $backupFile = "$($diskb):\regbackupbeforeGAchanges_$diskb.reg"
-            Log-Info "Backing up full registry hive to $backupFile..."
-            $backupResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("export", "HKLM\$hiveName", $backupFile, "/y") -Description "reg export backup ($diskb)"
-            if ($backupResult.ExitCode -ne 0) {
-                throw "Registry backup failed for $($diskb): $($backupResult.Output -join '; ')"
-            }
-
             # Step 4 - Identify the primary and backup ControlSets from the Select key
             $selectPath = "Registry::HKLM\$hiveName\Select"
             $defaultSetID = (Get-ItemProperty -path $selectPath).default
@@ -812,7 +807,7 @@ try {
 
     if ($failedDisks.Count -gt 0) {
         Log-Error "Processing failed on disks: $($failedDisks -join ', ')"
-        throw "One or more disks failed final hive unload or copy-back validation: $($failedDisks -join ', '). Please review logs."
+        throw "One or more disks failed backup, hive processing, unload, or copy-back validation: $($failedDisks -join ', '). Please review logs."
     }
 
     Log-Info "Processing summary: processed=$processedCount skipped=$skippedCount failed=$failedCount changed=$changedCount"

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -18,18 +18,28 @@
 
 .NOTES
     Name:    GA_offlinefixer.ps1
-    Version: 1.4
+    Version: 1.3
     Original Author: Daniel Munoz L (damunozl@microsoft.com)
     Modified by: Tony.Mocanu@Microsoft.com
 
 .VERSION
-    v1.4: [May 2026] - Updated the script (current)
-                       - Aligned nested VM detection with win-LKGC guard pattern.
-                       - Skips Get-VM safely when Hyper-V module is unavailable.
-                       - Fixed relative path evaluation bug for helper files.
-    v1.3: [May 2026] - Updated the script again (current)
-                       - Fixed breaking exception when the Hyper-V module is not installed on the host.
-                       - Added explicit checking via Get-Module before executing nested VM discovery.
+    v1.3: [August 2026] - Identifies and excludes the rescue VM OS disk by physical disk number.
+                        - Requires an attached Microsoft virtual disk before service or disk disruption.
+                        - Groups candidates by physical disk and validates winload plus the SYSTEM hive.
+                        - Temporarily mounts unlettered Windows partition candidates and cleans them up.
+                        - Refuses collision-offlined attached disks rather than changing disk identities.
+                        - Restores and verifies the original WSearch service state.
+                        - No longer stops Windows Defender on the rescue VM.
+                        - Makes fallback hive copy-back part of per-disk success accounting.
+                        - Removes the unnecessary Azure Instance Metadata Service request.
+                        - Validates WindowsAzure xcopy source and destination content.
+                        - Updated the script (current)
+                        - Aligned nested VM detection with win-LKGC guard pattern.
+                        - Skips Get-VM safely when Hyper-V module is unavailable.
+                        - Fixed relative path evaluation bug for helper files.
+                        - Updated the script again (current)
+                        - Fixed breaking exception when the Hyper-V module is not installed on the host.
+                        - Added explicit checking via Get-Module before executing nested VM discovery.
     v1.2: [May 2026] - Updated the script
                        - Included advanced Gen2 unlettered EFI fallback and dynamic drive-letter assignment.
     v0.1: Initial commit. This was the version 1.0 of the script.
@@ -176,6 +186,35 @@ function Invoke-CriticalCommand {
     }
 }
 
+function Get-AvailableTempDriveLetter {
+    $usedLetters = @(Get-Volume -ErrorAction SilentlyContinue |
+        Where-Object { $_.DriveLetter } |
+        Select-Object -ExpandProperty DriveLetter)
+
+    foreach ($letter in @('Z','Y','X','W','V','U','T','S','R','Q')) {
+        if ($letter -notin $usedLetters -and -not (Test-Path -LiteralPath "${letter}:\")) {
+            return $letter
+        }
+    }
+
+    return $null
+}
+
+function Invoke-GaDiskPart {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Commands,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Operation
+    )
+
+    $output = $Commands | diskpart.exe 2>&1
+    foreach ($line in @($output)) {
+        if ($line) { Log-Info "diskpart $Operation :: $line" }
+    }
+}
+
 # Status Tracking
 $script_final_status = $STATUS_ERROR
 $serviceStates = @{}  # Track original service states for restoration
@@ -183,12 +222,11 @@ $processedCount = 0
 $skippedCount = 0
 $failedCount = 0
 $changedCount = 0
+$temporaryOsMounts = @()
 
-# VM Metadata Capture for Telemetry
+# Local execution context for diagnostic logging. No data is transmitted off-box.
 $vmMetadata = @{
     OSVersion = $null
-    VMSku = $null
-    Region = $null
     HostName = $env:COMPUTERNAME
 }
 
@@ -204,24 +242,8 @@ try {
         Log-Warning "OS metadata discovery failed: $($_.Exception.Message)"
     }
 
-    # Attempt to capture Azure VM metadata from Instance Metadata Service
-    try {
-        $imdHeaders = @{Metadata = $true }
-        $imdUri = "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
-        $imdResponse = Invoke-RestMethod -Uri $imdUri -Headers $imdHeaders -ErrorAction SilentlyContinue
-        if ($imdResponse) {
-            $vmMetadata.VMSku = $imdResponse.compute.vmSize
-            $vmMetadata.Region = $imdResponse.compute.location
-        }
-    }
-    catch {
-        Log-Warning "Instance metadata discovery failed: $($_.Exception.Message)"
-    }
-
     # Create metadata context string for logging
     $metadataContext = "[Host:$($vmMetadata.HostName)"
-    if ($vmMetadata.Region) { $metadataContext += " Region:$($vmMetadata.Region)" }
-    if ($vmMetadata.VMSku) { $metadataContext += " SKU:$($vmMetadata.VMSku)" }
     if ($vmMetadata.OSVersion) { $metadataContext += " OS:$($vmMetadata.OSVersion)" }
     $metadataContext += "]"
 
@@ -270,62 +292,192 @@ try {
     if ($hklmKeys) { Log-Info "Loaded HKLM hives: $($hklmKeys -join ', ')" }
     if ($hkuKeys) { Log-Info "Loaded HKU hives: $($hkuKeys -join ', ')" }
 
-    # Stop services that scan/index attached disks and lock hive files
-    Log-Info "Stopping services that may lock disk files..."
-    foreach ($svc in @('WSearch', 'WinDefend')) {
+    # Identify the rescue OS disk before stopping services or touching any disk.
+    $rescueDrive = $env:SystemDrive -replace ':', ''
+    $rescueOsPartition = Get-Partition -DriveLetter $rescueDrive -ErrorAction Stop | Select-Object -First 1
+    if ($null -eq $rescueOsPartition -or $null -eq $rescueOsPartition.DiskNumber) {
+        throw "CRITICAL SAFETY CHECK FAILED: Could not identify the rescue VM OS disk from $($env:SystemDrive)."
+    }
+    $rescueDiskNum = [int]$rescueOsPartition.DiskNumber
+    Log-Info "Rescue VM OS disk identified as physical Disk $rescueDiskNum."
+
+    $azureVirtualDiskNumbers = @(Get-CimInstance -ClassName Win32_DiskDrive -ErrorAction Stop |
+        Where-Object { $_.Model -like 'Microsoft Virtual Disk*' } |
+        ForEach-Object { [int]$_.Index })
+    $attachedDisks = @(Get-Disk -ErrorAction Stop | Where-Object {
+        $_.Number -in $azureVirtualDiskNumbers -and $_.Number -ne $rescueDiskNum
+    })
+    if ($attachedDisks.Count -eq 0) {
+        throw 'REPAIR-ONLY SCRIPT: No attached Microsoft virtual disk was found. No service or disk changes were attempted.'
+    }
+
+    $collisionDisks = @($attachedDisks | Where-Object {
+        $_.IsOffline -and [string]$_.OfflineReason -eq 'Collision'
+    })
+    if ($collisionDisks.Count -gt 0) {
+        throw "Attached disk identity collision detected on Disk(s) $($collisionDisks.Number -join ', '). Refusing to change disk identities; use a non-colliding rescue VM or matching-generation nested repair."
+    }
+    $attachedDiskNumbers = @($attachedDisks | Select-Object -ExpandProperty Number)
+    Log-Info "Attached repair candidate disk numbers: $($attachedDiskNumbers -join ', ')"
+
+    # Pause indexing while attached hives are modified. Defender remains running.
+    Log-Info "Stopping Windows Search temporarily to reduce attached-disk file locks..."
+    foreach ($svc in @('WSearch')) {
         try {
-            $svcObj = Get-Service -Name $svc -ErrorAction SilentlyContinue
+            $svcObj = Get-Service -Name $svc -ErrorAction Stop
             if ($svcObj) {
-                $serviceStates[$svc] = $svcObj.Status
+                $serviceStates[$svc] = [string]$svcObj.Status
                 Log-Info "Captured original state of $svc : $($svcObj.Status)"
-                Stop-Service -Name $svc -Force -ErrorAction SilentlyContinue
+                if ($svcObj.Status -ne 'Stopped') {
+                    Stop-Service -Name $svc -ErrorAction Stop
+                    $svcObj.WaitForStatus('Stopped', [TimeSpan]::FromSeconds(30))
+                    Log-Info "$svc stopped temporarily."
+                }
             }
         }
         catch {
-            Log-Warning "Failed to capture state of $svc : $($_.Exception.Message)"
+            throw "Could not safely capture or stop $svc before disk repair: $($_.Exception.Message)"
         }
     }
 
     [System.GC]::Collect()
     [System.GC]::WaitForPendingFinalizers()
 
-    # Cycle non-system disks offline/online to release ALL file handles
+    # Cycle only verified attached Microsoft virtual disks to release file handles.
     Log-Info "Cycling attached disks offline/online to release file locks..."
-    $rescueDiskNum = (Get-Partition -DriveLetter ($env:SystemDrive -replace ':', '') -ErrorAction SilentlyContinue).DiskNumber
-    Get-Disk | Where-Object { $_.Number -ne $rescueDiskNum -and $_.OperationalStatus -eq 'Online' } | ForEach-Object {
+    $attachedDisks | Where-Object { -not $_.IsOffline } | ForEach-Object {
         $dnum = $_.Number
         Log-Info "Cycling disk $dnum offline/online..."
-        Set-Disk -Number $dnum -IsOffline $true -ErrorAction SilentlyContinue
+        Set-Disk -Number $dnum -IsOffline $true -ErrorAction Stop
         Start-Sleep -Seconds 2
-        Set-Disk -Number $dnum -IsOffline $false -ErrorAction SilentlyContinue
-        Set-Disk -Number $dnum -IsReadOnly $false -ErrorAction SilentlyContinue
+        Set-Disk -Number $dnum -IsOffline $false -ErrorAction Stop
+        Set-Disk -Number $dnum -IsReadOnly $false -ErrorAction Stop
     }
     Start-Sleep -Seconds 3
 
-    # Step 1 - Enumerate partitions to locate the faulty OS drive(s)
-    $partitionlist = Get-Disk-Partitions
-    $rescueDrive = $env:SystemDrive -replace ':', ''
-    $fixedDisks = @()
-    $failedDisks = @()  # Track disks that failed copy-back
+    # Step 1 - Find one validated Windows volume on each attached physical disk.
+    $partitionlist = @(Get-Disk-Partitions)
+    if ($partitionlist.Count -eq 0) {
+        throw 'Get-Disk-Partitions returned no partitions from Azure virtual disks.'
+    }
 
-    foreach ($partition in $partitionlist) {
-        $processedCount++
-        if (-not $partition.DriveLetter) { $skippedCount++; continue }
-        # Skip the rescue VM's own OS drive (its hives are locked by the running OS)
-        if ($partition.DriveLetter -eq $rescueDrive) {
-            Log-Info "Skipping rescue VM system drive $rescueDrive (own OS)"
-            $skippedCount++
-            continue
+    $targetDiskGroups = @($partitionlist |
+        Where-Object { [int]$_.DiskNumber -in $attachedDiskNumbers -and [int]$_.DiskNumber -ne $rescueDiskNum } |
+        Group-Object DiskNumber)
+    if ($targetDiskGroups.Count -eq 0) {
+        throw 'REPAIR-ONLY SCRIPT: The partition helper returned no partitions from an attached repair disk.'
+    }
+
+    $targetWindowsVolumes = @()
+    $efiGptType = 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'
+    foreach ($diskGroup in $targetDiskGroups) {
+        $diskNumber = [int]$diskGroup.Name
+        $diskPartitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction Stop)
+        $targetVolume = $null
+
+        foreach ($candidate in @($diskPartitions | Where-Object { $_.DriveLetter -and $_.DriveLetter -ne [char]0 })) {
+            $candidateLetter = [string]$candidate.DriveLetter
+            $winloadExe = "${candidateLetter}:\Windows\System32\winload.exe"
+            $winloadEfi = "${candidateLetter}:\Windows\System32\winload.efi"
+            $systemHive = "${candidateLetter}:\Windows\System32\config\SYSTEM"
+            if (((Test-Path -LiteralPath $winloadExe -PathType Leaf) -or
+                    (Test-Path -LiteralPath $winloadEfi -PathType Leaf)) -and
+                (Test-Path -LiteralPath $systemHive -PathType Leaf)) {
+                $targetVolume = [pscustomobject]@{
+                    DiskNumber = $diskNumber
+                    PartitionNumber = [int]$candidate.PartitionNumber
+                    DriveLetter = $candidateLetter
+                    TemporaryMount = $false
+                }
+                break
+            }
         }
-        if (-not (Test-Path -Path "$($partition.DriveLetter):\Windows")) { $skippedCount++; continue }
 
-        $diskb = $partition.DriveLetter
-        Log-Info "Target OS disk found on letter: $($diskb):"
+        if (-not $targetVolume) {
+            $unletteredCandidates = @($diskPartitions | Where-Object {
+                (-not $_.DriveLetter -or $_.DriveLetter -eq [char]0) -and
+                (([string]$_.GptType).Trim().Trim('{', '}') -ine $efiGptType)
+            } | Sort-Object Size -Descending)
+
+            foreach ($candidate in $unletteredCandidates) {
+                $candidateLetter = Get-AvailableTempDriveLetter
+                if (-not $candidateLetter) {
+                    throw "No temporary drive letter is available to inspect unlettered partitions on Disk $diskNumber."
+                }
+
+                Invoke-GaDiskPart -Operation 'os-assign' -Commands @(
+                    "select disk $diskNumber"
+                    "select partition $($candidate.PartitionNumber)"
+                    "assign letter=$candidateLetter"
+                )
+                Start-Sleep -Seconds 2
+
+                $mounted = Test-Path -LiteralPath "${candidateLetter}:\" -PathType Container
+                $probeMount = [pscustomobject]@{
+                    DiskNumber = $diskNumber
+                    PartitionNumber = [int]$candidate.PartitionNumber
+                    DriveLetter = $candidateLetter
+                    TemporaryMount = $true
+                }
+                if ($mounted) {
+                    $temporaryOsMounts += $probeMount
+                }
+                $winloadExe = "${candidateLetter}:\Windows\System32\winload.exe"
+                $winloadEfi = "${candidateLetter}:\Windows\System32\winload.efi"
+                $systemHive = "${candidateLetter}:\Windows\System32\config\SYSTEM"
+                if ($mounted -and
+                    ((Test-Path -LiteralPath $winloadExe -PathType Leaf) -or
+                        (Test-Path -LiteralPath $winloadEfi -PathType Leaf)) -and
+                    (Test-Path -LiteralPath $systemHive -PathType Leaf)) {
+                    $targetVolume = $probeMount
+                    break
+                }
+
+                Invoke-GaDiskPart -Operation 'os-probe-remove' -Commands @(
+                    "select disk $diskNumber"
+                    "select partition $($candidate.PartitionNumber)"
+                    "remove letter=$candidateLetter noerr"
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                $probePartition = Get-Partition -DiskNumber $diskNumber -PartitionNumber $candidate.PartitionNumber -ErrorAction Stop
+                if ([string]$probePartition.DriveLetter -ieq $candidateLetter) {
+                    throw "Temporary letter ${candidateLetter}: could not be removed from Disk $diskNumber Partition $($candidate.PartitionNumber)."
+                }
+                $temporaryOsMounts = @($temporaryOsMounts | Where-Object {
+                    -not ($_.DiskNumber -eq $diskNumber -and
+                        $_.PartitionNumber -eq $candidate.PartitionNumber -and
+                        $_.DriveLetter -ieq $candidateLetter)
+                })
+            }
+        }
+
+        if ($targetVolume) {
+            $targetWindowsVolumes += $targetVolume
+            Log-Info "Validated Windows target on Disk $diskNumber Partition $($targetVolume.PartitionNumber) at $($targetVolume.DriveLetter):."
+        }
+        else {
+            $skippedCount++
+            Log-Warning "Disk $diskNumber has no partition containing both a Windows loader and SYSTEM hive."
+        }
+    }
+
+    if ($targetWindowsVolumes.Count -eq 0) {
+        throw 'No attached Windows OS disk passed loader and SYSTEM hive validation.'
+    }
+
+    $fixedDisks = @()
+    $failedDisks = @()
+
+    foreach ($targetVolume in $targetWindowsVolumes) {
+        $processedCount++
+        $diskb = [string]$targetVolume.DriveLetter
+        Log-Info "Processing validated target Disk $($targetVolume.DiskNumber) on letter $($diskb):"
         # Step 2 - Load the SYSTEM registry hive from the target disk
         $hiveName = "BROKENSYSTEM_$diskb"
         $hiveSource = "$($diskb):\Windows\System32\config\SYSTEM"
         $hiveCopy = $null
         $diskProcessedSuccessfully = $false
+        $diskChangesCompleted = $false
         & reg.exe unload "HKLM\$hiveName" 2>$null
         [System.GC]::Collect()
         Start-Sleep -Seconds 1
@@ -358,8 +510,10 @@ try {
             }
         }
         if ($LASTEXITCODE -ne 0) {
-            Log-Warning "Failed to load Registry Hive from $($diskb): $loadResult - skipping this partition"
+            Log-Error "Failed to load Registry Hive from $($diskb): $loadResult"
             if ($hiveCopy -and (Test-Path $hiveCopy)) { Remove-Item $hiveCopy -Force -ErrorAction SilentlyContinue }
+            $failedDisks += $diskb
+            $failedCount++
             continue
         }
         Start-Sleep -Seconds 2
@@ -393,10 +547,10 @@ try {
                 }
                 # Export healthy key from the current Rescue VM
                 $serviceExportResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("export", "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\$service", "$regFile", "/y") -Description "reg export service $service"
-                
+
                 if ($serviceExportResult.ExitCode -eq 0 -and (Test-Path $regFile)) {
                     $originalContent = Get-Content $regFile
-                    
+
                     # Update Primary Set
                     Log-Info "Updating $service in $primarySet on $($diskb):..."
                     $content = $originalContent -replace 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet', "HKEY_LOCAL_MACHINE\$hiveName\$primarySet"
@@ -439,12 +593,20 @@ try {
             $destPath = "$($diskb):\WindowsAzure"
             $backupPath = "$($diskb):\WindowsazurefaultyGAbackup"
 
+            $sourceFiles = @(Get-ChildItem -LiteralPath $sourcePath -File -Recurse -Force -ErrorAction Stop)
+            if ($sourceFiles.Count -eq 0) {
+                throw "Rescue VM source folder '$sourcePath' contains no files. Refusing to replace the target WindowsAzure folder."
+            }
+
             if (Test-Path $destPath) {
                 Log-Info "Backing up existing WindowsAzure folder on $($diskb): to WindowsazurefaultyGAbackup..."
                 if (-not (Test-Path $backupPath)) { $null = New-Item -Path $backupPath -ItemType Directory -Force }
                 $backupCopyResult = Invoke-CriticalCommand -Command "xcopy" -Arguments @("$destPath", "$backupPath", "/E", "/Y", "/H", "/Q") -Description "xcopy backup WindowsAzure ($diskb)"
                 if ($backupCopyResult.ExitCode -ge 2) {
                     throw "Failed to back up existing WindowsAzure folder on $($diskb): $($backupCopyResult.Output -join '; ')"
+                }
+                if (-not (Get-ChildItem -LiteralPath $backupPath -File -Recurse -Force -ErrorAction SilentlyContinue | Select-Object -First 1)) {
+                    throw "WindowsAzure backup on $($diskb): contains no files after xcopy."
                 }
                 Log-Info "Removing old WindowsAzure folder on $($diskb):..."
                 Remove-Item $destPath -Recurse -Force -ErrorAction SilentlyContinue
@@ -456,6 +618,9 @@ try {
             if ($restoreCopyResult.ExitCode -ge 2) {
                 throw "Failed to copy WindowsAzure folder to $($diskb): $($restoreCopyResult.Output -join '; ')"
             }
+            if (-not (Get-ChildItem -LiteralPath $destPath -File -Recurse -Force -ErrorAction SilentlyContinue | Select-Object -First 1)) {
+                throw "Target WindowsAzure folder on $($diskb): contains no files after xcopy."
+            }
 
             # Remove Logs folder from copied content (not relevant to the target VM)
             $logsPath = "$destPath\Logs"
@@ -463,14 +628,11 @@ try {
                 Remove-Item $logsPath -Recurse -Force -ErrorAction SilentlyContinue
             }
 
-            $diskProcessedSuccessfully = $true
-            $fixedDisks += $diskb
-            $changedCount++
+            $diskChangesCompleted = $true
         }
         catch {
             Log-Error "Failed to process $($diskb):: $($_.Exception.Message)"
             $diskProcessedSuccessfully = $false
-            $failedCount++
         }
         finally {
             # Step 8 - Release handles and safely unload the registry hive
@@ -487,7 +649,8 @@ try {
                 Start-Sleep -Seconds 5
             }
             if (-not $unloaded) {
-                Log-Warning "Could not unload $hiveName hive - may need manual cleanup"
+                Log-Error "Could not unload $hiveName hive - marking Disk $diskb as failed."
+                $failedDisks += $diskb
             }
 
             # If we used the copy fallback, copy the modified hive back to the original location
@@ -495,36 +658,48 @@ try {
                 if ($unloaded) {
                     Log-Info "Copying modified hive back to $hiveSource..."
                     try {
+                        $expectedHiveHash = (Get-FileHash -LiteralPath $hiveCopy -Algorithm SHA256 -ErrorAction Stop).Hash
                         Copy-Item -Path $hiveCopy -Destination $hiveSource -Force -ErrorAction Stop
-                        Log-Info "Successfully copied modified hive back to $($diskb):"
+                        $actualHiveHash = (Get-FileHash -LiteralPath $hiveSource -Algorithm SHA256 -ErrorAction Stop).Hash
+                        if ($actualHiveHash -ne $expectedHiveHash) {
+                            throw "Hive copy-back verification failed: source and destination SHA256 hashes differ."
+                        }
+                        Log-Info "Successfully copied and verified the modified hive back to $($diskb):"
                     }
                     catch {
                         Log-Error "Failed to copy modified hive back to $($diskb):: $($_.Exception.Message)"
-                        $diskProcessedSuccessfully = $false
                         $failedDisks += $diskb
                     }
+                }
+                else {
+                    Log-Error "Modified fallback hive for $($diskb): cannot be copied back because $hiveName did not unload."
+                    $failedDisks += $diskb
                 }
                 Remove-Item $hiveCopy -Force -ErrorAction SilentlyContinue
             }
 
-            # Remove from fixed list if processing failed
-            if (-not $diskProcessedSuccessfully) {
-                $fixedDisks = @($fixedDisks | Where-Object { $_ -ne $diskb })
+            $diskProcessedSuccessfully = $diskChangesCompleted -and ($diskb -notin $failedDisks)
+            if ($diskProcessedSuccessfully) {
+                $fixedDisks += $diskb
+                $changedCount++
+            }
+            else {
                 if ($diskb -notin $failedDisks) {
                     $failedDisks += $diskb
                 }
+                $failedCount++
             }
         }
     }
 
     if ($failedDisks.Count -gt 0) {
-        Log-Error "Copy-back operation failed on disks: $($failedDisks -join ', ')"
-        throw "Hive copy-back failed on one or more disks: $($failedDisks -join ', '). Please review logs."
+        Log-Error "Processing failed on disks: $($failedDisks -join ', ')"
+        throw "One or more disks failed final hive unload or copy-back validation: $($failedDisks -join ', '). Please review logs."
     }
 
     Log-Info "Processing summary: processed=$processedCount skipped=$skippedCount failed=$failedCount changed=$changedCount"
     if ($fixedDisks.Count -gt 0) {
-        Log-Output "VMAgent Fix completed and verified successfully on drives: $($fixedDisks -join ', ') | Metadata: Host=$($vmMetadata.HostName), Region=$($vmMetadata.Region), SKU=$($vmMetadata.VMSku)"
+        Log-Output "VMAgent Fix completed and verified successfully on drives: $($fixedDisks -join ', ') | Host=$($vmMetadata.HostName)"
         $script_final_status = $STATUS_SUCCESS
     }
     else {
@@ -538,9 +713,30 @@ catch {
     $script_final_status = $STATUS_ERROR
 }
 finally {
-    # Log execution metadata for Application Insights correlation
-    if ($vmMetadata.Region -or $vmMetadata.VMSku -or $vmMetadata.OSVersion) {
-        Log-Info "Execution Context - Host: $($vmMetadata.HostName), Region: $($vmMetadata.Region), SKU: $($vmMetadata.VMSku), OS: $($vmMetadata.OSVersion)"
+    foreach ($mount in @($temporaryOsMounts | Sort-Object DiskNumber, PartitionNumber -Unique)) {
+        try {
+            Log-Info "Removing temporary OS letter $($mount.DriveLetter): from Disk $($mount.DiskNumber) Partition $($mount.PartitionNumber)."
+            Invoke-GaDiskPart -Operation 'os-cleanup' -Commands @(
+                "select disk $($mount.DiskNumber)"
+                "select partition $($mount.PartitionNumber)"
+                "remove letter=$($mount.DriveLetter) noerr"
+            )
+            Update-HostStorageCache -ErrorAction SilentlyContinue
+            $cleanedPartition = Get-Partition -DiskNumber $mount.DiskNumber -PartitionNumber $mount.PartitionNumber -ErrorAction Stop
+            if ([string]$cleanedPartition.DriveLetter -ieq [string]$mount.DriveLetter) {
+                throw "Temporary drive letter removal could not be verified."
+            }
+            Log-Info "Temporary OS letter $($mount.DriveLetter): removal verified."
+        }
+        catch {
+            Log-Error "Failed to remove temporary OS letter $($mount.DriveLetter): $($_.Exception.Message)"
+            $script_final_status = $STATUS_ERROR
+        }
+    }
+
+    # Log local execution context only; this script performs no telemetry upload.
+    if ($vmMetadata.OSVersion) {
+        Log-Info "Execution Context - Host: $($vmMetadata.HostName), OS: $($vmMetadata.OSVersion)"
     }
 
     # Restore original service states
@@ -550,12 +746,22 @@ finally {
             $originalState = $serviceStates[$svc]
             Log-Info "Restoring $svc to state: $originalState"
             if ($originalState -eq 'Running') {
-                Start-Service -Name $svc -ErrorAction SilentlyContinue
+                Start-Service -Name $svc -ErrorAction Stop
+                $restoredService = Get-Service -Name $svc -ErrorAction Stop
+                $restoredService.WaitForStatus('Running', [TimeSpan]::FromSeconds(30))
             }
-            # If original state was Stopped, service remains stopped (already stopped)
+            elseif ($originalState -eq 'Stopped') {
+                Stop-Service -Name $svc -Force -ErrorAction Stop
+            }
+            $restoredState = [string](Get-Service -Name $svc -ErrorAction Stop).Status
+            if ($restoredState -ne $originalState) {
+                throw "$svc restoration verification failed: expected $originalState, found $restoredState."
+            }
+            Log-Info "$svc restored and verified in state $restoredState."
         }
         catch {
-            Log-Warning "Failed to restore $svc to state $originalState : $($_.Exception.Message)"
+            Log-Error "Failed to restore $svc to state $originalState : $($_.Exception.Message)"
+            $script_final_status = $STATUS_ERROR
         }
     }
 

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -67,21 +67,23 @@ Get-ChildItem F:\WindowsAzure\GuestAgent_*
     Expected: One or more GuestAgent folders present.
 #>
 
-# Initialization
-$initScriptPath = Join-Path $PSScriptRoot "common\setup\init.ps1"
-$diskHelperPath = Join-Path $PSScriptRoot "common\helpers\Get-Disk-Partitions-v2.ps1"
+# Initialization (path-validated)
+$initPath = Join-Path -Path $PSScriptRoot -ChildPath 'common\setup\init.ps1'
+$diskPartitionsPath = Join-Path -Path $PSScriptRoot -ChildPath 'common\helpers\Get-Disk-Partitions-v2.ps1'
 
-if (-not (Test-Path -Path $initScriptPath)) {
-    Write-Error "Required helper script not found: $initScriptPath"
-    return 1
-}
-if (-not (Test-Path -Path $diskHelperPath)) {
-    Write-Error "Required helper script not found: $diskHelperPath"
+if (-not (Test-Path -Path $initPath -PathType Leaf)) {
+    Write-Error "Missing required dependency: $initPath"
     return 1
 }
 
-. $initScriptPath
-. $diskHelperPath
+. $initPath
+
+if (-not (Test-Path -Path $diskPartitionsPath -PathType Leaf)) {
+    Log-Error "Missing required dependency: $diskPartitionsPath"
+    return $STATUS_ERROR
+}
+
+. $diskPartitionsPath
 
 # Log Configuration
 $logDir = [Environment]::GetFolderPath('Desktop')

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -53,7 +53,7 @@ Get-ChildItem F:\WindowsAzure\GuestAgent_* | Rename-Item -NewName { $_.Name + '_
 
 .VERIFICATION
     1. Check the log file for success:
-Get-ChildItem "C:\WindowsAzure\Logs\Plugins\Microsoft.Compute.CustomScriptExtension\GA_offlinefixer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1 | Get-Content
+Get-ChildItem "$env:USERPROFILE\Desktop\GA_offlinefixer_*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1 | Get-Content
     Expected: "VMAgent Fix completed and verified successfully." and return code 0 ($STATUS_SUCCESS).
     2. Reload the SYSTEM hive and verify agent service keys exist (replace F with disk letter):
 reg load HKLM\VERIFY F:\Windows\System32\config\SYSTEM
@@ -67,18 +67,56 @@ Get-ChildItem F:\WindowsAzure\GuestAgent_*
 #>
 
 # Initialization
-. .\src\windows\common\setup\init.ps1
-. .\src\windows\common\helpers\Get-Disk-Partitions-v2.ps1
+$initScriptPath = Join-Path $PSScriptRoot "src\windows\common\setup\init.ps1"
+$diskHelperPath = Join-Path $PSScriptRoot "src\windows\common\helpers\Get-Disk-Partitions-v2.ps1"
+
+if (-not (Test-Path -Path $initScriptPath)) {
+    Write-Error "Required helper script not found: $initScriptPath"
+    return 1
+}
+if (-not (Test-Path -Path $diskHelperPath)) {
+    Write-Error "Required helper script not found: $diskHelperPath"
+    return 1
+}
+
+. $initScriptPath
+. $diskHelperPath
 
 # Log Configuration
-$logDir = "C:\WindowsAzure\Logs\Plugins\Microsoft.Compute.CustomScriptExtension"
+$logDir = [Environment]::GetFolderPath('Desktop')
 if (-not (Test-Path $logDir)) { $null = New-Item -ItemType Directory -Path $logDir -Force }
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
 $logFile = "$logDir\GA_offlinefixer_$timestamp.log"
 
+function Invoke-CriticalCommand {
+    param(
+        [Parameter(Mandatory=$true)][string]$Command,
+        [Parameter(Mandatory=$true)][string[]]$Arguments,
+        [Parameter(Mandatory=$true)][string]$Description
+    )
+
+    $output = & $Command @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+
+    if ($output) {
+        foreach ($line in @($output)) {
+            Log-Info "$Description :: $line"
+        }
+    }
+
+    return [PSCustomObject]@{
+        ExitCode = $exitCode
+        Output = @($output)
+    }
+}
+
 # Status Tracking
 $script_final_status = $STATUS_ERROR
 $serviceStates = @{}  # Track original service states for restoration
+$processedCount = 0
+$skippedCount = 0
+$failedCount = 0
+$changedCount = 0
 
 # VM Metadata Capture for Telemetry
 $vmMetadata = @{
@@ -91,13 +129,13 @@ $vmMetadata = @{
 try {
     # Capture OS version from rescue VM
     try {
-        $osInfo = Get-WmiObject -Class Win32_OperatingSystem -ErrorAction SilentlyContinue
+        $osInfo = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction SilentlyContinue
         if ($osInfo) {
             $vmMetadata.OSVersion = "$($osInfo.Caption) $($osInfo.Version)"
         }
     }
     catch {
-        # Silent fail - metadata is optional
+        Log-Warning "OS metadata discovery failed: $($_.Exception.Message)"
     }
 
     # Attempt to capture Azure VM metadata from Instance Metadata Service
@@ -111,7 +149,7 @@ try {
         }
     }
     catch {
-        # Silent fail - metadata is optional, may not be available in all environments
+        Log-Warning "Instance metadata discovery failed: $($_.Exception.Message)"
     }
 
     # Create metadata context string for logging
@@ -121,8 +159,8 @@ try {
     if ($vmMetadata.OSVersion) { $metadataContext += " OS:$($vmMetadata.OSVersion)" }
     $metadataContext += "]"
 
-    Log-Info "Starting VMAgent Offline Fixer... $metadataContext" | Tee-Object -FilePath $logFile -Append
-
+    Log-Info "Starting VMAgent Offline Fixer... $metadataContext"
+    Log-Info "Desktop log file path: $logFile"
     # Stop nested guest VM if running
     # Guard Get-VM if Hyper-V module is not available
     try {
@@ -130,25 +168,25 @@ try {
             $guestHyperVVirtualMachine = Get-VM -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
             if ($guestHyperVVirtualMachine) {
                 if ($guestHyperVVirtualMachine.State -eq 'Running') {
-                    Log-Info "Stopping nested guest VM $($guestHyperVVirtualMachine.VMName)" | Tee-Object -FilePath $logFile -Append
+                    Log-Info "Stopping nested guest VM $($guestHyperVVirtualMachine.VMName)"
                     try {
                         Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
                     }
                     catch {
-                        Log-Warning "Failed to stop nested guest VM, will continue but may have limited success" | Tee-Object -FilePath $logFile -Append
+                        Log-Warning "Failed to stop nested guest VM, will continue but may have limited success"
                     }
                 }
             }
         } else {
-            Log-Info "Hyper-V PowerShell module is not available on this host. Skipping nested VM validation." | Tee-Object -FilePath $logFile -Append
+            Log-Info "Hyper-V PowerShell module is not available on this host. Skipping nested VM validation."
         }
     }
     catch {
-        Log-Warning "Nested VM check encountered an error but will be skipped: $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+        Log-Warning "Nested VM check encountered an error but will be skipped: $($_.Exception.Message)"
     }
 
     # Clean up stale hive mounts from previous failed runs
-    Log-Info "Cleaning up any stale registry hive mounts..." | Tee-Object -FilePath $logFile -Append
+    Log-Info "Cleaning up any stale registry hive mounts..."
     foreach ($staleKey in @("BROKENSYSTEM", "BROKENSW")) {
         & reg.exe unload "HKLM\$staleKey" 2>$null
         & reg.exe unload "HKU\$staleKey" 2>$null
@@ -163,22 +201,22 @@ try {
     # Log any externally loaded hives (diagnostic)
     $hklmKeys = & reg.exe query HKLM 2>$null | Where-Object { $_ -match 'BROKEN|OFFLINE|SYSTEM_' }
     $hkuKeys = & reg.exe query HKU 2>$null | Where-Object { $_ -match 'BROKEN|OFFLINE|SYSTEM_' }
-    if ($hklmKeys) { Log-Info "Loaded HKLM hives: $($hklmKeys -join ', ')" | Tee-Object -FilePath $logFile -Append }
-    if ($hkuKeys) { Log-Info "Loaded HKU hives: $($hkuKeys -join ', ')" | Tee-Object -FilePath $logFile -Append }
+    if ($hklmKeys) { Log-Info "Loaded HKLM hives: $($hklmKeys -join ', ')" }
+    if ($hkuKeys) { Log-Info "Loaded HKU hives: $($hkuKeys -join ', ')" }
 
     # Stop services that scan/index attached disks and lock hive files
-    Log-Info "Stopping services that may lock disk files..." | Tee-Object -FilePath $logFile -Append
+    Log-Info "Stopping services that may lock disk files..."
     foreach ($svc in @('WSearch', 'WinDefend')) {
         try {
             $svcObj = Get-Service -Name $svc -ErrorAction SilentlyContinue
             if ($svcObj) {
                 $serviceStates[$svc] = $svcObj.Status
-                Log-Info "Captured original state of $svc : $($svcObj.Status)" | Tee-Object -FilePath $logFile -Append
+                Log-Info "Captured original state of $svc : $($svcObj.Status)"
                 Stop-Service -Name $svc -Force -ErrorAction SilentlyContinue
             }
         }
         catch {
-            Log-Warning "Failed to capture state of $svc : $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+            Log-Warning "Failed to capture state of $svc : $($_.Exception.Message)"
         }
     }
 
@@ -186,11 +224,11 @@ try {
     [System.GC]::WaitForPendingFinalizers()
 
     # Cycle non-system disks offline/online to release ALL file handles
-    Log-Info "Cycling attached disks offline/online to release file locks..." | Tee-Object -FilePath $logFile -Append
+    Log-Info "Cycling attached disks offline/online to release file locks..."
     $rescueDiskNum = (Get-Partition -DriveLetter ($env:SystemDrive -replace ':', '') -ErrorAction SilentlyContinue).DiskNumber
     Get-Disk | Where-Object { $_.Number -ne $rescueDiskNum -and $_.OperationalStatus -eq 'Online' } | ForEach-Object {
         $dnum = $_.Number
-        Log-Info "Cycling disk $dnum offline/online..." | Tee-Object -FilePath $logFile -Append
+        Log-Info "Cycling disk $dnum offline/online..."
         Set-Disk -Number $dnum -IsOffline $true -ErrorAction SilentlyContinue
         Start-Sleep -Seconds 2
         Set-Disk -Number $dnum -IsOffline $false -ErrorAction SilentlyContinue
@@ -205,17 +243,18 @@ try {
     $failedDisks = @()  # Track disks that failed copy-back
 
     foreach ($partition in $partitionlist) {
-        if (-not $partition.DriveLetter) { continue }
+        $processedCount++
+        if (-not $partition.DriveLetter) { $skippedCount++; continue }
         # Skip the rescue VM's own OS drive (its hives are locked by the running OS)
         if ($partition.DriveLetter -eq $rescueDrive) {
-            Log-Info "Skipping rescue VM system drive $rescueDrive (own OS)" | Tee-Object -FilePath $logFile -Append
+            Log-Info "Skipping rescue VM system drive $rescueDrive (own OS)"
+            $skippedCount++
             continue
         }
-        if (-not (Test-Path -Path "$($partition.DriveLetter):\Windows")) { continue }
+        if (-not (Test-Path -Path "$($partition.DriveLetter):\Windows")) { $skippedCount++; continue }
 
         $diskb = $partition.DriveLetter
-        Log-Info "Target OS disk found on letter: $($diskb):" | Tee-Object -FilePath $logFile -Append
-
+        Log-Info "Target OS disk found on letter: $($diskb):"
         # Step 2 - Load the SYSTEM registry hive from the target disk
         $hiveName = "BROKENSYSTEM_$diskb"
         $hiveSource = "$($diskb):\Windows\System32\config\SYSTEM"
@@ -224,11 +263,11 @@ try {
         & reg.exe unload "HKLM\$hiveName" 2>$null
         [System.GC]::Collect()
         Start-Sleep -Seconds 1
-        Log-Info "Loading SYSTEM hive from $($diskb): as $hiveName..." | Tee-Object -FilePath $logFile -Append
+        Log-Info "Loading SYSTEM hive from $($diskb): as $hiveName..."
         $loadResult = & reg.exe load "HKLM\$hiveName" $hiveSource 2>&1
         if ($LASTEXITCODE -ne 0) {
             # Retry once after a short wait
-            Log-Warning "First reg load attempt failed for $($diskb):, retrying in 5 seconds..." | Tee-Object -FilePath $logFile -Append
+            Log-Warning "First reg load attempt failed for $($diskb):, retrying in 5 seconds..."
             Start-Sleep -Seconds 5
             [System.GC]::Collect()
             [System.GC]::WaitForPendingFinalizers()
@@ -236,24 +275,24 @@ try {
         }
         if ($LASTEXITCODE -ne 0) {
             # Fallback: use esentutl.exe /y to copy locked hive via Windows Backup API semantics
-            Log-Warning "Direct load failed. Trying esentutl copy fallback for $($diskb):..." | Tee-Object -FilePath $logFile -Append
+            Log-Warning "Direct load failed. Trying esentutl copy fallback for $($diskb):..."
             $hiveCopy = "$env:TEMP\SYSTEM_COPY_$diskb"
             try {
                 $esentResult = & esentutl.exe /y $hiveSource /d $hiveCopy /o 2>&1
                 if ($LASTEXITCODE -eq 0 -and (Test-Path $hiveCopy)) {
-                    Log-Info "Hive copied successfully to $hiveCopy via esentutl" | Tee-Object -FilePath $logFile -Append
+                    Log-Info "Hive copied successfully to $hiveCopy via esentutl"
                     $loadResult = & reg.exe load "HKLM\$hiveName" $hiveCopy 2>&1
                 }
                 else {
-                    Log-Warning "esentutl copy failed for $($diskb): $esentResult" | Tee-Object -FilePath $logFile -Append
+                    Log-Warning "esentutl copy failed for $($diskb): $esentResult"
                 }
             }
             catch {
-                Log-Warning "esentutl fallback failed for $($diskb):: $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+                Log-Warning "esentutl fallback failed for $($diskb):: $($_.Exception.Message)"
             }
         }
         if ($LASTEXITCODE -ne 0) {
-            Log-Warning "Failed to load Registry Hive from $($diskb): $loadResult - skipping this partition" | Tee-Object -FilePath $logFile -Append
+            Log-Warning "Failed to load Registry Hive from $($diskb): $loadResult - skipping this partition"
             if ($hiveCopy -and (Test-Path $hiveCopy)) { Remove-Item $hiveCopy -Force -ErrorAction SilentlyContinue }
             continue
         }
@@ -262,10 +301,10 @@ try {
         try {
             # Step 3 - Create a full backup of the loaded hive before making changes
             $backupFile = "$($diskb):\regbackupbeforeGAchanges_$diskb.reg"
-            Log-Info "Backing up full registry hive to $backupFile..." | Tee-Object -FilePath $logFile -Append
-            & reg.exe export "HKLM\$hiveName" $backupFile /y 2>&1 | Out-Null
-            if ($LASTEXITCODE -ne 0) {
-                Log-Warning "Registry backup failed for $($diskb): -- continuing anyway" | Tee-Object -FilePath $logFile -Append
+            Log-Info "Backing up full registry hive to $backupFile..."
+            $backupResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("export", "HKLM\$hiveName", $backupFile, "/y") -Description "reg export backup ($diskb)"
+            if ($backupResult.ExitCode -ne 0) {
+                throw "Registry backup failed for $($diskb): $($backupResult.Output -join '; ')"
             }
 
             # Step 4 - Identify the primary and backup ControlSets from the Select key
@@ -274,33 +313,42 @@ try {
             $primarySet = "ControlSet00$defaultSetID"
             $otherSet = if ($primarySet -eq "ControlSet001") { "ControlSet002" } else { "ControlSet001" }
 
-            Log-Info "Primary ControlSet identified: $primarySet" | Tee-Object -FilePath $logFile -Append
-
+            Log-Info "Primary ControlSet identified: $primarySet"
             # Step 5 - Export healthy service keys and inject into both ControlSets
             $services = @("WindowsAzureGuestAgent", "WindowsAzureTelemetryService", "RdAgent")
 
             foreach ($service in $services) {
                 $regFile = "$($diskb):\$service.reg"
                 # Export healthy key from the current Rescue VM
-                & reg.exe export "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\$service" "$regFile" /y 2>$null
+                $serviceExportResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("export", "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\$service", "$regFile", "/y") -Description "reg export service $service"
                 
-                if (Test-Path $regFile) {
+                if ($serviceExportResult.ExitCode -eq 0 -and (Test-Path $regFile)) {
                     $originalContent = Get-Content $regFile
                     
                     # Update Primary Set
-                    Log-Info "Updating $service in $primarySet on $($diskb):..." | Tee-Object -FilePath $logFile -Append
+                    Log-Info "Updating $service in $primarySet on $($diskb):..."
                     $content = $originalContent -replace 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet', "HKEY_LOCAL_MACHINE\$hiveName\$primarySet"
                     $content | Set-Content $regFile
-                    & reg.exe import $regFile 2>&1 | Out-Null
+                    $primaryImportResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("import", $regFile) -Description "reg import $service into $primarySet ($diskb)"
+                    if ($primaryImportResult.ExitCode -ne 0) {
+                        throw "Failed to import $service into $primarySet for $($diskb): $($primaryImportResult.Output -join '; ')"
+                    }
 
                     # Update Secondary Set (if it exists on disk)
                     if (Test-Path "Registry::HKLM\$hiveName\$otherSet") {
-                        Log-Info "Updating $service in backup $otherSet on $($diskb):..." | Tee-Object -FilePath $logFile -Append
+                        Log-Info "Updating $service in backup $otherSet on $($diskb):..."
                         $content = $originalContent -replace 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet', "HKEY_LOCAL_MACHINE\$hiveName\$otherSet"
                         $content | Set-Content $regFile
-                        & reg.exe import $regFile 2>&1 | Out-Null
+                        $secondaryImportResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("import", $regFile) -Description "reg import $service into $otherSet ($diskb)"
+                        if ($secondaryImportResult.ExitCode -ne 0) {
+                            throw "Failed to import $service into $otherSet for $($diskb): $($secondaryImportResult.Output -join '; ')"
+                        }
                     }
                     Remove-Item $regFile -Force
+                }
+                else {
+                    $serviceExportText = $serviceExportResult.Output -join '; '
+                    throw ("Failed to export service key for " + $service + " - " + $serviceExportText)
                 }
             }
 
@@ -308,10 +356,10 @@ try {
             $wagaPath = "HKLM\$hiveName\$primarySet\Services\WindowsAzureGuestAgent"
             $afterImagePath = (Get-ItemProperty -Path "Registry::$wagaPath" -ErrorAction SilentlyContinue).ImagePath
             if ([string]::IsNullOrWhiteSpace($afterImagePath)) {
-                Log-Warning "Verification Warning on $($diskb): VMAgent ImagePath is empty after injection." | Tee-Object -FilePath $logFile -Append
+                Log-Warning "Verification Warning on $($diskb): VMAgent ImagePath is empty after injection."
             }
             else {
-                Log-Info "Verification Success on $($diskb):: ImagePath is now $afterImagePath" | Tee-Object -FilePath $logFile -Append
+                Log-Info "Verification Success on $($diskb):: ImagePath is now $afterImagePath"
             }
 
             # Step 7 - Backup existing WindowsAzure folder and replace with rescue VM copy
@@ -320,16 +368,22 @@ try {
             $backupPath = "$($diskb):\WindowsazurefaultyGAbackup"
 
             if (Test-Path $destPath) {
-                Log-Info "Backing up existing WindowsAzure folder on $($diskb): to WindowsazurefaultyGAbackup..." | Tee-Object -FilePath $logFile -Append
+                Log-Info "Backing up existing WindowsAzure folder on $($diskb): to WindowsazurefaultyGAbackup..."
                 if (-not (Test-Path $backupPath)) { $null = New-Item -Path $backupPath -ItemType Directory -Force }
-                & xcopy "$destPath" "$backupPath" /E /Y /H /Q 2>&1 | Out-Null
-                Log-Info "Removing old WindowsAzure folder on $($diskb):..." | Tee-Object -FilePath $logFile -Append
+                $backupCopyResult = Invoke-CriticalCommand -Command "xcopy" -Arguments @("$destPath", "$backupPath", "/E", "/Y", "/H", "/Q") -Description "xcopy backup WindowsAzure ($diskb)"
+                if ($backupCopyResult.ExitCode -ge 2) {
+                    throw "Failed to back up existing WindowsAzure folder on $($diskb): $($backupCopyResult.Output -join '; ')"
+                }
+                Log-Info "Removing old WindowsAzure folder on $($diskb):..."
                 Remove-Item $destPath -Recurse -Force -ErrorAction SilentlyContinue
             }
 
-            Log-Info "Copying full WindowsAzure folder from rescue VM to $($diskb):..." | Tee-Object -FilePath $logFile -Append
+            Log-Info "Copying full WindowsAzure folder from rescue VM to $($diskb):..."
             $null = New-Item -Path $destPath -ItemType Directory -Force
-            & xcopy "$sourcePath" "$destPath" /E /Y /H /Q 2>&1 | Out-Null
+            $restoreCopyResult = Invoke-CriticalCommand -Command "xcopy" -Arguments @("$sourcePath", "$destPath", "/E", "/Y", "/H", "/Q") -Description "xcopy restore WindowsAzure ($diskb)"
+            if ($restoreCopyResult.ExitCode -ge 2) {
+                throw "Failed to copy WindowsAzure folder to $($diskb): $($restoreCopyResult.Output -join '; ')"
+            }
 
             # Remove Logs folder from copied content (not relevant to the target VM)
             $logsPath = "$destPath\Logs"
@@ -339,39 +393,41 @@ try {
 
             $diskProcessedSuccessfully = $true
             $fixedDisks += $diskb
+            $changedCount++
         }
         catch {
-            Log-Error "Failed to process $($diskb):: $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+            Log-Error "Failed to process $($diskb):: $($_.Exception.Message)"
             $diskProcessedSuccessfully = $false
+            $failedCount++
         }
         finally {
             # Step 8 - Release handles and safely unload the registry hive
-            Log-Info "Unloading registry hive $hiveName..." | Tee-Object -FilePath $logFile -Append
+            Log-Info "Unloading registry hive $hiveName..."
             [System.GC]::Collect()
             [System.GC]::WaitForPendingFinalizers()
             Start-Sleep -Seconds 3
 
             $unloaded = $false
             for ($i=1; $i -le 3; $i++) {
-                & reg.exe unload "HKLM\$hiveName" 2>&1 | Out-Null
-                if ($LASTEXITCODE -eq 0) { $unloaded = $true; break }
-                Log-Warning "Unload attempt $i for $hiveName failed, retrying..." | Tee-Object -FilePath $logFile -Append
+                $unloadResult = Invoke-CriticalCommand -Command "reg.exe" -Arguments @("unload", "HKLM\$hiveName") -Description "reg unload $hiveName attempt $i"
+                if ($unloadResult.ExitCode -eq 0) { $unloaded = $true; break }
+                Log-Warning "Unload attempt $i for $hiveName failed, retrying..."
                 Start-Sleep -Seconds 5
             }
             if (-not $unloaded) {
-                Log-Warning "Could not unload $hiveName hive - may need manual cleanup" | Tee-Object -FilePath $logFile -Append
+                Log-Warning "Could not unload $hiveName hive - may need manual cleanup"
             }
 
             # If we used the copy fallback, copy the modified hive back to the original location
             if ($hiveCopy -and (Test-Path $hiveCopy)) {
                 if ($unloaded) {
-                    Log-Info "Copying modified hive back to $hiveSource..." | Tee-Object -FilePath $logFile -Append
+                    Log-Info "Copying modified hive back to $hiveSource..."
                     try {
                         Copy-Item -Path $hiveCopy -Destination $hiveSource -Force -ErrorAction Stop
-                        Log-Info "Successfully copied modified hive back to $($diskb):" | Tee-Object -FilePath $logFile -Append
+                        Log-Info "Successfully copied modified hive back to $($diskb):"
                     }
                     catch {
-                        Log-Error "Failed to copy modified hive back to $($diskb):: $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+                        Log-Error "Failed to copy modified hive back to $($diskb):: $($_.Exception.Message)"
                         $diskProcessedSuccessfully = $false
                         $failedDisks += $diskb
                     }
@@ -390,12 +446,13 @@ try {
     }
 
     if ($failedDisks.Count -gt 0) {
-        Log-Error "Copy-back operation failed on disks: $($failedDisks -join ', ')" | Tee-Object -FilePath $logFile -Append
+        Log-Error "Copy-back operation failed on disks: $($failedDisks -join ', ')"
         throw "Hive copy-back failed on one or more disks: $($failedDisks -join ', '). Please review logs."
     }
 
+    Log-Info "Processing summary: processed=$processedCount skipped=$skippedCount failed=$failedCount changed=$changedCount"
     if ($fixedDisks.Count -gt 0) {
-        Log-Output "VMAgent Fix completed and verified successfully on drives: $($fixedDisks -join ', ') | Metadata: Host=$($vmMetadata.HostName), Region=$($vmMetadata.Region), SKU=$($vmMetadata.VMSku)" | Tee-Object -FilePath $logFile -Append
+        Log-Output "VMAgent Fix completed and verified successfully on drives: $($fixedDisks -join ', ') | Metadata: Host=$($vmMetadata.HostName), Region=$($vmMetadata.Region), SKU=$($vmMetadata.VMSku)"
         $script_final_status = $STATUS_SUCCESS
     }
     else {
@@ -405,32 +462,34 @@ try {
 }
 catch {
     $errorMessage = $_.Exception.Message
-    Log-Error "SCRIPT FAILED: $errorMessage" | Tee-Object -FilePath $logFile -Append
+    Log-Error "SCRIPT FAILED: $errorMessage"
     $script_final_status = $STATUS_ERROR
 }
 finally {
     # Log execution metadata for Application Insights correlation
     if ($vmMetadata.Region -or $vmMetadata.VMSku -or $vmMetadata.OSVersion) {
-        Log-Info "Execution Context - Host: $($vmMetadata.HostName), Region: $($vmMetadata.Region), SKU: $($vmMetadata.VMSku), OS: $($vmMetadata.OSVersion)" | Tee-Object -FilePath $logFile -Append
+        Log-Info "Execution Context - Host: $($vmMetadata.HostName), Region: $($vmMetadata.Region), SKU: $($vmMetadata.VMSku), OS: $($vmMetadata.OSVersion)"
     }
 
     # Restore original service states
-    Log-Info "Restoring original service states..." | Tee-Object -FilePath $logFile -Append
+    Log-Info "Restoring original service states..."
     foreach ($svc in $serviceStates.Keys) {
         try {
             $originalState = $serviceStates[$svc]
-            Log-Info "Restoring $svc to state: $originalState" | Tee-Object -FilePath $logFile -Append
+            Log-Info "Restoring $svc to state: $originalState"
             if ($originalState -eq 'Running') {
                 Start-Service -Name $svc -ErrorAction SilentlyContinue
             }
             # If original state was Stopped, service remains stopped (already stopped)
         }
         catch {
-            Log-Warning "Failed to restore $svc to state $originalState : $($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+            Log-Warning "Failed to restore $svc to state $originalState : $($_.Exception.Message)"
         }
     }
 
-    Log-Info "Execution ended at $(Get-Date)" | Tee-Object -FilePath $logFile -Append
+    Log-Info "Execution ended at $(Get-Date)"
+    Log-Info "Desktop log file path: $logFile"
 }
 
 return $script_final_status
+

--- a/src/windows/GA_offlinefixer.ps1
+++ b/src/windows/GA_offlinefixer.ps1
@@ -13,9 +13,9 @@
      6. Exports healthy service keys (WindowsAzureGuestAgent, WindowsAzureTelemetryService, RdAgent)
          from the rescue VM and injects them into every boot-referenced ControlSet on the target hive.
      7. Verifies both required services use automatic startup and have non-empty ImagePath values.
-     8. Copies the latest GuestAgent installation folder, or the documented ImagePath folder fallback,
-         into a staging directory and verifies the exact executables referenced by both required services.
-         The existing Agent folder is restored if activation fails.
+     8. Stages the complete WindowsAzure repository from the rescue VM and verifies the exact
+         executables referenced by both required services. The existing repository is restored
+         if activation fails.
      9. Releases handles, reloads the persisted SYSTEM hive, and verifies the required service keys.
          If processing fails, restores and hash-verifies SYSTEM, Agent files, and any changed BCD.
 
@@ -26,8 +26,8 @@
     Modified by: Tony.Mocanu@Microsoft.com
 
 .VERSION
-    v1.3: [August 2026] - Copies only the newest versioned GuestAgent installation folder.
-                        - Uses the WindowsAzureGuestAgent ImagePath folder as a fallback.
+    v1.3: [August 2026] - Stages and atomically replaces the complete WindowsAzure repository.
+                        - Verifies both required service executables in the staged repository.
                                                 - Follows the Microsoft Learn offline VM Agent registry and binary-copy procedure.
                                                 - Aligns disk safety, rollback accounting, and rescue service restoration with
                                                     win-LKGC and win-sac-onLatest.
@@ -73,9 +73,8 @@
     Use only on a disposable test VM with a snapshot or recoverable OS disk.
     Run GA_offlinefixer_testbreaker.ps1 on the healthy test VM before detaching its OS disk:
 .\GA_offlinefixer_testbreaker.ps1 -Mode Break -ConfirmDestructiveTest
-    The breaker exports both required service keys and moves C:\WindowsAzure into a timestamped
-    backup. It intentionally preserves the Agent SOFTWARE keys and C:\Packages because those
-    artifacts are outside this fixer's documented offline recovery scope.
+    The breaker exports both required service keys and moves the complete WindowsAzure repository
+    into a timestamped backup. It intentionally preserves the Agent SOFTWARE keys and C:\Packages.
     To undo the test without running the offline fixer:
 .\GA_offlinefixer_testbreaker.ps1 -Mode Restore -BackupPath 'C:\GAOfflineRepairTestBackups\<timestamp>'
     After creating the test state, shut down the VM, run the offline fixer through VM Repair,
@@ -96,8 +95,8 @@ Get-ItemProperty -Path "HKLM:\VERIFY\$defaultSet\Services\WindowsAzureGuestAgent
 Get-ItemProperty -Path "HKLM:\VERIFY\$defaultSet\Services\RdAgent" -Name Start, ImagePath
 reg unload HKLM\VERIFY
     Expected: ImagePath values are populated and Start is 2 for both services.
-    3. Verify GuestAgent binaries were copied to the target disk:
-Get-ChildItem F:\WindowsAzure\GuestAgent_*
+    3. Verify the WindowsAzure repository was copied to the target disk:
+Get-ChildItem F:\WindowsAzure -Force
     Expected: The exact executables referenced by both service ImagePath values are present and non-empty.
     4. After az vm repair restore, verify that the repaired disk was actually reattached:
 Get-Content C:\ProgramData\GA-OfflineRepair-Verification.json
@@ -1129,76 +1128,43 @@ try {
                     Write-GaInfo "Validated $requiredService in ${targetControlSet}: Start=2, ImagePath=$($serviceConfiguration.ImagePath)"
                 }
             }
-            $afterImagePath = [string]$targetServiceConfigurations['WindowsAzureGuestAgent'].ImagePath
-
-            # Step 7 - Copy only the current VM Agent installation folder.
+            # Step 7 - Stage and activate the complete, internally consistent Agent repository.
             $sourcePath = "C:\WindowsAzure"
             $destPath = "$($diskb):\WindowsAzure"
             $backupPath = "$($diskb):\WindowsazurefaultyGAbackup"
 
-            $guestAgentCandidates = @(Get-ChildItem -LiteralPath $sourcePath -Directory -Force -ErrorAction Stop |
-                ForEach-Object {
-                    if ($_.Name -match '^GuestAgent_(.+)$') {
-                        $parsedVersion = $null
-                        if ([version]::TryParse($matches[1], [ref]$parsedVersion)) {
-                            [pscustomobject]@{
-                                Directory = $_
-                                Version = $parsedVersion
-                            }
-                        }
-                    }
-                } | Sort-Object Version -Descending)
-
-            $sourceAgentFolder = $null
-            if ($guestAgentCandidates.Count -gt 0) {
-                $sourceAgentFolder = $guestAgentCandidates[0].Directory
-                Write-GaInfo "Selected latest VM Agent installation folder $($sourceAgentFolder.Name)."
-            }
-            else {
-                $expandedImagePath = [Environment]::ExpandEnvironmentVariables($afterImagePath).Trim()
-                $imageExecutable = if ($expandedImagePath.StartsWith('"')) {
-                    ($expandedImagePath -split '"')[1]
-                }
-                else {
-                    ($expandedImagePath -split '\s+')[0]
-                }
-                if (-not [string]::IsNullOrWhiteSpace($imageExecutable)) {
-                    $imageFolder = Split-Path -Parent $imageExecutable
-                    if (Test-Path -LiteralPath $imageFolder -PathType Container) {
-                        $sourceAgentFolder = Get-Item -LiteralPath $imageFolder -ErrorAction Stop
-                        Write-GaWarning "No versioned GuestAgent folder was found; using ImagePath folder '$imageFolder'."
-                    }
-                }
+            if (-not (Test-Path -LiteralPath $sourcePath -PathType Container)) {
+                throw "The rescue VM Agent repository does not exist: $sourcePath"
             }
 
-            if (-not $sourceAgentFolder) {
-                throw "No GuestAgent installation folder was found under '$sourcePath' or through ImagePath '$afterImagePath'."
-            }
-
-            $null = New-Item -Path $destPath -ItemType Directory -Force
-            $targetAgentFolder = Join-Path $destPath $sourceAgentFolder.Name
-            $stagingAgentFolder = Join-Path $destPath ('.GA_repair_{0}_{1}' -f $sourceAgentFolder.Name, [guid]::NewGuid().ToString('N'))
+            $targetAgentFolder = $destPath
+            $stagingAgentFolder = "$($diskb):\.GA_WindowsAzure_repair_$([guid]::NewGuid().ToString('N'))"
 
             try {
-                Write-GaInfo "Staging VM Agent folder $($sourceAgentFolder.FullName) at $stagingAgentFolder..."
+                Write-GaInfo "Staging the complete VM Agent repository $sourcePath at $stagingAgentFolder..."
                 $restoreCopyResult = Invoke-CriticalCommand -Command "robocopy.exe" -Arguments @(
-                    $sourceAgentFolder.FullName, $stagingAgentFolder, '/E', '/COPY:DAT', '/DCOPY:DAT',
+                    $sourcePath, $stagingAgentFolder, '/E', '/COPY:DAT', '/DCOPY:DAT',
                     '/XJ', '/R:2', '/W:2', '/NFL', '/NDL', '/NJH', '/NJS', '/NP'
-                ) -Description "robocopy VM Agent $($sourceAgentFolder.Name) ($diskb)"
+                ) -Description "robocopy complete WindowsAzure repository ($diskb)"
                 if ($restoreCopyResult.ExitCode -ge 8) {
-                    throw "Failed to stage VM Agent folder on $($diskb): $($restoreCopyResult.Output -join '; ')"
+                    throw "Failed to stage the VM Agent repository on $($diskb): $($restoreCopyResult.Output -join '; ')"
+                }
+
+                $stagedLogsPath = Join-Path $stagingAgentFolder 'Logs'
+                if (Test-Path -LiteralPath $stagedLogsPath) {
+                    Remove-Item -LiteralPath $stagedLogsPath -Recurse -Force -ErrorAction Stop
                 }
 
                 foreach ($requiredService in $requiredAgentServices) {
-                    $targetExecutable = Get-GaServiceExecutablePath `
+                    $sourceExecutable = Get-GaServiceExecutablePath `
                         -ImagePath ([string]$targetServiceConfigurations[$requiredService].ImagePath) `
-                        -TargetDriveLetter $diskb
-                    $targetAgentPrefix = $targetAgentFolder.TrimEnd('\') + '\'
-                    if (-not $targetExecutable.StartsWith($targetAgentPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
-                        throw "Required service '$requiredService' points outside the selected Agent folder: $targetExecutable"
+                        -TargetDriveLetter 'C'
+                    $sourceAgentPrefix = $sourcePath.TrimEnd('\') + '\'
+                    if (-not $sourceExecutable.StartsWith($sourceAgentPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+                        throw "Required service '$requiredService' points outside the rescue VM Agent repository: $sourceExecutable"
                     }
 
-                    $relativeExecutable = $targetExecutable.Substring($targetAgentPrefix.Length)
+                    $relativeExecutable = $sourceExecutable.Substring($sourceAgentPrefix.Length)
                     $stagedExecutable = Join-Path $stagingAgentFolder $relativeExecutable
                     if (-not (Test-Path -LiteralPath $stagedExecutable -PathType Leaf)) {
                         throw "Required executable for service '$requiredService' was not found in the staged copy: $stagedExecutable"
@@ -1210,17 +1176,17 @@ try {
                     Write-GaInfo "Validated staged $requiredService executable ($($stagedExecutableInfo.Length) bytes)."
                 }
 
-                if (Test-Path -LiteralPath $targetAgentFolder) {
+                if (Test-Path -LiteralPath $destPath) {
                     $null = New-Item -Path $backupPath -ItemType Directory -Force
-                    $targetAgentBackup = Join-Path $backupPath "$($sourceAgentFolder.Name)_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
-                    Write-GaInfo "Moving existing $($sourceAgentFolder.Name) folder to $targetAgentBackup..."
-                    Move-Item -LiteralPath $targetAgentFolder -Destination $targetAgentBackup -ErrorAction Stop
+                    $targetAgentBackup = Join-Path $backupPath "WindowsAzure_$(Get-Date -Format 'yyyyMMdd_HHmmss')"
+                    Write-GaInfo "Moving the existing WindowsAzure repository to $targetAgentBackup..."
+                    Move-Item -LiteralPath $destPath -Destination $targetAgentBackup -ErrorAction Stop
                     $existingAgentMoved = $true
                 }
 
-                Move-Item -LiteralPath $stagingAgentFolder -Destination $targetAgentFolder -ErrorAction Stop
+                Move-Item -LiteralPath $stagingAgentFolder -Destination $destPath -ErrorAction Stop
                 $agentFolderActivated = $true
-                Write-GaInfo "Activated validated VM Agent folder at $targetAgentFolder."
+                Write-GaInfo "Activated the validated complete VM Agent repository at $destPath."
             }
             catch {
                 $activationError = $_
@@ -1233,7 +1199,7 @@ try {
                     }
                     Move-Item -LiteralPath $targetAgentBackup -Destination $targetAgentFolder -ErrorAction Stop
                     $agentFolderActivated = $false
-                    Write-GaWarning "Restored the original VM Agent folder after replacement failed."
+                    Write-GaWarning "Restored the original VM Agent repository after replacement failed."
                 }
                 throw $activationError
             }
@@ -1411,15 +1377,15 @@ try {
                             throw "Original VM Agent backup is missing: $targetAgentBackup"
                         }
                         Move-Item -LiteralPath $targetAgentBackup -Destination $targetAgentFolder -ErrorAction Stop
-                        Write-GaWarning "Restored the original VM Agent folder because registry persistence did not complete."
+                        Write-GaWarning "Restored the original VM Agent repository because registry persistence did not complete."
                     }
                     else {
-                        Write-GaWarning "Removed the newly introduced VM Agent folder because registry persistence did not complete."
+                        Write-GaWarning "Removed the newly introduced VM Agent repository because registry persistence did not complete."
                     }
                     $agentFolderActivated = $false
                 }
                 catch {
-                    Write-GaError "Failed to roll back the VM Agent folder on $($diskb):: $($_.Exception.Message)"
+                    Write-GaError "Failed to roll back the VM Agent repository on $($diskb):: $($_.Exception.Message)"
                     if ($diskb -notin $failedDisks) { $failedDisks += $diskb }
                 }
             }


### PR DESCRIPTION
This script repairs a broken Azure Guest Agent by restoring registry keys and binaries from a rescue VM. It includes detailed steps for loading the SYSTEM hive, backing up, injecting service keys, and verifying the restoration process. .VERSION
    v1.3: [May 2026] - Updated the script (current)
                       - Aligned nested VM detection with win-LKGC guard pattern.
                       - Skips Get-VM safely when Hyper-V module is unavailable.
    v1.2: [May 2026] - Updated the script again (current)
                       - Fixed breaking exception when the Hyper-V module is not installed on the host.
                       - Added explicit checking via Get-Module before executing nested VM discovery.
    v1.1: [May 2026] - Updated the script
                       - Included advanced Gen2 unlettered EFI fallback and dynamic drive-letter assignment.
    v1.0: Initial commit. This was the version 1.0 of the script.