### PR TITLE
Update win-ignoreAllFailures to v1.3

### DIFF
--- a/src/windows/win-ignoreAllFailures.ps1
+++ b/src/windows/win-ignoreAllFailures.ps1
@@ -26,6 +26,8 @@
                            - Aligns BCD target validation and no-boot protections with the proven repair scripts.
                            - Excludes repair-host critical disks and preserves source disk identities across collisions.
                            - Restores and verifies every temporary GPT or MBR identity before reporting success.
+                           - Verifies DiskPart mounts by access path to avoid stale Get-Partition drive-letter data.
+                           - Probes unlettered non-EFI partitions and cleans up every temporary OS mount.
     v1.2: [May 2026] - Updated the script
                        - Added guarded nested VM handling to prevent Get-VM failures when Hyper-V module is unavailable.
                        - Switched partition discovery from inline CIM enumeration to shared Get-Disk-Partitions-v2 helper.
@@ -121,6 +123,7 @@ if (-not (Test-Path $logFile)) { $null = New-Item -ItemType File -Path $logFile 
 $successReport = New-Object System.Collections.Generic.List[string]
 $script_final_status = $STATUS_ERROR
 $assignedEfiLetters = @()  # Track EFI partition drive letters for cleanup
+$assignedOsLetters = @()   # Track Windows partition drive letters for cleanup
 $processedDisks = 0
 $skippedDisks = 0
 $failedDisks = 0
@@ -442,15 +445,11 @@ try {
                 )
                 Update-HostStorageCache -ErrorAction SilentlyContinue
                 Start-Sleep -Seconds 2
-                $mountedPartition = Get-Partition -DiskNumber $diskGroup.Name -PartitionNumber $part.PartitionNumber -ErrorAction Stop
-                if ([string]$mountedPartition.DriveLetter -ine [string]$newLetter) {
+                if (-not (Test-Path -LiteralPath "${newLetter}:\" -PathType Container)) {
                     throw "Disk $($diskGroup.Name): temporary EFI mount on ${newLetter}: could not be verified."
                 }
                 $assignedEfiLetters += @{ Letter = $newLetter; DiskNumber = $diskGroup.Name; PartitionNumber = $part.PartitionNumber }
                 $mountTracked = $true
-                if (-not (Test-Path -LiteralPath "${newLetter}:\" -PathType Container)) {
-                    throw "Disk $($diskGroup.Name): verified letter ${newLetter}: is not accessible."
-                }
             }
             catch {
                 if (-not $mountTracked) {
@@ -465,7 +464,14 @@ try {
             }
         }
 
-        $currentDrives = Get-Partition -DiskNumber $diskGroup.Name | Where-Object { $_.DriveLetter -and $_.DriveLetter -ne [char]0 } | Select-Object -ExpandProperty DriveLetter
+        $currentDrives = @(
+            @(Get-Partition -DiskNumber $diskGroup.Name -ErrorAction Stop |
+                Where-Object { $_.DriveLetter -and $_.DriveLetter -ne [char]0 } |
+                Select-Object -ExpandProperty DriveLetter)
+            @($assignedEfiLetters |
+                Where-Object { [int]$_.DiskNumber -eq [int]$diskGroup.Name } |
+                Select-Object -ExpandProperty Letter)
+        ) | Sort-Object -Unique
         foreach ($drive in $currentDrives) {
             $driveStr = "$($drive):"
             if ($null -eq $currentDiskBcdPath) {
@@ -485,6 +491,62 @@ try {
                     ((Test-Path -LiteralPath "$driveStr\windows\system32\winload.exe" -PathType Leaf) -or
                      (Test-Path -LiteralPath "$driveStr\windows\system32\winload.efi" -PathType Leaf))) {
                     $currentDiskOsDrive = [string]$drive
+                }
+            }
+        }
+
+        if (-not $currentDiskOsDrive) {
+            $unletteredOsCandidates = @($diskPartitions | Where-Object {
+                (-not $_.DriveLetter -or $_.DriveLetter -eq [char]0) -and
+                ([string]$_.GptType).Trim().Trim('{', '}') -ine $efiGptType -and
+                $_.Type -ne 'System'
+            } | Sort-Object Size -Descending)
+
+            Write-ScriptLog -Message "Disk $($diskGroup.Name): probing $($unletteredOsCandidates.Count) unlettered non-EFI partition(s) for Windows"
+            foreach ($osCandidate in $unletteredOsCandidates) {
+                $osLetter = Get-NextFreeDriveLetter
+                if (-not $osLetter) {
+                    Write-ScriptLog -Level Warning -Message "Disk $($diskGroup.Name): no temporary drive letter is available for Windows partition probing"
+                    break
+                }
+
+                $osMountTracked = $false
+                try {
+                    Invoke-IgnoreAllFailuresDiskPart -Operation 'os-assign' -Commands @(
+                        "select disk $($diskGroup.Name)"
+                        "select partition $($osCandidate.PartitionNumber)"
+                        "assign letter=$osLetter"
+                    )
+                    Update-HostStorageCache -ErrorAction SilentlyContinue
+                    Start-Sleep -Seconds 2
+                    $osMounted = Test-Path -LiteralPath "${osLetter}:\" -PathType Container
+                    $systemHivePath = "${osLetter}:\Windows\System32\config\SYSTEM"
+                    $hasSystemHive = $osMounted -and (Test-Path -LiteralPath $systemHivePath -PathType Leaf)
+                    $hasWindowsLoader = $osMounted -and
+                        ((Test-Path -LiteralPath "${osLetter}:\Windows\System32\winload.exe" -PathType Leaf) -or
+                         (Test-Path -LiteralPath "${osLetter}:\Windows\System32\winload.efi" -PathType Leaf))
+
+                    Write-ScriptLog -Message "Disk $($diskGroup.Name): checked temporary ${osLetter}: for Windows; mounted=$osMounted systemHive=$hasSystemHive loader=$hasWindowsLoader"
+                    if ($hasSystemHive -and $hasWindowsLoader) {
+                        $assignedOsLetters += @{ Letter = $osLetter; DiskNumber = $diskGroup.Name; PartitionNumber = $osCandidate.PartitionNumber }
+                        $osMountTracked = $true
+                        $currentDiskOsDrive = [string]$osLetter
+                        break
+                    }
+                }
+                finally {
+                    if (-not $osMountTracked) {
+                        Invoke-IgnoreAllFailuresDiskPart -Operation 'os-probe-remove' -Commands @(
+                            "select disk $($diskGroup.Name)"
+                            "select partition $($osCandidate.PartitionNumber)"
+                            "remove letter=$osLetter noerr"
+                        )
+                        Update-HostStorageCache -ErrorAction SilentlyContinue
+                        Start-Sleep -Seconds 1
+                        if (Test-Path -LiteralPath "${osLetter}:\" -PathType Container) {
+                            throw "Disk $($diskGroup.Name): temporary OS probe letter ${osLetter}: could not be removed."
+                        }
+                    }
                 }
             }
         }
@@ -607,6 +669,28 @@ catch {
     $script_final_status = $STATUS_ERROR
 }
 finally {
+    if ($assignedOsLetters.Count -gt 0) {
+        Write-ScriptLog -Message "Cleaning up temporarily assigned Windows partition drive letters..."
+        foreach ($osMount in $assignedOsLetters) {
+            try {
+                Invoke-IgnoreAllFailuresDiskPart -Operation 'os-remove' -Commands @(
+                    "select disk $($osMount.DiskNumber)"
+                    "select partition $($osMount.PartitionNumber)"
+                    "remove letter=$($osMount.Letter) noerr"
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                Start-Sleep -Seconds 1
+                if (Test-Path -LiteralPath "$($osMount.Letter):\" -PathType Container) {
+                    throw 'Temporary Windows partition drive letter removal could not be verified.'
+                }
+            }
+            catch {
+                Write-ScriptLog -Level Error -Message "Failed to remove temporary Windows partition letter $($osMount.Letter): $($_.Exception.Message)"
+                $script_final_status = $STATUS_ERROR
+            }
+        }
+    }
+
     # Cleanup: Remove temporarily assigned EFI drive letters to avoid leaving orphaned mounts on rescue host
     if ($assignedEfiLetters.Count -gt 0) {
         Write-ScriptLog -Message "Cleaning up temporarily assigned EFI partition drive letters..."
@@ -620,8 +704,7 @@ finally {
                 )
                 Update-HostStorageCache -ErrorAction SilentlyContinue
                 Start-Sleep -Seconds 1
-                $cleanedPartition = Get-Partition -DiskNumber $efiMount.DiskNumber -PartitionNumber $efiMount.PartitionNumber -ErrorAction Stop
-                if ([string]$cleanedPartition.DriveLetter -ieq [string]$efiMount.Letter) {
+                if (Test-Path -LiteralPath "$($efiMount.Letter):\" -PathType Container) {
                     throw 'Temporary EFI drive letter removal could not be verified.'
                 }
             }

--- a/src/windows/win-ignoreAllFailures.ps1
+++ b/src/windows/win-ignoreAllFailures.ps1
@@ -1,27 +1,32 @@
 <#
 .SYNOPSIS
-    win-ignoreAllFailures.ps1 (v1.2) - Sets BCD bootstatuspolicy to IgnoreAllFailures to break Automatic Repair loops.
+    Safely sets IgnoreAllFailures on the validated default Windows boot loader of an attached OS disk.
 
 .DESCRIPTION
     This script runs from a rescue VM to modify the BCD store on an attached faulty OS disk.
     It performs the following steps:
     1. Enumerates attached partitions via Get-Disk-Partitions to locate the BCD store and OS loader.
-    2. Identifies the default boot entry GUID from the BCD bootmgr displayorder.
-    3. Logs the BCD configuration before any changes are made.
-    4. Sets the default boot entry to the identified GUID.
-    5. Sets bootstatuspolicy to IgnoreAllFailures on the default entry.
-    6. Logs the BCD configuration after changes for verification.
+    2. Excludes the repair VM disk and validates a same-disk, generation-appropriate BCD store and Windows loader.
+    3. Identifies the explicit default Windows loader from the BCD boot manager and validates its path.
+    4. Creates and verifies a BCD backup before making any change.
+    5. Sets bootstatuspolicy to IgnoreAllFailures without changing the default boot selection.
+    6. Verifies the policy and restores the backup if the BCD transaction fails.
 
     This resolves VMs stuck in Automatic Repair loops caused by failed boot, failed shutdown,
     or failed checkpoint errors.
 
 .NOTES
     Name:    win-ignoreAllFailures.ps1
-    Version: 1.2
+    Version: 1.3
     Author:  Microsoft Azure Compute Support
 
 .VERSION
-    v1.2: [May 2026] - Updated the script (current)
+    v1.3: [August 2026] - Validates temporary EFI mounts before tracking them for cleanup.
+                           - Excludes null and empty drive letters from mounted partition scans.
+                           - Aligns BCD target validation and no-boot protections with the proven repair scripts.
+                           - Excludes repair-host critical disks and preserves source disk identities across collisions.
+                           - Restores and verifies every temporary GPT or MBR identity before reporting success.
+    v1.2: [May 2026] - Updated the script
                        - Added guarded nested VM handling to prevent Get-VM failures when Hyper-V module is unavailable.
                        - Switched partition discovery from inline CIM enumeration to shared Get-Disk-Partitions-v2 helper.
                        - Added .SYNOPSIS header and aligned metadata versioning/documentation with current script behavior.
@@ -97,6 +102,11 @@ if (-not (Test-Path -Path $partitionsHelperPath -PathType Leaf)) {
 
 . $partitionsHelperPath
 
+if (-not (Get-Command -Name Get-Disk-Partitions -CommandType Function -ErrorAction SilentlyContinue)) {
+    Log-Error "Dependency did not define the required Get-Disk-Partitions function: $partitionsHelperPath"
+    return $STATUS_ERROR
+}
+
 $desktopPath = [Environment]::GetFolderPath('Desktop')
 if ([string]::IsNullOrWhiteSpace($desktopPath) -or -not (Test-Path $desktopPath)) {
     $desktopPath = Join-Path $env:USERPROFILE 'Desktop'
@@ -115,6 +125,9 @@ $processedDisks = 0
 $skippedDisks = 0
 $failedDisks = 0
 $changedDisks = 0
+$collisionDiskRecords = @()
+$gptCollisionDiskNumbers = @()
+$repairDiskIdentityRecord = $null
 
 function Get-FormattedOutput {
     param([string]$text)
@@ -156,10 +169,120 @@ function Add-CommandOutput {
 }
 
 function Get-NextFreeDriveLetter {
-    $usedLetters = Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name
+    $usedLetters = @(Get-Volume -ErrorAction SilentlyContinue |
+        Where-Object { $_.DriveLetter } |
+        Select-Object -ExpandProperty DriveLetter)
     $letters = 90..69 | ForEach-Object { [char]$_ } 
     foreach ($letter in $letters) {
-        if ($letter -notin $usedLetters) { return $letter }
+        if ($letter -notin $usedLetters -and -not (Test-Path -LiteralPath "${letter}:\")) { return $letter }
+    }
+
+    return $null
+}
+
+function Invoke-IgnoreAllFailuresDiskPart {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Commands,
+        [Parameter(Mandatory = $true)]
+        [string]$Operation
+    )
+
+    $output = $Commands | diskpart.exe 2>&1
+    foreach ($line in @($output)) {
+        if ($line) { Write-ScriptLog -Message "[diskpart][$Operation] $line" }
+    }
+}
+
+function Get-IgnoreAllFailuresDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$DiskNumber
+    )
+
+    $disk = Get-Disk -Number $DiskNumber -ErrorAction Stop
+    if ([string]$disk.PartitionStyle -eq 'MBR') {
+        $signature = [uint32]$disk.Signature
+        return [pscustomobject]@{
+            PartitionStyle = 'MBR'
+            Value = $signature.ToString('X8')
+            DiskPartValue = $signature.ToString('X8')
+        }
+    }
+    if ([string]$disk.PartitionStyle -eq 'GPT') {
+        $diskGuid = ([guid]$disk.Guid).ToString('D')
+        return [pscustomobject]@{
+            PartitionStyle = 'GPT'
+            Value = $diskGuid
+            DiskPartValue = $diskGuid
+        }
+    }
+
+    throw "Disk $DiskNumber has unsupported partition style '$($disk.PartitionStyle)'."
+}
+
+function Set-IgnoreAllFailuresTemporarySourceIdentity {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Record)
+
+    if ($Record.PartitionStyle -ne 'MBR') {
+        throw 'Temporary source disk identities are permitted only for the Gen1 MBR path.'
+    }
+    Invoke-IgnoreAllFailuresDiskPart -Operation 'collision-prepare' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
+        'online disk'
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+    $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    $currentIdentity = Get-IgnoreAllFailuresDiskIdentity -DiskNumber $Record.DiskNumber
+    if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
+        throw "Disk $($Record.DiskNumber) could not be brought online with its verified temporary identity."
+    }
+}
+
+function Restore-IgnoreAllFailuresSourceIdentity {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Record)
+
+    Invoke-IgnoreAllFailuresDiskPart -Operation 'collision-restore' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        'offline disk'
+        "uniqueid disk id=$($Record.OriginalDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+    $restoredDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    $restoredIdentity = Get-IgnoreAllFailuresDiskIdentity -DiskNumber $Record.DiskNumber
+    if (-not $restoredDisk.IsOffline -or $restoredIdentity.Value -ine $Record.OriginalValue) {
+        throw "Disk $($Record.DiskNumber) did not return to its original offline identity."
+    }
+}
+
+function Set-IgnoreAllFailuresTemporaryRepairIdentity {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Record)
+
+    Invoke-IgnoreAllFailuresDiskPart -Operation 'repair-host-collision-prepare' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+    $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    $currentIdentity = Get-IgnoreAllFailuresDiskIdentity -DiskNumber $Record.DiskNumber
+    if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
+        throw 'The repair VM OS disk did not retain a verified temporary GPT identity.'
+    }
+}
+
+function Restore-IgnoreAllFailuresRepairIdentity {
+    param([Parameter(Mandatory = $true)][pscustomobject]$Record)
+
+    Invoke-IgnoreAllFailuresDiskPart -Operation 'repair-host-collision-restore' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.OriginalDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+    $restoredDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    $restoredIdentity = Get-IgnoreAllFailuresDiskIdentity -DiskNumber $Record.DiskNumber
+    if ($restoredDisk.IsOffline -or $restoredIdentity.Value -ine $Record.OriginalValue) {
+        throw 'The repair VM OS disk did not return to its original GPT identity.'
     }
 }
 
@@ -191,48 +314,182 @@ try {
         Write-ScriptLog -Level Warning -Message "Nested VM check encountered an error but will be skipped: $($_.Exception.Message)"
     }
     
-    $partitionlist = Get-Disk-Partitions
-
     $rescueDrive = $env:SystemDrive -replace ':', ''
-    Write-ScriptLog -Message "Starting deep scan for BCD files..."
+    $rescueOsPartition = Get-Partition -DriveLetter $rescueDrive -ErrorAction Stop | Select-Object -First 1
+    if ($null -eq $rescueOsPartition -or $null -eq $rescueOsPartition.DiskNumber) {
+        throw "CRITICAL SAFETY CHECK FAILED: Could not identify the repair VM OS disk from $($env:SystemDrive)."
+    }
+    $rescueDiskNumber = [int]$rescueOsPartition.DiskNumber
+    $repairDiskIdentity = Get-IgnoreAllFailuresDiskIdentity -DiskNumber $rescueDiskNumber
 
-    forEach ($diskGroup in $partitionlist | Group-Object DiskNumber) {
-        $processedDisks++
-        if ($diskGroup.Group.DriveLetter -contains $rescueDrive) {
-            $skippedDisks++
-            Write-ScriptLog -Message "Skipping rescue host disk $($diskGroup.Name)"
+    $protectedDiskNumbers = @($rescueDiskNumber)
+    $protectedDiskNumbers += @(Get-Disk -ErrorAction Stop |
+        Where-Object { $_.IsBoot -or $_.IsSystem } |
+        Select-Object -ExpandProperty Number)
+    $pageFileDriveLetters = @(Get-CimInstance -ClassName Win32_PageFileUsage -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            if ([string]$_.Name -match '^([A-Za-z]):\\') { $matches[1] }
+        } | Select-Object -Unique)
+    foreach ($pageFileDriveLetter in $pageFileDriveLetters) {
+        $pageFilePartition = Get-Partition -DriveLetter $pageFileDriveLetter -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($pageFilePartition) { $protectedDiskNumbers += [int]$pageFilePartition.DiskNumber }
+    }
+    $protectedDiskNumbers = @($protectedDiskNumbers | Sort-Object -Unique)
+    Write-ScriptLog -Message "Protected repair-host disk numbers: $($protectedDiskNumbers -join ', ')"
+
+    $azureVirtualDiskNumbers = @(Get-CimInstance -ClassName Win32_DiskDrive -ErrorAction Stop |
+        Where-Object { $_.Model -like 'Microsoft Virtual Disk*' } |
+        ForEach-Object { [int]$_.Index })
+    $attachedDisks = @(Get-Disk -ErrorAction Stop | Where-Object {
+        $_.Number -in $azureVirtualDiskNumbers -and $_.Number -notin $protectedDiskNumbers
+    })
+    if ($attachedDisks.Count -eq 0) {
+        throw 'REPAIR-ONLY SCRIPT: No attached Microsoft virtual disk was found.'
+    }
+
+    foreach ($collisionDisk in @($attachedDisks | Where-Object { $_.IsOffline -and [string]$_.OfflineReason -eq 'Collision' })) {
+        $originalIdentity = Get-IgnoreAllFailuresDiskIdentity -DiskNumber $collisionDisk.Number
+        if ($originalIdentity.PartitionStyle -eq 'GPT') {
+            if ($repairDiskIdentity.PartitionStyle -ne 'GPT' -or $repairDiskIdentity.Value -ine $originalIdentity.Value) {
+                throw "Disk $($collisionDisk.Number) reports an unverified GPT identity collision."
+            }
+            if (-not $repairDiskIdentityRecord) {
+                $temporaryRepairGuid = ([guid]::NewGuid()).ToString('D')
+                $repairDiskIdentityRecord = [pscustomobject]@{
+                    DiskNumber = $rescueDiskNumber
+                    PartitionStyle = 'GPT'
+                    OriginalValue = $repairDiskIdentity.Value
+                    OriginalDiskPartValue = $repairDiskIdentity.DiskPartValue
+                    TemporaryValue = $temporaryRepairGuid
+                    TemporaryDiskPartValue = $temporaryRepairGuid
+                }
+                Write-ScriptLog -Level Warning -Message 'Temporarily changing only the repair VM OS disk GPT identity; the source disk identity remains unchanged.'
+                Set-IgnoreAllFailuresTemporaryRepairIdentity -Record $repairDiskIdentityRecord
+            }
+            $gptCollisionDiskNumbers += [int]$collisionDisk.Number
+            Invoke-IgnoreAllFailuresDiskPart -Operation 'source-gpt-online' -Commands @(
+                "select disk $($collisionDisk.Number)"
+                'online disk'
+            )
+            Update-HostStorageCache -ErrorAction SilentlyContinue
+            $releasedDisk = Get-Disk -Number $collisionDisk.Number -ErrorAction Stop
+            $releasedIdentity = Get-IgnoreAllFailuresDiskIdentity -DiskNumber $collisionDisk.Number
+            if ($releasedDisk.IsOffline -or $releasedIdentity.Value -ine $originalIdentity.Value) {
+                throw "Disk $($collisionDisk.Number) could not be onlined with its original GPT identity unchanged."
+            }
             continue
         }
-        
+
+        do {
+            $temporaryValue = ([Convert]::ToUInt32(([guid]::NewGuid().ToString('N').Substring(0, 8)), 16)).ToString('X8')
+        } while ($temporaryValue -eq '00000000' -or $temporaryValue -ieq $originalIdentity.Value)
+        $identityRecord = [pscustomobject]@{
+            DiskNumber = [int]$collisionDisk.Number
+            PartitionStyle = 'MBR'
+            OriginalValue = $originalIdentity.Value
+            OriginalDiskPartValue = $originalIdentity.DiskPartValue
+            TemporaryValue = $temporaryValue
+            TemporaryDiskPartValue = $temporaryValue
+        }
+        $collisionDiskRecords += $identityRecord
+        Set-IgnoreAllFailuresTemporarySourceIdentity -Record $identityRecord
+    }
+
+    $partitionlist = @(Get-Disk-Partitions)
+    if ($partitionlist.Count -eq 0) {
+        throw 'Get-Disk-Partitions returned no partitions from Azure virtual disks.'
+    }
+    $attachedDiskNumbers = @($attachedDisks | Select-Object -ExpandProperty Number)
+    $targetDiskGroups = @($partitionlist |
+        Where-Object { [int]$_.DiskNumber -in $attachedDiskNumbers -and [int]$_.DiskNumber -notin $protectedDiskNumbers } |
+        Group-Object DiskNumber)
+    if ($targetDiskGroups.Count -eq 0) {
+        throw 'REPAIR-ONLY SCRIPT: No secondary disk was returned by the partition helper.'
+    }
+
+    Write-ScriptLog -Message "Starting deep scan for BCD files..."
+
+    forEach ($diskGroup in $targetDiskGroups) {
+        $processedDisks++
+
         $currentDiskBcdPath = $null
-        $currentDiskOsFound = $false
+        $currentDiskOsDrive = $null
         
         # EFI Mounter Logic
         # Filter for hidden partitions: check for null/empty DriveLetter or DriveLetter -eq 0
-        $hiddenPartitions = Get-Partition -DiskNumber $diskGroup.Name | Where-Object { (-not $_.DriveLetter) -and ($_.GptType -eq "{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}" -or $_.Type -eq "System") }
+        $diskPartitions = @(Get-Partition -DiskNumber $diskGroup.Name -ErrorAction Stop)
+        $efiGptType = 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'
+        $efiPartitions = @($diskPartitions | Where-Object { ([string]$_.GptType).Trim().Trim('{', '}') -ieq $efiGptType })
+        $isGen2Disk = $efiPartitions.Count -gt 0
+        $hiddenPartitions = @($diskPartitions | Where-Object {
+            (-not $_.DriveLetter -or $_.DriveLetter -eq [char]0) -and
+            (($isGen2Disk -and ([string]$_.GptType).Trim().Trim('{', '}') -ieq $efiGptType) -or
+             (-not $isGen2Disk -and $_.Type -eq 'System'))
+        })
         foreach ($part in $hiddenPartitions) {
             $newLetter = Get-NextFreeDriveLetter
+            if (-not $newLetter) {
+                Write-ScriptLog -Level Warning -Message "Disk $($diskGroup.Name): no temporary drive letter is available for EFI partition $($part.PartitionNumber)"
+                continue
+            }
             Write-ScriptLog -Message "Mounting hidden EFI partition on Disk $($diskGroup.Name) to $newLetter`:"
-            $part | Set-Partition -NewDriveLetter $newLetter -ErrorAction SilentlyContinue
-            # Track assigned letter for cleanup in finally block
-            $assignedEfiLetters += @{ Letter = $newLetter; DiskNumber = $diskGroup.Name; Partition = $part }
-            Start-Sleep -Seconds 2
+            $mountTracked = $false
+            try {
+                Invoke-IgnoreAllFailuresDiskPart -Operation 'bcd-assign' -Commands @(
+                    "select disk $($diskGroup.Name)"
+                    "select partition $($part.PartitionNumber)"
+                    "assign letter=$newLetter"
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                Start-Sleep -Seconds 2
+                $mountedPartition = Get-Partition -DiskNumber $diskGroup.Name -PartitionNumber $part.PartitionNumber -ErrorAction Stop
+                if ([string]$mountedPartition.DriveLetter -ine [string]$newLetter) {
+                    throw "Disk $($diskGroup.Name): temporary EFI mount on ${newLetter}: could not be verified."
+                }
+                $assignedEfiLetters += @{ Letter = $newLetter; DiskNumber = $diskGroup.Name; PartitionNumber = $part.PartitionNumber }
+                $mountTracked = $true
+                if (-not (Test-Path -LiteralPath "${newLetter}:\" -PathType Container)) {
+                    throw "Disk $($diskGroup.Name): verified letter ${newLetter}: is not accessible."
+                }
+            }
+            catch {
+                if (-not $mountTracked) {
+                    Invoke-IgnoreAllFailuresDiskPart -Operation 'failed-bcd-assign-cleanup' -Commands @(
+                        "select disk $($diskGroup.Name)"
+                        "select partition $($part.PartitionNumber)"
+                        "remove letter=$newLetter noerr"
+                    )
+                    Update-HostStorageCache -ErrorAction SilentlyContinue
+                }
+                throw
+            }
         }
 
-        $currentDrives = Get-Partition -DiskNumber $diskGroup.Name | Where-Object { $_.DriveLetter -ne 0 } | Select-Object -ExpandProperty DriveLetter
+        $currentDrives = Get-Partition -DiskNumber $diskGroup.Name | Where-Object { $_.DriveLetter -and $_.DriveLetter -ne [char]0 } | Select-Object -ExpandProperty DriveLetter
         foreach ($drive in $currentDrives) {
             $driveStr = "$($drive):"
             if ($null -eq $currentDiskBcdPath) {
-                if (Test-Path "$driveStr\boot\bcd") { $currentDiskBcdPath = "$driveStr\boot\bcd" }
-                elseif (Test-Path "$driveStr\efi\microsoft\boot\bcd") { $currentDiskBcdPath = "$driveStr\efi\microsoft\boot\bcd" }
+                $candidateBcdPath = if ($isGen2Disk) {
+                    "$driveStr\efi\microsoft\boot\bcd"
+                }
+                else {
+                    "$driveStr\boot\bcd"
+                }
+                if (Test-Path -LiteralPath $candidateBcdPath -PathType Leaf) {
+                    $currentDiskBcdPath = $candidateBcdPath
+                }
             }
-            if ($currentDiskOsFound -eq $false) {
-                if (Test-Path "$driveStr\windows\system32\winload.exe") { $currentDiskOsFound = $true }
-                elseif (Test-Path "$driveStr\windows\system32\winload.efi") { $currentDiskOsFound = $true }
+            if (-not $currentDiskOsDrive) {
+                $systemHivePath = "$driveStr\windows\system32\config\SYSTEM"
+                if ((Test-Path -LiteralPath $systemHivePath -PathType Leaf) -and
+                    ((Test-Path -LiteralPath "$driveStr\windows\system32\winload.exe" -PathType Leaf) -or
+                     (Test-Path -LiteralPath "$driveStr\windows\system32\winload.efi" -PathType Leaf))) {
+                    $currentDiskOsDrive = [string]$drive
+                }
             }
         }
 
-        if ($currentDiskBcdPath -and $currentDiskOsFound) {
+        if ($currentDiskBcdPath -and $currentDiskOsDrive) {
             Write-ScriptLog -Message "Disk $($diskGroup.Name): candidate BCD store found at $currentDiskBcdPath"
             $bcdout = bcdedit /store $currentDiskBcdPath /enum bootmgr /v 2>&1
             Add-CommandOutput -Header "--- BCD BOOTMGR OUTPUT (Disk $($diskGroup.Name)) ---" -Output $bcdout
@@ -243,10 +500,15 @@ try {
                 continue
             }
 
-            $defaultLine = $bcdout | Select-String 'displayorder' | Select-Object -First 1
+            $defaultLine = $bcdout | Select-String -Pattern '^\s*default\s+' | Select-Object -First 1
             
             if ($defaultLine -and ($defaultLine -match '\{([^}]+)\}')) {
                 $defaultId = $matches[0]
+                if ($defaultId -notmatch '^(?i)\{[0-9a-f\-]{36}\}$') {
+                    $failedDisks++
+                    Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): default BCD loader identifier '$defaultId' is invalid"
+                    continue
+                }
                 
                 $beforeRaw = bcdedit /store $currentDiskBcdPath /enum $defaultId 2>&1
                 Add-CommandOutput -Header "--- BCD BEFORE CHANGE (Disk $($diskGroup.Name)) ---" -Output $beforeRaw
@@ -255,38 +517,83 @@ try {
                     Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): failed to read BCD entry $defaultId before change (exit code $LASTEXITCODE)"
                     continue
                 }
-                
-                $setDefaultOutput = bcdedit /store $currentDiskBcdPath /default $defaultId 2>&1
-                Add-CommandOutput -Header "--- BCD SET DEFAULT OUTPUT (Disk $($diskGroup.Name)) ---" -Output $setDefaultOutput
-                if ($LASTEXITCODE -ne 0) {
+
+                $loaderText = $beforeRaw -join "`n"
+                $loaderPathMatch = [regex]::Match($loaderText, '(?im)^\s*path\s+(.+?)\s*$')
+                $loaderSystemRootMatch = [regex]::Match($loaderText, '(?im)^\s*systemroot\s+(.+?)\s*$')
+                if (-not $loaderPathMatch.Success -or -not $loaderSystemRootMatch.Success) {
                     $failedDisks++
-                    Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): failed to set default entry to $defaultId (exit code $LASTEXITCODE)"
+                    Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): default loader $defaultId is missing path or systemroot; refusing BCD changes"
                     continue
                 }
 
-                $setPolicyOutput = bcdedit /store $currentDiskBcdPath /set $defaultId bootstatuspolicy IgnoreAllFailures 2>&1
-                Add-CommandOutput -Header "--- BCD SET BOOTSTATUSPOLICY OUTPUT (Disk $($diskGroup.Name)) ---" -Output $setPolicyOutput
-                if ($LASTEXITCODE -ne 0) {
+                $loaderPath = $loaderPathMatch.Groups[1].Value.Trim()
+                $loaderSystemRoot = $loaderSystemRootMatch.Groups[1].Value.Trim()
+                $expectedLoaderPath = if ($isGen2Disk) { '\Windows\System32\winload.efi' } else { '\Windows\System32\winload.exe' }
+                if ($loaderPath -ine $expectedLoaderPath -or
+                    $loaderSystemRoot -ine '\Windows') {
                     $failedDisks++
-                    Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): failed to set bootstatuspolicy IgnoreAllFailures on $defaultId (exit code $LASTEXITCODE)"
+                    Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): default loader $defaultId has unsupported path or systemroot; refusing BCD changes"
                     continue
                 }
-                
-                $afterRaw = bcdedit /store $currentDiskBcdPath /enum $defaultId 2>&1
-                Add-CommandOutput -Header "--- BCD AFTER CHANGE (Disk $($diskGroup.Name)) ---" -Output $afterRaw
-                if ($LASTEXITCODE -ne 0) {
+
+                $resolvedLoaderPath = Join-Path -Path "${currentDiskOsDrive}:\" -ChildPath $loaderPath.TrimStart('\')
+                if (-not (Test-Path -LiteralPath $resolvedLoaderPath -PathType Leaf)) {
                     $failedDisks++
-                    Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): failed to read BCD entry $defaultId after change (exit code $LASTEXITCODE)"
+                    Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): default loader $defaultId does not resolve to '$resolvedLoaderPath'; refusing BCD changes"
                     continue
                 }
-                
-                $changedDisks++
-                $script_final_status = $STATUS_SUCCESS
-                Write-ScriptLog -Message "Disk $($diskGroup.Name): successfully set bootstatuspolicy IgnoreAllFailures for default entry $defaultId"
+
+                $bcdBackupPath = $currentDiskBcdPath + '.IgnoreAllFailures.bak.' + $timestamp
+                $bcdWriteStarted = $false
+                try {
+                    Copy-Item -LiteralPath $currentDiskBcdPath -Destination $bcdBackupPath -Force -ErrorAction Stop
+                    $sourceLength = (Get-Item -LiteralPath $currentDiskBcdPath -Force -ErrorAction Stop).Length
+                    $backupLength = (Get-Item -LiteralPath $bcdBackupPath -Force -ErrorAction Stop).Length
+                    if ($sourceLength -le 0 -or $backupLength -ne $sourceLength) {
+                        throw "BCD backup verification failed at '$bcdBackupPath'."
+                    }
+                    Write-ScriptLog -Message "Disk $($diskGroup.Name): verified BCD backup created at $bcdBackupPath"
+
+                    $bcdWriteStarted = $true
+                    $setPolicyOutput = bcdedit /store $currentDiskBcdPath /set $defaultId bootstatuspolicy IgnoreAllFailures 2>&1
+                    $setPolicyExitCode = $LASTEXITCODE
+                    Add-CommandOutput -Header "--- BCD SET BOOTSTATUSPOLICY OUTPUT (Disk $($diskGroup.Name)) ---" -Output $setPolicyOutput
+                    if ($setPolicyExitCode -ne 0) {
+                        throw "Failed to set bootstatuspolicy IgnoreAllFailures on $defaultId (exit code $setPolicyExitCode)."
+                    }
+
+                    $afterRaw = bcdedit /store $currentDiskBcdPath /enum $defaultId /v 2>&1
+                    $afterExitCode = $LASTEXITCODE
+                    Add-CommandOutput -Header "--- BCD AFTER CHANGE (Disk $($diskGroup.Name)) ---" -Output $afterRaw
+                    if ($afterExitCode -ne 0 -or ($afterRaw -join "`n") -notmatch '(?im)^\s*bootstatuspolicy\s+IgnoreAllFailures\s*$') {
+                        throw "Post-change verification failed for default loader $defaultId."
+                    }
+
+                    $changedDisks++
+                    $script_final_status = $STATUS_SUCCESS
+                    Write-ScriptLog -Message "Disk $($diskGroup.Name): successfully set and verified bootstatuspolicy IgnoreAllFailures for validated default entry $defaultId"
+                }
+                catch {
+                    $failedDisks++
+                    Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): BCD transaction failed: $($_.Exception.Message)"
+                    if ($bcdWriteStarted -and (Test-Path -LiteralPath $bcdBackupPath -PathType Leaf)) {
+                        try {
+                            Copy-Item -LiteralPath $bcdBackupPath -Destination $currentDiskBcdPath -Force -ErrorAction Stop
+                            if ((Get-Item -LiteralPath $currentDiskBcdPath -Force -ErrorAction Stop).Length -ne $backupLength) {
+                                throw 'Restored BCD length does not match the verified backup.'
+                            }
+                            Write-ScriptLog -Level Warning -Message "Disk $($diskGroup.Name): restored the verified BCD backup after transaction failure"
+                        }
+                        catch {
+                            Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): CRITICAL BCD rollback failure: $($_.Exception.Message)"
+                        }
+                    }
+                }
             }
             else {
                 $failedDisks++
-                Write-ScriptLog -Level Warning -Message "Disk $($diskGroup.Name): unable to identify default boot entry from displayorder"
+                Write-ScriptLog -Level Warning -Message "Disk $($diskGroup.Name): unable to identify the explicit default loader from boot manager"
             }
         }
         else {
@@ -306,14 +613,68 @@ finally {
         foreach ($efiMount in $assignedEfiLetters) {
             try {
                 Write-ScriptLog -Message "Removing drive letter $($efiMount.Letter): from EFI partition (Disk $($efiMount.DiskNumber))"
-                $efiMount.Partition | Set-Partition -NewDriveLetter $null -ErrorAction SilentlyContinue
+                Invoke-IgnoreAllFailuresDiskPart -Operation 'bcd-remove' -Commands @(
+                    "select disk $($efiMount.DiskNumber)"
+                    "select partition $($efiMount.PartitionNumber)"
+                    "remove letter=$($efiMount.Letter) noerr"
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
                 Start-Sleep -Seconds 1
+                $cleanedPartition = Get-Partition -DiskNumber $efiMount.DiskNumber -PartitionNumber $efiMount.PartitionNumber -ErrorAction Stop
+                if ([string]$cleanedPartition.DriveLetter -ieq [string]$efiMount.Letter) {
+                    throw 'Temporary EFI drive letter removal could not be verified.'
+                }
             }
             catch {
                 Write-ScriptLog -Level Warning -Message "Failed to remove drive letter $($efiMount.Letter): from EFI partition, but continuing cleanup: $($_.Exception.Message)"
+                $script_final_status = $STATUS_ERROR
             }
         }
     }
+
+    $identityRestorationFailed = $false
+    if ($repairDiskIdentityRecord) {
+        foreach ($diskNumber in @($gptCollisionDiskNumbers | Sort-Object -Unique)) {
+            try {
+                Invoke-IgnoreAllFailuresDiskPart -Operation 'source-before-repair-host-restore' -Commands @(
+                    "select disk $diskNumber"
+                    'offline disk'
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                $sourceDisk = Get-Disk -Number $diskNumber -ErrorAction Stop
+                $sourceIdentity = Get-IgnoreAllFailuresDiskIdentity -DiskNumber $diskNumber
+                if (-not $sourceDisk.IsOffline -or $sourceIdentity.Value -ine $repairDiskIdentityRecord.OriginalValue) {
+                    throw "Source Disk $diskNumber was not offline with its unchanged original GPT identity."
+                }
+            }
+            catch {
+                $identityRestorationFailed = $true
+                Write-ScriptLog -Level Error -Message "CRITICAL: Could not safely offline source Disk ${diskNumber}: $($_.Exception.Message)"
+            }
+        }
+        if (-not $identityRestorationFailed) {
+            try {
+                Restore-IgnoreAllFailuresRepairIdentity -Record $repairDiskIdentityRecord
+                Write-ScriptLog -Message 'Repair VM OS disk GPT identity restored and verified.'
+            }
+            catch {
+                $identityRestorationFailed = $true
+                Write-ScriptLog -Level Error -Message "CRITICAL: Failed to restore the repair VM OS disk identity: $($_.Exception.Message)"
+            }
+        }
+    }
+
+    foreach ($identityRecord in @($collisionDiskRecords | Sort-Object DiskNumber -Descending)) {
+        try {
+            Restore-IgnoreAllFailuresSourceIdentity -Record $identityRecord
+            Write-ScriptLog -Message "Disk $($identityRecord.DiskNumber) original MBR identity restored and verified."
+        }
+        catch {
+            $identityRestorationFailed = $true
+            Write-ScriptLog -Level Error -Message "CRITICAL: Failed to restore Disk $($identityRecord.DiskNumber) identity: $($_.Exception.Message)"
+        }
+    }
+    if ($identityRestorationFailed) { $script_final_status = $STATUS_ERROR }
     
     # Final logging of report via Log-Info (NOT Write-Output)
     if ($successReport.Count -gt 0) {
@@ -322,7 +683,7 @@ finally {
         }
     }
 
-    if ($changedDisks -eq 0) {
+    if ($changedDisks -eq 0 -or $failedDisks -gt 0) {
         $script_final_status = $STATUS_ERROR
     }
 

--- a/src/windows/win-ignoreAllFailures.ps1
+++ b/src/windows/win-ignoreAllFailures.ps1
@@ -28,6 +28,8 @@
                            - Restores and verifies every temporary GPT or MBR identity before reporting success.
                            - Verifies DiskPart mounts by access path to avoid stale Get-Partition drive-letter data.
                            - Probes unlettered non-EFI partitions and cleans up every temporary OS mount.
+                           - Uses typed temporary-mount records for Windows PowerShell 5.1 compatibility.
+                           - Repairs only unknown default-loader device mappings and verifies mapping invariance.
     v1.2: [May 2026] - Updated the script
                        - Added guarded nested VM handling to prevent Get-VM failures when Hyper-V module is unavailable.
                        - Switched partition discovery from inline CIM enumeration to shared Get-Disk-Partitions-v2 helper.
@@ -36,17 +38,20 @@
     v1.0: Initial commit - Sets BCD boot status policy to IgnoreAllFailures to break Automatic Repair loops
         
 .SCENARIO_RECREATION
-    To recreate a testable scenario on a rescue VM with an attached OS disk:
-    1. Create a test VM in Azure and attach its OS disk to a rescue VM.
-    2. Find the attached disk's drive letter and locate the BCD store:
+    To recreate a testable scenario on a disposable test VM:
+    1. Set the default loader to DisplayAllFailures before stopping the test VM:
+bcdedit /set {default} bootstatuspolicy DisplayAllFailures
+    2. Verify the policy:
+bcdedit /enum {default}
+    Expected: bootstatuspolicy = DisplayAllFailures.
+    3. Trigger an unclean stop of the disposable VM, then use Azure VM Repair to attach its OS disk to a rescue VM.
+    4. Find the attached disk's drive letter and locate the BCD store:
        Gen1: <drive>:\boot\bcd  |  Gen2: <drive>:\efi\microsoft\boot\bcd
-    3. Remove or reset the bootstatuspolicy to simulate an Automatic Repair loop (replace <bcdpath> with your actual BCD path):
-bcdedit /store <bcdpath> /deletevalue {default} bootstatuspolicy
-    4. Verify bootstatuspolicy is absent:
+    5. Verify the offline store still has the failure-display policy (replace <bcdpath> with the actual BCD path):
 bcdedit /store <bcdpath> /enum {default}
-    Expected: No bootstatuspolicy line in the output.
-    5. Run the script. It should set bootstatuspolicy to IgnoreAllFailures.
-    6. Verify the change:
+    Expected: bootstatuspolicy = DisplayAllFailures.
+    6. Run the script. It should set bootstatuspolicy to IgnoreAllFailures.
+    7. Verify the change:
 bcdedit /store <bcdpath> /enum {default}
     Expected: bootstatuspolicy = IgnoreAllFailures.
 
@@ -448,7 +453,11 @@ try {
                 if (-not (Test-Path -LiteralPath "${newLetter}:\" -PathType Container)) {
                     throw "Disk $($diskGroup.Name): temporary EFI mount on ${newLetter}: could not be verified."
                 }
-                $assignedEfiLetters += @{ Letter = $newLetter; DiskNumber = $diskGroup.Name; PartitionNumber = $part.PartitionNumber }
+                $assignedEfiLetters += [pscustomobject]@{
+                    Letter = [string]$newLetter
+                    DiskNumber = [int]$diskGroup.Name
+                    PartitionNumber = [int]$part.PartitionNumber
+                }
                 $mountTracked = $true
             }
             catch {
@@ -528,7 +537,11 @@ try {
 
                     Write-ScriptLog -Message "Disk $($diskGroup.Name): checked temporary ${osLetter}: for Windows; mounted=$osMounted systemHive=$hasSystemHive loader=$hasWindowsLoader"
                     if ($hasSystemHive -and $hasWindowsLoader) {
-                        $assignedOsLetters += @{ Letter = $osLetter; DiskNumber = $diskGroup.Name; PartitionNumber = $osCandidate.PartitionNumber }
+                        $assignedOsLetters += [pscustomobject]@{
+                            Letter = [string]$osLetter
+                            DiskNumber = [int]$diskGroup.Name
+                            PartitionNumber = [int]$osCandidate.PartitionNumber
+                        }
                         $osMountTracked = $true
                         $currentDiskOsDrive = [string]$osLetter
                         break
@@ -582,15 +595,34 @@ try {
 
                 $loaderText = $beforeRaw -join "`n"
                 $loaderPathMatch = [regex]::Match($loaderText, '(?im)^\s*path\s+(.+?)\s*$')
+                $loaderDeviceMatch = [regex]::Match($loaderText, '(?im)^\s*device\s+(.+?)\s*$')
+                $loaderOsDeviceMatch = [regex]::Match($loaderText, '(?im)^\s*osdevice\s+(.+?)\s*$')
                 $loaderSystemRootMatch = [regex]::Match($loaderText, '(?im)^\s*systemroot\s+(.+?)\s*$')
-                if (-not $loaderPathMatch.Success -or -not $loaderSystemRootMatch.Success) {
+                if (-not $loaderPathMatch.Success -or
+                    -not $loaderDeviceMatch.Success -or
+                    -not $loaderOsDeviceMatch.Success -or
+                    -not $loaderSystemRootMatch.Success) {
                     $failedDisks++
-                    Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): default loader $defaultId is missing path or systemroot; refusing BCD changes"
+                    Write-ScriptLog -Level Error -Message "Disk $($diskGroup.Name): default loader $defaultId is missing required mapping elements; refusing BCD changes"
                     continue
                 }
 
                 $loaderPath = $loaderPathMatch.Groups[1].Value.Trim()
+                $loaderDevice = $loaderDeviceMatch.Groups[1].Value.Trim()
+                $loaderOsDevice = $loaderOsDeviceMatch.Groups[1].Value.Trim()
                 $loaderSystemRoot = $loaderSystemRootMatch.Groups[1].Value.Trim()
+                $expectedDeviceAfterWrite = if ($loaderDevice -match '(?i)^unknown$') {
+                    "partition=${currentDiskOsDrive}:"
+                }
+                else {
+                    $loaderDevice
+                }
+                $expectedOsDeviceAfterWrite = if ($loaderOsDevice -match '(?i)^unknown$') {
+                    "partition=${currentDiskOsDrive}:"
+                }
+                else {
+                    $loaderOsDevice
+                }
                 $expectedLoaderPath = if ($isGen2Disk) { '\Windows\System32\winload.efi' } else { '\Windows\System32\winload.exe' }
                 if ($loaderPath -ine $expectedLoaderPath -or
                     $loaderSystemRoot -ine '\Windows') {
@@ -618,6 +650,24 @@ try {
                     Write-ScriptLog -Message "Disk $($diskGroup.Name): verified BCD backup created at $bcdBackupPath"
 
                     $bcdWriteStarted = $true
+                    $validatedWindowsPartition = "partition=${currentDiskOsDrive}:"
+                    if ($loaderDevice -match '(?i)^unknown$') {
+                        $setDeviceOutput = bcdedit /store $currentDiskBcdPath /set $defaultId device $validatedWindowsPartition 2>&1
+                        $setDeviceExitCode = $LASTEXITCODE
+                        Add-CommandOutput -Header "--- BCD REPAIR DEVICE OUTPUT (Disk $($diskGroup.Name)) ---" -Output $setDeviceOutput
+                        if ($setDeviceExitCode -ne 0) {
+                            throw "Failed to repair unknown device mapping on $defaultId (exit code $setDeviceExitCode)."
+                        }
+                    }
+                    if ($loaderOsDevice -match '(?i)^unknown$') {
+                        $setOsDeviceOutput = bcdedit /store $currentDiskBcdPath /set $defaultId osdevice $validatedWindowsPartition 2>&1
+                        $setOsDeviceExitCode = $LASTEXITCODE
+                        Add-CommandOutput -Header "--- BCD REPAIR OSDEVICE OUTPUT (Disk $($diskGroup.Name)) ---" -Output $setOsDeviceOutput
+                        if ($setOsDeviceExitCode -ne 0) {
+                            throw "Failed to repair unknown osdevice mapping on $defaultId (exit code $setOsDeviceExitCode)."
+                        }
+                    }
+
                     $setPolicyOutput = bcdedit /store $currentDiskBcdPath /set $defaultId bootstatuspolicy IgnoreAllFailures 2>&1
                     $setPolicyExitCode = $LASTEXITCODE
                     Add-CommandOutput -Header "--- BCD SET BOOTSTATUSPOLICY OUTPUT (Disk $($diskGroup.Name)) ---" -Output $setPolicyOutput
@@ -628,7 +678,21 @@ try {
                     $afterRaw = bcdedit /store $currentDiskBcdPath /enum $defaultId /v 2>&1
                     $afterExitCode = $LASTEXITCODE
                     Add-CommandOutput -Header "--- BCD AFTER CHANGE (Disk $($diskGroup.Name)) ---" -Output $afterRaw
-                    if ($afterExitCode -ne 0 -or ($afterRaw -join "`n") -notmatch '(?im)^\s*bootstatuspolicy\s+IgnoreAllFailures\s*$') {
+                    $afterText = $afterRaw -join "`n"
+                    $afterPathMatch = [regex]::Match($afterText, '(?im)^\s*path\s+(.+?)\s*$')
+                    $afterDeviceMatch = [regex]::Match($afterText, '(?im)^\s*device\s+(.+?)\s*$')
+                    $afterOsDeviceMatch = [regex]::Match($afterText, '(?im)^\s*osdevice\s+(.+?)\s*$')
+                    $afterSystemRootMatch = [regex]::Match($afterText, '(?im)^\s*systemroot\s+(.+?)\s*$')
+                    if ($afterExitCode -ne 0 -or
+                        -not $afterPathMatch.Success -or
+                        -not $afterDeviceMatch.Success -or
+                        -not $afterOsDeviceMatch.Success -or
+                        -not $afterSystemRootMatch.Success -or
+                        $afterPathMatch.Groups[1].Value.Trim() -ine $loaderPath -or
+                        $afterDeviceMatch.Groups[1].Value.Trim() -ine $expectedDeviceAfterWrite -or
+                        $afterOsDeviceMatch.Groups[1].Value.Trim() -ine $expectedOsDeviceAfterWrite -or
+                        $afterSystemRootMatch.Groups[1].Value.Trim() -ine $loaderSystemRoot -or
+                        $afterText -notmatch '(?im)^\s*bootstatuspolicy\s+IgnoreAllFailures\s*$') {
                         throw "Post-change verification failed for default loader $defaultId."
                     }
 


### PR DESCRIPTION
v1.3: [August 2026] - Validates temporary EFI mounts before tracking them for cleanup.
                           - Excludes null and empty drive letters from mounted partition scans.
                           - Aligns BCD target validation and no-boot protections with the proven repair scripts.
                           - Excludes repair-host critical disks and preserves source disk identities across collisions.
                           - Restores and verifies every temporary GPT or MBR identity before reporting success.