### PR TITLE
Update win-LKGC.ps1 to 1.3.1

### DIFF
--- a/src/windows/win-LKGC.ps1
+++ b/src/windows/win-LKGC.ps1
@@ -170,7 +170,7 @@ function Invoke-LkgcDiskPart {
 
     $output = $Commands | diskpart 2>&1
     foreach ($line in @($output)) {
-        if ($line) { Log-Output "[diskpart][$Operation] $line" | Out-Null }
+        if ($line) { Write-LogOutput "[diskpart][$Operation] $line" | Out-Null }
     }
 }
 
@@ -186,7 +186,7 @@ function Invoke-LkgcBcdEdit {
     $output = & bcdedit.exe @Arguments 2>&1
     $exitCode = $LASTEXITCODE
     foreach ($line in @($output)) {
-        if ($line) { Log-Output "[bcdedit][$Operation] $line" | Out-Null }
+        if ($line) { Write-LogOutput "[bcdedit][$Operation] $line" | Out-Null }
     }
     return [pscustomobject]@{
         Output = @($output)
@@ -196,6 +196,7 @@ function Invoke-LkgcBcdEdit {
 }
 
 function Set-LkgcTemporarySourceDiskIdentity {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true)]
         [pscustomobject]$Record
@@ -205,17 +206,19 @@ function Set-LkgcTemporarySourceDiskIdentity {
         throw 'Temporary source disk identities are permitted only for the Gen1 MBR path.'
     }
 
-    Invoke-LkgcDiskPart -Operation 'collision-prepare' -Commands @(
-        "select disk $($Record.DiskNumber)"
-        "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
-        'online disk'
-    )
-    Update-HostStorageCache -ErrorAction SilentlyContinue
+    if ($PSCmdlet.ShouldProcess("Disk $($Record.DiskNumber)", "temporarily set identity to $($Record.TemporaryValue)")) {
+        Invoke-LkgcDiskPart -Operation 'collision-prepare' -Commands @(
+            "select disk $($Record.DiskNumber)"
+            "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
+            'online disk'
+        )
+        Update-HostStorageCache -ErrorAction SilentlyContinue
 
-    $currentIdentity = Get-LkgcDiskIdentity -DiskNumber $Record.DiskNumber
-    $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
-    if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
-        throw "Disk $($Record.DiskNumber) could not be brought online with its verified temporary identity."
+        $currentIdentity = Get-LkgcDiskIdentity -DiskNumber $Record.DiskNumber
+        $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+        if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
+            throw "Disk $($Record.DiskNumber) could not be brought online with its verified temporary identity."
+        }
     }
 }
 
@@ -240,21 +243,24 @@ function Restore-LkgcSourceDiskIdentity {
 }
 
 function Set-LkgcTemporaryRepairDiskIdentity {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true)]
         [pscustomobject]$Record
     )
 
-    Invoke-LkgcDiskPart -Operation 'repair-host-collision-prepare' -Commands @(
-        "select disk $($Record.DiskNumber)"
-        "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
-    )
-    Update-HostStorageCache -ErrorAction SilentlyContinue
+    if ($PSCmdlet.ShouldProcess("Repair disk $($Record.DiskNumber)", "temporarily set GPT identity to $($Record.TemporaryValue)")) {
+        Invoke-LkgcDiskPart -Operation 'repair-host-collision-prepare' -Commands @(
+            "select disk $($Record.DiskNumber)"
+            "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
+        )
+        Update-HostStorageCache -ErrorAction SilentlyContinue
 
-    $currentIdentity = Get-LkgcDiskIdentity -DiskNumber $Record.DiskNumber
-    $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
-    if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
-        throw 'The repair VM OS disk did not retain a verified temporary GPT identity.'
+        $currentIdentity = Get-LkgcDiskIdentity -DiskNumber $Record.DiskNumber
+        $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+        if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
+            throw 'The repair VM OS disk did not retain a verified temporary GPT identity.'
+        }
     }
 }
 
@@ -297,7 +303,7 @@ $script:OriginalLogWarning = (Get-Command Log-Warning -CommandType Function).Scr
 $script:OriginalLogError = (Get-Command Log-Error -CommandType Function).ScriptBlock
 $script:OriginalLogDebug = (Get-Command Log-Debug -CommandType Function).ScriptBlock
 
-function Write-DesktopLogLine {
+function Write-DesktopLogEntry {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Level,
@@ -316,19 +322,19 @@ function Write-DesktopLogLine {
     }
 }
 
-function Log-Output {
+function Write-LogOutput {
     Param([Parameter(Mandatory = $true)][PSObject[]]$message)
     & $script:OriginalLogOutput -message $message
-    Write-DesktopLogLine -Level 'Output' -Message $message
+    Write-DesktopLogEntry -Level 'Output' -Message $message
 }
-function Log-Info { Param([PSObject[]]$message) & $script:OriginalLogInfo -message $message; Write-DesktopLogLine -Level 'Info' -Message $message }
-function Log-Warning { Param([PSObject[]]$message) & $script:OriginalLogWarning -message $message; Write-DesktopLogLine -Level 'Warning' -Message $message }
-function Log-Error {
+function Write-LogInfo { Param([PSObject[]]$message) & $script:OriginalLogInfo -message $message; Write-DesktopLogEntry -Level 'Info' -Message $message }
+function Write-LogWarning { Param([PSObject[]]$message) & $script:OriginalLogWarning -message $message; Write-DesktopLogEntry -Level 'Warning' -Message $message }
+function Write-LogError {
     Param([Parameter(Mandatory = $true)][PSObject[]]$message)
     & $script:OriginalLogError -message $message
-    Write-DesktopLogLine -Level 'Error' -Message $message
+    Write-DesktopLogEntry -Level 'Error' -Message $message
 }
-function Log-Debug { Param([PSObject[]]$message) & $script:OriginalLogDebug -message $message; Write-DesktopLogLine -Level 'Debug' -Message $message }
+function Write-LogDebug { Param([PSObject[]]$message) & $script:OriginalLogDebug -message $message; Write-DesktopLogEntry -Level 'Debug' -Message $message }
 
 $script:RepairScriptVersion = '1.3'
 $script:ExecutionStarted = Get-Date
@@ -362,8 +368,67 @@ function Write-LkgcTelemetry {
     }
 }
 
-Log-Info "Starting AUTO LKGC Script. Desktop log: $logFilePath"
-Log-Info "[script_start] Script=win-LKGC Version=$($script:RepairScriptVersion)"
+function Write-LkgcResolutionTelemetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ResolutionPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Outcome,
+
+        [string]$DiskNumber = '',
+
+        [string]$TargetDrive = '',
+
+        [hashtable]$Properties = @{}
+    )
+
+    $props = @{
+        CoverageCategory = 'ResolutionPath'
+        ResolutionPath = $ResolutionPath
+        Outcome = $Outcome
+        DiskNumber = $DiskNumber
+        TargetDrive = $TargetDrive
+    }
+
+    foreach ($key in $Properties.Keys) {
+        $props[$key] = $Properties[$key]
+    }
+
+    Write-LkgcTelemetry -Event Operation -Message "Resolution path: $ResolutionPath" -Properties $props
+}
+
+function Write-LkgcCatchTelemetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CatchName,
+
+        [string]$DiskNumber = '',
+
+        [string]$TargetDrive = '',
+
+        [string]$Stage = '',
+
+        [hashtable]$Properties = @{}
+    )
+
+    $props = @{
+        CoverageCategory = 'CatchBlock'
+        CatchName = $CatchName
+        DiskNumber = $DiskNumber
+        TargetDrive = $TargetDrive
+        Stage = $Stage
+    }
+
+    foreach ($key in $Properties.Keys) {
+        $props[$key] = $Properties[$key]
+    }
+
+    Write-LkgcTelemetry -Event Error -Message "Catch block: $CatchName" -Properties $props
+}
+
+Write-LogInfo "Starting AUTO LKGC Script. Desktop log: $logFilePath"
+Write-LogInfo "[script_start] Script=win-LKGC Version=$($script:RepairScriptVersion)"
 Write-LkgcTelemetry -Event Start -Message 'Starting LKGC restoration' -Properties @{
     ScriptName = 'win-LKGC.ps1'
     ScriptVersion = $script:RepairScriptVersion
@@ -389,7 +454,14 @@ try {
         $guestHyperVVirtualMachine = Get-VM -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
         if ($guestHyperVVirtualMachine -and $guestHyperVVirtualMachine.State -eq 'Running') {
             Log-Info "Stopping nested guest VM $($guestHyperVVirtualMachine.VMName)"
-            try { Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force } catch { Log-Warning "Failed to stop nested guest VM" }
+            try {
+            Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
+        }
+        catch {
+            $errorMessage = $_.Exception.Message
+            Write-LogWarning "Failed to stop nested guest VM: $errorMessage"
+            Write-LkgcCatchTelemetry -CatchName 'NestedVmStop' -DiskNumber '' -TargetDrive $env:SystemDrive -Stage 'Preflight' -Properties @{ Error = $errorMessage }
+        }
         }
     } else {
         Log-Info "Hyper-V PowerShell module is not available on this host. Skipping nested VM validation."
@@ -403,7 +475,7 @@ try {
     }
     $repairDiskNumber = [int]$repairOsPartition.DiskNumber
     $repairDiskIdentity = Get-LkgcDiskIdentity -DiskNumber $repairDiskNumber
-    Log-Info "Repair VM OS disk identified as Disk $repairDiskNumber ($($repairDiskIdentity.PartitionStyle))."
+    Write-LogInfo "Repair VM OS disk identified as Disk $repairDiskNumber ($($repairDiskIdentity.PartitionStyle))."
 
     # Match the latest SAC path: resolve identity collisions before the helper onlines disks.
     $azureVirtualDiskNumbers = @(Get-CimInstance -ClassName Win32_DiskDrive -ErrorAction Stop |
@@ -434,10 +506,12 @@ try {
                     TemporaryDiskPartValue = $temporaryRepairGuid
                 }
                 Log-Warning 'Temporarily changing only the repair VM OS disk GPT identity to release the attached Gen2 collision. The source disk GUID will not be changed.'
+                Write-LkgcResolutionTelemetry -ResolutionPath 'RepairDiskIdentityCollisionRelease' -Outcome 'Preparing' -DiskNumber "$repairDiskNumber" -TargetDrive "$repairDrive" -Properties @{ OriginalIdentity = $repairDiskIdentity.Value; TemporaryIdentity = $temporaryRepairGuid }
                 Set-LkgcTemporaryRepairDiskIdentity -Record $repairDiskIdentityRecord
             }
 
             $gptCollisionDiskNumbers += [int]$collisionDisk.Number
+            Write-LkgcResolutionTelemetry -ResolutionPath 'SourceDiskCollisionRelease' -Outcome 'Proceeding' -DiskNumber "$($collisionDisk.Number)" -TargetDrive "$repairDrive" -Properties @{ OriginalIdentity = $originalIdentity.Value }
             Invoke-LkgcDiskPart -Operation 'source-gpt-online' -Commands @(
                 "select disk $($collisionDisk.Number)"
                 'online disk'
@@ -468,6 +542,7 @@ try {
         }
         $collisionDiskRecords += $record
         Log-Warning "Disk $($record.DiskNumber) is offline due to an identity collision. Applying a temporary MBR identity for this repair run."
+        Write-LkgcResolutionTelemetry -ResolutionPath 'SourceDiskTemporaryIdentity' -Outcome 'Prepared' -DiskNumber "$($record.DiskNumber)" -TargetDrive "$repairDrive" -Properties @{ OriginalIdentity = $originalIdentity.Value; TemporaryIdentity = $temporaryValue }
         Set-LkgcTemporarySourceDiskIdentity -Record $record
     }
 
@@ -581,6 +656,7 @@ try {
 
             if (-not $targetOSDrive) {
                 Log-Info "Disk $diskNumber skipped: no valid attached OS partition containing \Windows found."
+                Write-LkgcResolutionTelemetry -ResolutionPath 'TargetDiskSkip' -Outcome 'Skipped' -DiskNumber "$diskNumber" -TargetDrive '' -Properties @{ Reason = 'No valid Windows SYSTEM hive found on attached partitions' }
                 $skippedCount++
                 continue
             }
@@ -643,6 +719,7 @@ try {
             }
 
             if (-not $bcdPath) {
+                Write-LkgcResolutionTelemetry -ResolutionPath 'BCDDiscovery' -Outcome 'Failed' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Properties @{ Reason = 'No generation-appropriate BCD store found' }
                 throw "Disk $diskNumber has no generation-appropriate BCD store. No registry changes were attempted."
             }
 
@@ -707,7 +784,8 @@ try {
             if ($repairLoaderDevice -or $repairLoaderOsDevice) {
                 $validatedWindowsPartition = "partition=${targetOSDrive}:"
                 $bcdWriteStarted = $true
-                Log-Warning "Loader mapping contains an unknown descriptor. Repairing it to $validatedWindowsPartition using the validated Windows partition."
+                Write-LkgcResolutionTelemetry -ResolutionPath 'LoaderMappingRepair' -Outcome 'Repairing' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Properties @{ LoaderId = $defaultLoaderId; RepairDevice = [bool]$repairLoaderDevice; RepairOsDevice = [bool]$repairLoaderOsDevice }
+                Write-LogWarning "Loader mapping contains an unknown descriptor. Repairing it to $validatedWindowsPartition using the validated Windows partition."
                 if ($repairLoaderDevice) {
                     $setDevice = Invoke-LkgcBcdEdit -Arguments @('/store', $bcdPath, '/set', $defaultLoaderId, 'device', $validatedWindowsPartition) -Operation 'repair-loader-device'
                     if (-not $setDevice.Success) { throw "Could not repair device for loader $defaultLoaderId." }
@@ -739,6 +817,7 @@ try {
 
             if ($restoreTestBootPolicy) {
                 $bcdWriteStarted = $true
+                Write-LkgcResolutionTelemetry -ResolutionPath 'BootPolicyRestore' -Outcome 'Repairing' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Properties @{ LoaderId = $defaultLoaderId }
                 $removeBootPolicy = Invoke-LkgcBcdEdit -Arguments @('/store', $bcdPath, '/deletevalue', $defaultLoaderId, 'bootstatuspolicy') -Operation 'restore-bootstatuspolicy'
                 if (-not $removeBootPolicy.Success) {
                     throw "Could not remove the lab bootstatuspolicy from loader $defaultLoaderId."
@@ -759,46 +838,45 @@ try {
                 Log-Info "Disk ${diskNumber}: normal boot recovery policy restored and verified."
             }
 
-        $systemHivePath = "$(${targetOSDrive}):\Windows\System32\config\SYSTEM"
-        $systemHiveBackup = "$systemHivePath.LKGC.bak.$runTimestamp"
+            $systemHivePath = "$(${targetOSDrive}):\Windows\System32\config\SYSTEM"
+            $systemHiveBackup = "$systemHivePath.LKGC.bak.$runTimestamp"
 
-        try {
-            Copy-Item -LiteralPath $systemHivePath -Destination $systemHiveBackup -Force -ErrorAction Stop
-            Log-Info "[$targetOSDrive] SYSTEM hive backup created: $systemHiveBackup"
-        }
-        catch {
-            $failedCount++
-            Log-Error "[$targetOSDrive] Failed to create SYSTEM hive backup. Skipping disk. Error: $($_.Exception.Message)"
-            continue
-        }
-
-        # Step 2 - Load the SYSTEM hive from the target disk
-        $sysHive = "HKLM\BROKENSYS_$targetOSDrive"
-        [System.GC]::Collect()
-        [System.GC]::WaitForPendingFinalizers()
-        for ($preLoadUnloadAttempt = 1; $preLoadUnloadAttempt -le 3; $preLoadUnloadAttempt++) {
-            $preLoadUnloadOutput = & reg.exe unload $sysHive 2>&1
-            if ($LASTEXITCODE -eq 0) {
-                Log-Info "[$targetOSDrive] Removed a stale pre-existing hive mount on attempt $preLoadUnloadAttempt."
-                break
+            try {
+                Copy-Item -LiteralPath $systemHivePath -Destination $systemHiveBackup -Force -ErrorAction Stop
+                Write-LkgcResolutionTelemetry -ResolutionPath 'SystemHiveBackup' -Outcome 'Created' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Properties @{ BackupPath = $systemHiveBackup }
+                Log-Info "[$targetOSDrive] SYSTEM hive backup created: $systemHiveBackup"
             }
-            if ($preLoadUnloadAttempt -lt 3) { Start-Sleep -Seconds 2 }
-        }
-        $sysLoad = & reg.exe load $sysHive $systemHivePath 2>&1
+            catch {
+                $failedCount++
+            Write-LkgcCatchTelemetry -CatchName 'SystemHiveBackupCreate' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Stage 'Backup' -Properties @{ BackupPath = $systemHiveBackup; Error = $_.Exception.Message }
+            }
 
-        if ($LASTEXITCODE -ne 0) {
-            $failedCount++
-            Log-Warning "Failed to load SYSTEM hive from $($targetOSDrive): $($sysLoad -join ' | ') - skipping"
-            continue
-        }
+            # Step 2 - Load the SYSTEM hive from the target disk
+            $sysHive = "HKLM\BROKENSYS_$targetOSDrive"
+            [System.GC]::Collect()
+            [System.GC]::WaitForPendingFinalizers()
+            for ($preLoadUnloadAttempt = 1; $preLoadUnloadAttempt -le 3; $preLoadUnloadAttempt++) {
+                $preLoadUnloadOutput = & reg.exe unload $sysHive 2>&1
+                if ($LASTEXITCODE -eq 0) {
+                    Write-LogInfo "[$targetOSDrive] Removed a stale pre-existing hive mount on attempt $preLoadUnloadAttempt. Output: $($preLoadUnloadOutput -join ' ')"
+                    break
+                }
+                if ($preLoadUnloadAttempt -lt 3) { Start-Sleep -Seconds 2 }
+            }
+            $sysLoad = & reg.exe load $sysHive $systemHivePath 2>&1
 
-        Start-Sleep -Seconds 2
+            if ($LASTEXITCODE -ne 0) {
+                $failedCount++
+            Write-LkgcCatchTelemetry -CatchName 'SystemHiveLoad' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Stage 'Load' -Properties @{ HivePath = $systemHivePath; Error = ($sysLoad -join ' | ') }
+            }
 
-        $writeAttempted = $false
-        $restoreRequired = $false
-        $subKeyPath = "BROKENSYS_$targetOSDrive\Select"
-        $regKey = $null
-        $systemRootKey = $null
+            Write-LkgcResolutionTelemetry -ResolutionPath 'SystemHiveLoad' -Outcome 'Loaded' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Properties @{ HiveName = $sysHive; HivePath = $systemHivePath }
+
+            $writeAttempted = $false
+            $restoreRequired = $false
+            $subKeyPath = "BROKENSYS_$targetOSDrive\Select"
+            $regKey = $null
+            $systemRootKey = $null
 
         try {
             # Step 4 - Open via direct .NET API to eliminate PowerShell registry caching engine bugs
@@ -872,6 +950,7 @@ try {
             if ($lastKnownGood -eq $currentVal) {
                 Log-Warning "[$targetOSDrive] NO ALTERNATE LKGC EXISTS: LastKnownGood and Current both reference ControlSet$('{0:D3}' -f $currentVal)."
                 Log-Info "[$targetOSDrive] LKGC_APPLIED=false"
+                Write-LkgcResolutionTelemetry -ResolutionPath 'LKGCNoAlternate' -Outcome 'No-Op' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Properties @{ Current = $currentVal; LastKnownGood = $lastKnownGood }
                 Write-LkgcTelemetry -Event Success -Message "No alternate LKGC is available on drive $targetOSDrive" -Properties @{
                     DiskNumber  = "$diskNumber"
                     TargetDrive = "$targetOSDrive"
@@ -922,6 +1001,7 @@ try {
                 }
 
                 Log-Output -Message "LKGC APPLIED"
+                Write-LkgcResolutionTelemetry -ResolutionPath 'LKGCWrite' -Outcome 'Applied' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Properties @{ Current = $afterCurrent; Default = $afterDefault; Failed = $afterFailed; LastKnownGood = $afterLKG }
                 Write-LkgcTelemetry -Event Success -Message "LKGC registry values updated on drive $targetOSDrive" -Properties $telemetryProperties
 
                 $lkgcAppliedAny = $true
@@ -935,8 +1015,11 @@ try {
             $failedCount++
             $registryProcessingFailed = $true
             if ($writeAttempted) { $restoreRequired = $true }
+            Write-LkgcCatchTelemetry -CatchName 'RegistryMutation' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Stage 'RegistryWrite' -Properties @{ WriteAttempted = "$writeAttempted"; Error = $_.Exception.Message }
             Log-Error -Message "[$targetOSDrive] Failed to process registry modifications: $($_.Exception.Message)"
             Write-LkgcTelemetry -Event Error -Message 'Failed to process registry modifications' -Properties @{
+                CoverageCategory = 'CatchBlock'
+                CatchName = 'RegistryMutation'
                 DiskNumber    = "$diskNumber"
                 TargetDrive   = "$targetOSDrive"
                 WriteAttempted = "$writeAttempted"
@@ -946,8 +1029,8 @@ try {
         }
         finally {
             if ($null -ne $systemRootKey) {
-                try { $systemRootKey.Close() } catch {}
-                try { $systemRootKey.Dispose() } catch {}
+                try { $systemRootKey.Close() } catch { Write-LogDebug "[$targetOSDrive] Unable to close the SYSTEM root key cleanly: $($_.Exception.Message)" }
+                try { $systemRootKey.Dispose() } catch { Write-LogDebug "[$targetOSDrive] Unable to dispose the SYSTEM root key cleanly: $($_.Exception.Message)" }
             }
             if ($null -ne $regKey) {
                 try {
@@ -959,11 +1042,11 @@ try {
                         $registryProcessingFailed = $true
                     }
                     $restoreRequired = $true
-                    Log-Error "[$targetOSDrive] Failed to flush the SYSTEM hive Select key: $($_.Exception.Message)"
+                    Write-LogError "[$targetOSDrive] Failed to flush the SYSTEM hive Select key: $($_.Exception.Message)"
                 }
                 finally {
-                    try { $regKey.Close() } catch {}
-                    try { $regKey.Dispose() } catch {}
+                    try { $regKey.Close() } catch { Write-LogDebug "[$targetOSDrive] Unable to close the SYSTEM Select key cleanly: $($_.Exception.Message)" }
+                    try { $regKey.Dispose() } catch { Write-LogDebug "[$targetOSDrive] Unable to dispose the SYSTEM Select key cleanly: $($_.Exception.Message)" }
                 }
             }
             [System.GC]::Collect()
@@ -974,7 +1057,11 @@ try {
             $unloaded = $false
             for ($i=1; $i -le 3; $i++) {
                 $unloadOutput = & reg.exe unload $sysHive 2>&1
-                if ($LASTEXITCODE -eq 0) { $unloaded = $true; break }
+                if ($LASTEXITCODE -eq 0) {
+                    $unloaded = $true
+                    Write-LogDebug "[$targetOSDrive] Hive unload succeeded on attempt $i. Output: $($unloadOutput -join ' ')"
+                    break
+                }
                 Start-Sleep -Seconds 5
             }
 
@@ -1010,6 +1097,7 @@ try {
         }
         catch {
             $failedCount++
+            Write-LkgcCatchTelemetry -CatchName 'DiskProcessing' -DiskNumber "$diskNumber" -TargetDrive "$targetOSDrive" -Stage 'DiscoveryOrRepair' -Properties @{ Error = $_.Exception.Message }
             Log-Error "Disk $diskNumber failed during OS discovery or LKGC processing: $($_.Exception.Message)"
             if ($bcdWriteStarted -and -not $bcdBackupRestored -and
                 $bcdBackup -and (Test-Path -LiteralPath $bcdBackup -PathType Leaf)) {

--- a/src/windows/win-LKGC.ps1
+++ b/src/windows/win-LKGC.ps1
@@ -1,6 +1,7 @@
 <#
 .SYNOPSIS
-    Enables Last Known Good Configuration (LKGC) by incrementing the Select registry values.
+    Restores Last Known Good Configuration (LKGC) on attached Windows OS disks by updating
+    Select values in each offline SYSTEM registry hive.
 
 .DESCRIPTION
     This script runs from a rescue VM to activate LKGC on an attached faulty OS disk.
@@ -8,30 +9,61 @@
     It performs the following steps:
     1. Enumerates attached partitions via Get-Disk-Partitions, grouping by DiskNumber to isolate targets.
     2. Creates a safety backup of the target SYSTEM hive before modification.
-    3. Loads the SOFTWARE hive temporarily to verify the specific Windows version threshold engine.
-    4. Opens the Select key using explicit .NET API frameworks to avoid provider caching.
-    5. Evaluates threshold logic metrics via strict AND-logic parameters.
-    6. Increments the configuration values (current, default, failed, LastKnownGood) to force LKGC validation.
-    7. Unloads the hive safely using a defensive 3x retry loop with explicit garbage collection.
+    3. Opens the Select key using explicit .NET API frameworks to avoid provider caching.
+    4. Validates that referenced control sets contain core Control and Services trees.
+    5. Selects the existing LastKnownGood control set without inventing control-set numbers.
+    6. Unloads the hive safely using a defensive 3x retry loop with explicit garbage collection.
 
 .NOTES
-    Name:    win-LKGC.ps1
-    Author:  Tony.Mocanu@Microsoft.com
+    Name:          win-LKGC.ps1
+    Author:        Tony.Mocanu@Microsoft.com
+    Last Modified: 2026-08-12
+    Version:       1.3
+    Requirement:   Azure repair VM with an attached Windows OS disk and the VMRepair common helpers
+    DeployMode:    az vm repair run (with --run-on-repair)
+    Telemetry:     Emits structured start, success, output, and error events through the VMRepair logger
 
-.EXAMPLE
-    az vm repair run -g <rg> -n <vm> --run-id win-LKGC --run-on-repair
-
-.VERIFICATION
+    Verification:
     1. Check the log file for success:
 Get-ChildItem "C:\Users\Public\Desktop\win-LKGC-run-*\win-LKGC-*.log" | Sort-Object LastWriteTime -Descending | Select-Object -First 1 | Get-Content
     2. Confirm the presence of the terminal confirmation string:
        "SCRIPT FINISHED PROPERLY, CHANGES_APPLIED=TRUE"
+     3. Confirm the log lists the referenced control sets before any write:
+         "AVAILABLE CONTROL SETS: ControlSet001, ControlSet002"
 
-.VERSION
-    v1.3: [Jul 2026] - Partition Architecture Alignment: Refactored the core disk processing 
-                         loop to group by DiskNumber and map drive properties exactly like the 
+     Safety behavior:
+    If LastKnownGood references a missing ControlSet00N key, the script returns an error without
+    changing the hive. If LastKnownGood equals Current, no alternate LKGC exists and the script
+    returns success with no changes. A second valid control set cannot be created safely.
+
+     Recovery after 0xc0000225 referencing \Windows\System32\config\system:
+     Attach the OS disk to a repair VM and restore the pre-change SYSTEM.LKGC.bak.<timestamp>
+     backup, or load the hive offline and point Current, Default, and LastKnownGood only to an
+     existing ControlSet00N key. Always snapshot the OS disk before recovery.
+
+    Version history:
+    v1.3: [Aug 2026] - Aligns disk collision handling with the latest SAC repair path.
+                       Preserves the attached source disk identity, temporarily changes only the
+                       disposable repair OS disk for matching Gen2 GPT collisions, and restores
+                       and verifies every temporary identity before reporting success.
+    v1.2.2: [Aug 2026] - Selects the existing LastKnownGood control set instead of incrementing
+                       Select values and treats the absence of an alternate LKGC as a safe no-op.
+                       Validates referenced control sets and their core Control and Services trees.
+                       Prevents 0xc0000225 from missing or incomplete ControlSet references.
+                       Adds logger-compatible JSON telemetry, SYSTEM hive backup, post-write
+                       verification, unload retries, and backup rollback after failed writes.
+                       Rejects invalid zero or negative boot control-set references before writes
+                       and retries stale offline-hive cleanup before loading each SYSTEM hive.
+                       Adds SAC-aligned repair-context detection, repair-disk exclusion, unlettered
+                       Windows partition discovery, temporary drive assignment, and cleanup.
+    v1.2.1: [Aug 2026] - Added structured VMRepair telemetry for LKGC restoration.
+    Update [Jul 2026] - Partition Architecture Alignment: Refactored the core disk processing
+                         loop to group by DiskNumber and map drive properties exactly like the
                          validated sac-enabler.ps1 framework.
     v1.2: [May - Jul 2026] - Production Hardening & Handle Updates
+
+.EXAMPLE
+    az vm repair run -g <rg> -n <vm> --run-id win-LKGC --run-on-repair
 .LINK
     How to start Azure Windows VM with Last Known Good Configuration - Virtual Machines | Microsoft Learn
 #>
@@ -53,6 +85,197 @@ if (-not (Test-Path -Path $diskPartitionsPath -PathType Leaf)) {
 }
 
 . $diskPartitionsPath
+
+if (-not (Get-Command -Name Get-Disk-Partitions -CommandType Function -ErrorAction SilentlyContinue)) {
+    Log-Error "Dependency did not define the required Get-Disk-Partitions function: $diskPartitionsPath"
+    return $STATUS_ERROR
+}
+
+function Get-LkgcExecutionContext {
+    param(
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [object[]]$TargetDiskGroups
+    )
+
+    if ($TargetDiskGroups.Count -gt 0) {
+        return 'REPAIR_VM'
+    }
+
+    return 'STANDARD_VM'
+}
+
+function Get-LkgcAvailableTempDriveLetter {
+    $usedLetters = @(Get-Volume -ErrorAction SilentlyContinue |
+        Where-Object { $_.DriveLetter } |
+        Select-Object -ExpandProperty DriveLetter)
+    foreach ($letter in @('Z','Y','X','W','V','U','T','S','R','Q')) {
+        if ($letter -notin $usedLetters -and -not (Test-Path -Path "${letter}:\")) {
+            return $letter
+        }
+    }
+
+    return $null
+}
+
+function Test-LkgcGptType {
+    param(
+        [AllowNull()]
+        [object]$ActualType,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ExpectedType
+    )
+
+    $actual = ([string]$ActualType).Trim().Trim('{', '}')
+    $expected = $ExpectedType.Trim().Trim('{', '}')
+    return $actual -eq $expected
+}
+
+function Get-LkgcDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$DiskNumber
+    )
+
+    $disk = Get-Disk -Number $DiskNumber -ErrorAction Stop
+    if ([string]$disk.PartitionStyle -eq 'MBR') {
+        $signature = [uint32]$disk.Signature
+        return [pscustomobject]@{
+            PartitionStyle = 'MBR'
+            Value = $signature.ToString('X8')
+            DiskPartValue = $signature.ToString('X8')
+        }
+    }
+    if ([string]$disk.PartitionStyle -eq 'GPT') {
+        $diskGuid = ([guid]$disk.Guid).ToString('D')
+        return [pscustomobject]@{
+            PartitionStyle = 'GPT'
+            Value = $diskGuid
+            DiskPartValue = $diskGuid
+        }
+    }
+
+    throw "Disk $DiskNumber has unsupported partition style '$($disk.PartitionStyle)'."
+}
+
+function Invoke-LkgcDiskPart {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Commands,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Operation
+    )
+
+    $output = $Commands | diskpart 2>&1
+    foreach ($line in @($output)) {
+        if ($line) { Log-Output "[diskpart][$Operation] $line" | Out-Null }
+    }
+}
+
+function Invoke-LkgcBcdEdit {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Operation
+    )
+
+    $output = & bcdedit.exe @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    foreach ($line in @($output)) {
+        if ($line) { Log-Output "[bcdedit][$Operation] $line" | Out-Null }
+    }
+    return [pscustomobject]@{
+        Output = @($output)
+        ExitCode = $exitCode
+        Success = ($exitCode -eq 0)
+    }
+}
+
+function Set-LkgcTemporarySourceDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Record
+    )
+
+    if ($Record.PartitionStyle -ne 'MBR') {
+        throw 'Temporary source disk identities are permitted only for the Gen1 MBR path.'
+    }
+
+    Invoke-LkgcDiskPart -Operation 'collision-prepare' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
+        'online disk'
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $currentIdentity = Get-LkgcDiskIdentity -DiskNumber $Record.DiskNumber
+    $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
+        throw "Disk $($Record.DiskNumber) could not be brought online with its verified temporary identity."
+    }
+}
+
+function Restore-LkgcSourceDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Record
+    )
+
+    Invoke-LkgcDiskPart -Operation 'collision-restore' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        'offline disk'
+        "uniqueid disk id=$($Record.OriginalDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $restoredIdentity = Get-LkgcDiskIdentity -DiskNumber $Record.DiskNumber
+    $restoredDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if (-not $restoredDisk.IsOffline -or $restoredIdentity.Value -ine $Record.OriginalValue) {
+        throw "Disk $($Record.DiskNumber) did not return to its original offline identity."
+    }
+}
+
+function Set-LkgcTemporaryRepairDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Record
+    )
+
+    Invoke-LkgcDiskPart -Operation 'repair-host-collision-prepare' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $currentIdentity = Get-LkgcDiskIdentity -DiskNumber $Record.DiskNumber
+    $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
+        throw 'The repair VM OS disk did not retain a verified temporary GPT identity.'
+    }
+}
+
+function Restore-LkgcRepairDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Record
+    )
+
+    Invoke-LkgcDiskPart -Operation 'repair-host-collision-restore' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.OriginalDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $restoredIdentity = Get-LkgcDiskIdentity -DiskNumber $Record.DiskNumber
+    $restoredDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if ($restoredDisk.IsOffline -or $restoredIdentity.Value -ine $Record.OriginalValue) {
+        throw 'The repair VM OS disk did not return to its original GPT identity.'
+    }
+}
 
 # Script-level logging: create a plain text desktop log that mirrors Log-* output.
 $scriptName = [System.IO.Path]::GetFileNameWithoutExtension($MyInvocation.MyCommand.Name)
@@ -93,13 +316,60 @@ function Write-DesktopLogLine {
     }
 }
 
-function Log-Output { Param([PSObject[]]$message) & $script:OriginalLogOutput -message $message; Write-DesktopLogLine -Level 'Output' -Message $message }
+function Log-Output {
+    Param([Parameter(Mandatory = $true)][PSObject[]]$message)
+    & $script:OriginalLogOutput -message $message
+    Write-DesktopLogLine -Level 'Output' -Message $message
+}
 function Log-Info { Param([PSObject[]]$message) & $script:OriginalLogInfo -message $message; Write-DesktopLogLine -Level 'Info' -Message $message }
 function Log-Warning { Param([PSObject[]]$message) & $script:OriginalLogWarning -message $message; Write-DesktopLogLine -Level 'Warning' -Message $message }
-function Log-Error { Param([PSObject[]]$message) & $script:OriginalLogError -message $message; Write-DesktopLogLine -Level 'Error' -Message $message }
+function Log-Error {
+    Param([Parameter(Mandatory = $true)][PSObject[]]$message)
+    & $script:OriginalLogError -message $message
+    Write-DesktopLogLine -Level 'Error' -Message $message
+}
 function Log-Debug { Param([PSObject[]]$message) & $script:OriginalLogDebug -message $message; Write-DesktopLogLine -Level 'Debug' -Message $message }
 
+$script:RepairScriptVersion = '1.3'
+$script:ExecutionStarted = Get-Date
+
+function Write-LkgcTelemetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Start', 'Operation', 'Success', 'Error')]
+        [string]$Event,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message,
+
+        [hashtable]$Properties = @{}
+    )
+
+    $payload = [ordered]@{
+        Event = $Event
+        Message = $Message
+        TimestampUtc = (Get-Date).ToUniversalTime().ToString('o')
+        RepairScriptVersion = $script:RepairScriptVersion
+        Properties = $Properties
+    }
+
+    $json = $payload | ConvertTo-Json -Compress -Depth 8
+    if ($Event -eq 'Error') {
+        Log-Error "[Telemetry] $json" | Out-Null
+    }
+    else {
+        Log-Info "[Telemetry] $json" | Out-Null
+    }
+}
+
 Log-Info "Starting AUTO LKGC Script. Desktop log: $logFilePath"
+Log-Info "[script_start] Script=win-LKGC Version=$($script:RepairScriptVersion)"
+Write-LkgcTelemetry -Event Start -Message 'Starting LKGC restoration' -Properties @{
+    ScriptName = 'win-LKGC.ps1'
+    ScriptVersion = $script:RepairScriptVersion
+    ExecutionMode = 'REPAIR_VM_ONLY'
+    DesktopLog = $logFilePath
+}
 
 # Status Tracking
 $script_final_status = $STATUS_ERROR
@@ -108,6 +378,10 @@ $processedCount = 0
 $skippedCount = 0
 $failedCount = 0
 $changedCount = 0
+$detectedExecutionContext = 'UNDETERMINED'
+$collisionDiskRecords = @()
+$gptCollisionDiskNumbers = @()
+$repairDiskIdentityRecord = $null
 
 try {
     # Check if the Hyper-V module is available before performing nested VM checks
@@ -121,44 +395,373 @@ try {
         Log-Info "Hyper-V PowerShell module is not available on this host. Skipping nested VM validation."
     }
 
-    # Step 1 - Enumerate and Group partitions matching the sac-enabler architecture
-    $partitionlist = Get-Disk-Partitions
-    $rescueDrive = $env:SystemDrive -replace ':', ''
+    # Step 1 - Identify the repair VM OS disk and enumerate only secondary disks.
+    $repairDrive = $env:SystemDrive -replace ':', ''
+    $repairOsPartition = Get-Partition -DriveLetter $repairDrive -ErrorAction Stop | Select-Object -First 1
+    if ($null -eq $repairOsPartition -or $null -eq $repairOsPartition.DiskNumber) {
+        throw "CRITICAL SAFETY CHECK FAILED: Could not identify the repair VM OS disk from $($env:SystemDrive)."
+    }
+    $repairDiskNumber = [int]$repairOsPartition.DiskNumber
+    $repairDiskIdentity = Get-LkgcDiskIdentity -DiskNumber $repairDiskNumber
+    Log-Info "Repair VM OS disk identified as Disk $repairDiskNumber ($($repairDiskIdentity.PartitionStyle))."
+
+    # Match the latest SAC path: resolve identity collisions before the helper onlines disks.
+    $azureVirtualDiskNumbers = @(Get-CimInstance -ClassName Win32_DiskDrive -ErrorAction Stop |
+        Where-Object { $_.Model -like 'Microsoft Virtual Disk*' } |
+        ForEach-Object { [int]$_.Index })
+    $collisionDisks = @(Get-Disk -ErrorAction Stop | Where-Object {
+        $_.Number -in $azureVirtualDiskNumbers -and
+        $_.IsOffline -and
+        ([string]$_.OfflineReason -eq 'Collision')
+    })
+
+    foreach ($collisionDisk in $collisionDisks) {
+        $originalIdentity = Get-LkgcDiskIdentity -DiskNumber $collisionDisk.Number
+        if ($originalIdentity.PartitionStyle -eq 'GPT') {
+            if ($repairDiskIdentity.PartitionStyle -ne 'GPT' -or
+                $repairDiskIdentity.Value -ine $originalIdentity.Value) {
+                throw "Disk $($collisionDisk.Number) reports a GPT identity collision that does not match the repair VM OS disk. Refusing an unverified identity change."
+            }
+
+            if (-not $repairDiskIdentityRecord) {
+                $temporaryRepairGuid = ([guid]::NewGuid()).ToString('D')
+                $repairDiskIdentityRecord = [pscustomobject]@{
+                    DiskNumber = $repairDiskNumber
+                    PartitionStyle = 'GPT'
+                    OriginalValue = $repairDiskIdentity.Value
+                    OriginalDiskPartValue = $repairDiskIdentity.DiskPartValue
+                    TemporaryValue = $temporaryRepairGuid
+                    TemporaryDiskPartValue = $temporaryRepairGuid
+                }
+                Log-Warning 'Temporarily changing only the repair VM OS disk GPT identity to release the attached Gen2 collision. The source disk GUID will not be changed.'
+                Set-LkgcTemporaryRepairDiskIdentity -Record $repairDiskIdentityRecord
+            }
+
+            $gptCollisionDiskNumbers += [int]$collisionDisk.Number
+            Invoke-LkgcDiskPart -Operation 'source-gpt-online' -Commands @(
+                "select disk $($collisionDisk.Number)"
+                'online disk'
+            )
+            Update-HostStorageCache -ErrorAction SilentlyContinue
+            $releasedDisk = Get-Disk -Number $collisionDisk.Number -ErrorAction Stop
+            $sourceIdentityAfterRelease = Get-LkgcDiskIdentity -DiskNumber $collisionDisk.Number
+            if ($releasedDisk.IsOffline -or
+                [string]$releasedDisk.OfflineReason -eq 'Collision' -or
+                $sourceIdentityAfterRelease.Value -ine $originalIdentity.Value) {
+                throw "Disk $($collisionDisk.Number) could not be onlined with its original GPT identity unchanged."
+            }
+            Log-Info "Disk $($collisionDisk.Number) collision released; source GPT identity remains $($originalIdentity.Value)."
+            continue
+        }
+
+        do {
+            $temporaryValue = ([Convert]::ToUInt32(([guid]::NewGuid().ToString('N').Substring(0, 8)), 16)).ToString('X8')
+        } while ($temporaryValue -eq '00000000' -or $temporaryValue -ieq $originalIdentity.Value)
+
+        $record = [pscustomobject]@{
+            DiskNumber = [int]$collisionDisk.Number
+            PartitionStyle = $originalIdentity.PartitionStyle
+            OriginalValue = $originalIdentity.Value
+            OriginalDiskPartValue = $originalIdentity.DiskPartValue
+            TemporaryValue = $temporaryValue
+            TemporaryDiskPartValue = $temporaryValue
+        }
+        $collisionDiskRecords += $record
+        Log-Warning "Disk $($record.DiskNumber) is offline due to an identity collision. Applying a temporary MBR identity for this repair run."
+        Set-LkgcTemporarySourceDiskIdentity -Record $record
+    }
+
+    $partitionlist = @(Get-Disk-Partitions)
+    if ($partitionlist.Count -eq 0) {
+        throw 'Get-Disk-Partitions returned no partitions from Azure virtual disks.'
+    }
+
+    $targetDiskGroups = @($partitionlist | Group-Object DiskNumber |
+        Where-Object { [int]$_.Name -ne $repairDiskNumber })
+    $detectedExecutionContext = Get-LkgcExecutionContext -TargetDiskGroups $targetDiskGroups
+    Log-Info "Detected execution context: $detectedExecutionContext"
+    if ($detectedExecutionContext -ne 'REPAIR_VM') {
+        throw 'REPAIR-ONLY SCRIPT: No secondary disk was returned by the partition helper.'
+    }
+
     $fixedDisks = @()
 
     Log-Info 'Enumerating disk partitions for LKGC analysis...'
 
-    foreach ($partitionGroup in $partitionlist | Group-Object DiskNumber) {
+    foreach ($partitionGroup in $targetDiskGroups) {
         $processedCount++
-        $diskNumber = $partitionGroup.Name
+        $diskNumber = [int]$partitionGroup.Name
         $targetOSDrive = $null
-        
-        Log-Info "Processing Disk $diskNumber"
+        $tempOsLetter = $null
+        $tempOsDiskNum = $null
+        $tempOsPartNum = $null
+        $tempBcdLetter = $null
+        $tempBcdDiskNum = $null
+        $tempBcdPartNum = $null
+        $bcdPath = $null
+        $bcdBackup = $null
+        $bcdWriteStarted = $false
+        $bcdBackupRestored = $false
+        $registryProcessingFailed = $false
+        $bootPolicyMarkerPath = $null
+        $bootPolicyRestored = $false
 
-        # Scan each drive letter within this disk group for a valid Windows OS directory
-        foreach ($drive in $partitionGroup.Group | Select-Object -ExpandProperty DriveLetter) {
-            if ([string]::IsNullOrWhiteSpace($drive) -or $drive -eq $rescueDrive) { 
+        try {
+            Log-Info "Processing Disk $diskNumber"
+            $diskPartitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction Stop)
+            $efiGptType = 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'
+
+            # Scan every currently mounted partition on this target disk.
+            foreach ($partition in @($diskPartitions | Where-Object {
+                $_.DriveLetter -and $_.DriveLetter -ne [char]0
+            })) {
+                $drive = [string]$partition.DriveLetter
+                if ($drive -eq $repairDrive) { continue }
+
+                $systemCandidate = "${drive}:\Windows\System32\config\SYSTEM"
+                $candidateExists = Test-Path -LiteralPath $systemCandidate -PathType Leaf
+                Log-Info "Disk ${diskNumber}: checking ${drive}: for SYSTEM hive; exists=$candidateExists"
+                if ($candidateExists) {
+                    $targetOSDrive = $drive
+                    break
+                }
+            }
+
+            # Match SAC's Gen2-safe fallback by probing unlettered non-EFI partitions.
+            if (-not $targetOSDrive) {
+                $unletteredOsCandidates = @($diskPartitions | Where-Object {
+                    (-not $_.DriveLetter -or $_.DriveLetter -eq [char]0) -and
+                    -not (Test-LkgcGptType -ActualType $_.GptType -ExpectedType $efiGptType)
+                } | Sort-Object Size -Descending)
+
+                Log-Info "Disk ${diskNumber}: probing $($unletteredOsCandidates.Count) unlettered non-EFI partition(s) for Windows."
+                foreach ($osCandidate in $unletteredOsCandidates) {
+                    $candidateLetter = Get-LkgcAvailableTempDriveLetter
+                    if (-not $candidateLetter) {
+                        Log-Warning "Disk ${diskNumber}: no temporary drive letter is available for OS probing."
+                        break
+                    }
+
+                    $candidatePartNum = [int]$osCandidate.PartitionNumber
+                    Log-Info "Disk ${diskNumber}: assigning ${candidateLetter}: to Partition $candidatePartNum for OS probing."
+                    $assignOutput = @(
+                        "select disk $diskNumber"
+                        "select partition $candidatePartNum"
+                        "assign letter=$candidateLetter"
+                    ) | diskpart 2>&1
+                    foreach ($line in @($assignOutput)) {
+                        if ($line) { Log-Output "[diskpart][os-assign] $line" | Out-Null }
+                    }
+                    $tempOsLetter = $candidateLetter
+                    $tempOsDiskNum = $diskNumber
+                    $tempOsPartNum = $candidatePartNum
+                    Start-Sleep -Seconds 2
+
+                    $systemCandidate = "${candidateLetter}:\Windows\System32\config\SYSTEM"
+                    $candidateExists = Test-Path -LiteralPath $systemCandidate -PathType Leaf
+                    Log-Info "Disk ${diskNumber}: checked temporary ${candidateLetter}: for SYSTEM hive; exists=$candidateExists"
+                    if ($candidateExists) {
+                        $targetOSDrive = $candidateLetter
+                        break
+                    }
+
+                    $removeOutput = @(
+                        "select disk $diskNumber"
+                        "select partition $candidatePartNum"
+                        "remove letter=$candidateLetter noerr"
+                    ) | diskpart 2>&1
+                    foreach ($line in @($removeOutput)) {
+                        if ($line) { Log-Output "[diskpart][os-remove] $line" | Out-Null }
+                    }
+                    $tempOsLetter = $null
+                    $tempOsDiskNum = $null
+                    $tempOsPartNum = $null
+                }
+            }
+
+            if (-not $targetOSDrive) {
+                Log-Info "Disk $diskNumber skipped: no valid attached OS partition containing \Windows found."
                 $skippedCount++
-                continue 
+                continue
             }
 
-            if (Test-Path -Path "$(${drive}):\Windows\System32\config\SYSTEM") {
-                $targetOSDrive = $drive
-                break
+            Log-Info "Target OS partition successfully matched on letter: $($targetOSDrive):"
+
+            # Match latest SAC: validate and, only when necessary, repair the
+            # default loader mapping before changing the offline SYSTEM hive.
+            $diskPartitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction Stop)
+            $efiParts = @($diskPartitions | Where-Object {
+                Test-LkgcGptType -ActualType $_.GptType -ExpectedType $efiGptType
+            })
+            $isGen2Disk = $efiParts.Count -gt 0
+            Log-Info "Disk ${diskNumber}: generation detection result = $(if ($isGen2Disk) { 'Gen2/UEFI' } else { 'Gen1/BIOS' })"
+
+            $bcdCandidates = if ($isGen2Disk) { $efiParts } else { $diskPartitions }
+            foreach ($bcdCandidate in $bcdCandidates) {
+                $candidateLetter = $null
+                $letterAssignedByScript = $false
+                if ($bcdCandidate.DriveLetter -and $bcdCandidate.DriveLetter -ne [char]0) {
+                    $candidateLetter = [string]$bcdCandidate.DriveLetter
+                }
+                else {
+                    $candidateLetter = Get-LkgcAvailableTempDriveLetter
+                    if (-not $candidateLetter) { continue }
+                    $candidatePartNum = [int]$bcdCandidate.PartitionNumber
+                    Invoke-LkgcDiskPart -Operation 'bcd-assign' -Commands @(
+                        "select disk $diskNumber"
+                        "select partition $candidatePartNum"
+                        "assign letter=$candidateLetter"
+                    )
+                    Start-Sleep -Seconds 2
+                    $letterAssignedByScript = Test-Path -LiteralPath "${candidateLetter}:\" -PathType Container
+                }
+
+                $candidateBcdPath = if ($isGen2Disk) {
+                    "${candidateLetter}:\EFI\Microsoft\Boot\BCD"
+                }
+                else {
+                    "${candidateLetter}:\Boot\BCD"
+                }
+                if ($candidateLetter -and (Test-Path -LiteralPath $candidateBcdPath -PathType Leaf)) {
+                    $bcdPath = $candidateBcdPath
+                    if ($letterAssignedByScript) {
+                        $tempBcdLetter = $candidateLetter
+                        $tempBcdDiskNum = $diskNumber
+                        $tempBcdPartNum = [int]$bcdCandidate.PartitionNumber
+                    }
+                    Log-Info "Disk ${diskNumber}: selected BCD store: $bcdPath"
+                    break
+                }
+
+                if ($letterAssignedByScript) {
+                    Invoke-LkgcDiskPart -Operation 'bcd-remove' -Commands @(
+                        "select disk $diskNumber"
+                        "select partition $([int]$bcdCandidate.PartitionNumber)"
+                        "remove letter=$candidateLetter noerr"
+                    )
+                }
             }
-        }
 
-        if (-not $targetOSDrive) {
-            Log-Info "Disk $diskNumber skipped: no valid attached OS partition containing \Windows found."
-            $skippedCount++
-            continue
-        }
+            if (-not $bcdPath) {
+                throw "Disk $diskNumber has no generation-appropriate BCD store. No registry changes were attempted."
+            }
 
-        Log-Info "Target OS partition successfully matched on letter: $($targetOSDrive):"
+            $bootManagerQuery = Invoke-LkgcBcdEdit -Arguments @('/store', $bcdPath, '/enum', 'bootmgr', '/v') -Operation 'query-bootmgr'
+            if (-not $bootManagerQuery.Success) {
+                throw "Could not enumerate boot manager from $bcdPath. No registry changes were attempted."
+            }
+            $defaultLine = $bootManagerQuery.Output | Select-String -Pattern '^\s*default\s+' | Select-Object -First 1
+            if (-not $defaultLine -or $defaultLine -notmatch '\{([^}]+)\}') {
+                throw "Could not identify the default Windows loader in $bcdPath. No registry changes were attempted."
+            }
+            $defaultLoaderId = $matches[0]
+            if ($defaultLoaderId -notmatch '^(?i)\{[0-9a-f\-]{36}\}$') {
+                throw "Default BCD loader identifier '$defaultLoaderId' is invalid. No registry changes were attempted."
+            }
+
+            $loaderQuery = Invoke-LkgcBcdEdit -Arguments @('/store', $bcdPath, '/enum', $defaultLoaderId, '/v') -Operation 'validate-loader'
+            if (-not $loaderQuery.Success) {
+                throw "Could not enumerate default loader $defaultLoaderId. No registry changes were attempted."
+            }
+            $loaderText = $loaderQuery.Output -join "`n"
+            $loaderPathMatch = [regex]::Match($loaderText, '(?im)^\s*path\s+(.+?)\s*$')
+            $loaderDeviceMatch = [regex]::Match($loaderText, '(?im)^\s*device\s+(.+?)\s*$')
+            $loaderOsDeviceMatch = [regex]::Match($loaderText, '(?im)^\s*osdevice\s+(.+?)\s*$')
+            $loaderSystemRootMatch = [regex]::Match($loaderText, '(?im)^\s*systemroot\s+(.+?)\s*$')
+            if (-not $loaderPathMatch.Success -or
+                -not $loaderDeviceMatch.Success -or
+                -not $loaderOsDeviceMatch.Success -or
+                -not $loaderSystemRootMatch.Success) {
+                throw "Default loader $defaultLoaderId is missing required mapping elements. No registry changes were attempted."
+            }
+
+            $originalLoaderPath = $loaderPathMatch.Groups[1].Value.Trim()
+            $originalLoaderDevice = $loaderDeviceMatch.Groups[1].Value.Trim()
+            $originalLoaderOsDevice = $loaderOsDeviceMatch.Groups[1].Value.Trim()
+            $originalLoaderSystemRoot = $loaderSystemRootMatch.Groups[1].Value.Trim()
+            if ($originalLoaderPath -notmatch '(?i)^\\Windows\\System32\\winload\.(exe|efi)$') {
+                throw "Default loader $defaultLoaderId references unsupported path '$originalLoaderPath'. No registry changes were attempted."
+            }
+            $resolvedLoaderFile = Join-Path -Path "${targetOSDrive}:\" -ChildPath $originalLoaderPath.TrimStart('\')
+            if (-not (Test-Path -LiteralPath $resolvedLoaderFile -PathType Leaf)) {
+                throw "Default loader references '$originalLoaderPath', but '$resolvedLoaderFile' does not exist. No registry changes were attempted."
+            }
+
+            $repairLoaderDevice = $originalLoaderDevice -match '(?i)^unknown$'
+            $repairLoaderOsDevice = $originalLoaderOsDevice -match '(?i)^unknown$'
+            $bootPolicyMarkerPath = "${targetOSDrive}:\ProgramData\LKGC-Test-BootPolicy.json"
+            $restoreTestBootPolicy = Test-Path -LiteralPath $bootPolicyMarkerPath -PathType Leaf
+            if ($repairLoaderDevice -or $repairLoaderOsDevice -or $restoreTestBootPolicy) {
+                $bcdBackup = $bcdPath + '.LKGC.bak.' + $runTimestamp
+                Copy-Item -LiteralPath $bcdPath -Destination $bcdBackup -Force -ErrorAction Stop
+                if (-not (Test-Path -LiteralPath $bcdBackup -PathType Leaf)) {
+                    throw "BCD backup was not created at '$bcdBackup'. No BCD changes were attempted."
+                }
+                if ((Get-Item -LiteralPath $bcdBackup -Force -ErrorAction Stop).Length -ne
+                    (Get-Item -LiteralPath $bcdPath -Force -ErrorAction Stop).Length) {
+                    throw "BCD backup verification failed for '$bcdBackup'. No BCD changes were attempted."
+                }
+                Log-Info "Disk ${diskNumber}: BCD backup created and verified: $bcdBackup"
+            }
+
+            if ($repairLoaderDevice -or $repairLoaderOsDevice) {
+                $validatedWindowsPartition = "partition=${targetOSDrive}:"
+                $bcdWriteStarted = $true
+                Log-Warning "Loader mapping contains an unknown descriptor. Repairing it to $validatedWindowsPartition using the validated Windows partition."
+                if ($repairLoaderDevice) {
+                    $setDevice = Invoke-LkgcBcdEdit -Arguments @('/store', $bcdPath, '/set', $defaultLoaderId, 'device', $validatedWindowsPartition) -Operation 'repair-loader-device'
+                    if (-not $setDevice.Success) { throw "Could not repair device for loader $defaultLoaderId." }
+                }
+                if ($repairLoaderOsDevice) {
+                    $setOsDevice = Invoke-LkgcBcdEdit -Arguments @('/store', $bcdPath, '/set', $defaultLoaderId, 'osdevice', $validatedWindowsPartition) -Operation 'repair-loader-osdevice'
+                    if (-not $setOsDevice.Success) { throw "Could not repair osdevice for loader $defaultLoaderId." }
+                }
+
+                $verifyLoader = Invoke-LkgcBcdEdit -Arguments @('/store', $bcdPath, '/enum', $defaultLoaderId, '/v') -Operation 'verify-loader-mapping'
+                $verifyText = $verifyLoader.Output -join "`n"
+                $verifyPath = [regex]::Match($verifyText, '(?im)^\s*path\s+(.+?)\s*$')
+                $verifyDevice = [regex]::Match($verifyText, '(?im)^\s*device\s+(.+?)\s*$')
+                $verifyOsDevice = [regex]::Match($verifyText, '(?im)^\s*osdevice\s+(.+?)\s*$')
+                $verifySystemRoot = [regex]::Match($verifyText, '(?im)^\s*systemroot\s+(.+?)\s*$')
+                if (-not $verifyLoader.Success -or
+                    -not $verifyPath.Success -or
+                    -not $verifyDevice.Success -or
+                    -not $verifyOsDevice.Success -or
+                    -not $verifySystemRoot.Success -or
+                    $verifyDevice.Groups[1].Value.Trim() -match '(?i)^unknown$' -or
+                    $verifyOsDevice.Groups[1].Value.Trim() -match '(?i)^unknown$' -or
+                    $verifyPath.Groups[1].Value.Trim() -ine $originalLoaderPath -or
+                    $verifySystemRoot.Groups[1].Value.Trim() -ine $originalLoaderSystemRoot) {
+                    throw "Loader mapping repair verification failed for $defaultLoaderId."
+                }
+                Log-Info "Disk ${diskNumber}: BCD loader mapping repaired and verified."
+            }
+
+            if ($restoreTestBootPolicy) {
+                $bcdWriteStarted = $true
+                $removeBootPolicy = Invoke-LkgcBcdEdit -Arguments @('/store', $bcdPath, '/deletevalue', $defaultLoaderId, 'bootstatuspolicy') -Operation 'restore-bootstatuspolicy'
+                if (-not $removeBootPolicy.Success) {
+                    throw "Could not remove the lab bootstatuspolicy from loader $defaultLoaderId."
+                }
+                $enableRecovery = Invoke-LkgcBcdEdit -Arguments @('/store', $bcdPath, '/set', $defaultLoaderId, 'recoveryenabled', 'Yes') -Operation 'restore-recoveryenabled'
+                if (-not $enableRecovery.Success) {
+                    throw "Could not restore recoveryenabled=Yes on loader $defaultLoaderId."
+                }
+
+                $verifyBootPolicy = Invoke-LkgcBcdEdit -Arguments @('/store', $bcdPath, '/enum', $defaultLoaderId, '/v') -Operation 'verify-restored-boot-policy'
+                $verifyBootPolicyText = $verifyBootPolicy.Output -join "`n"
+                if (-not $verifyBootPolicy.Success -or
+                    $verifyBootPolicyText -match '(?im)^\s*bootstatuspolicy\s+IgnoreAllFailures\s*$' -or
+                    $verifyBootPolicyText -notmatch '(?im)^\s*recoveryenabled\s+Yes\s*$') {
+                    throw "Normal boot recovery policy verification failed for loader $defaultLoaderId."
+                }
+                $bootPolicyRestored = $true
+                Log-Info "Disk ${diskNumber}: normal boot recovery policy restored and verified."
+            }
 
         $systemHivePath = "$(${targetOSDrive}):\Windows\System32\config\SYSTEM"
         $systemHiveBackup = "$systemHivePath.LKGC.bak.$runTimestamp"
-        
+
         try {
             Copy-Item -LiteralPath $systemHivePath -Destination $systemHiveBackup -Force -ErrorAction Stop
             Log-Info "[$targetOSDrive] SYSTEM hive backup created: $systemHiveBackup"
@@ -169,28 +772,20 @@ try {
             continue
         }
 
-        # Step 2 - Load the SOFTWARE hive to detect the Windows version
-        $swHive = "HKLM\BROKENSW_$targetOSDrive"
-        $null = & reg.exe unload $swHive 2>&1
-        $swLoad = & reg.exe load $swHive "$(${targetOSDrive}):\Windows\System32\config\software" 2>&1
-        
-        if ($LASTEXITCODE -ne 0) {
-            $failedCount++
-            Log-Warning "Failed to load SOFTWARE hive from $($targetOSDrive): $($swLoad -join ' | ') - skipping"
-            continue
-        }
-
-        Start-Sleep -Seconds 2
-        $productName = (Get-ItemProperty -path "registry::$swHive\microsoft\windows nt\currentversion" -ErrorAction SilentlyContinue).ProductName
-        $winosver = 0
-        if ($productName -match '(\d+)') { $winosver = [int]$matches[1] }
-        $null = & reg.exe unload $swHive 2>&1
-
-        # Step 3 - Load the SYSTEM hive from the target disk
+        # Step 2 - Load the SYSTEM hive from the target disk
         $sysHive = "HKLM\BROKENSYS_$targetOSDrive"
-        $null = & reg.exe unload $sysHive 2>&1
+        [System.GC]::Collect()
+        [System.GC]::WaitForPendingFinalizers()
+        for ($preLoadUnloadAttempt = 1; $preLoadUnloadAttempt -le 3; $preLoadUnloadAttempt++) {
+            $preLoadUnloadOutput = & reg.exe unload $sysHive 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                Log-Info "[$targetOSDrive] Removed a stale pre-existing hive mount on attempt $preLoadUnloadAttempt."
+                break
+            }
+            if ($preLoadUnloadAttempt -lt 3) { Start-Sleep -Seconds 2 }
+        }
         $sysLoad = & reg.exe load $sysHive $systemHivePath 2>&1
-        
+
         if ($LASTEXITCODE -ne 0) {
             $failedCount++
             Log-Warning "Failed to load SYSTEM hive from $($targetOSDrive): $($sysLoad -join ' | ') - skipping"
@@ -203,47 +798,131 @@ try {
         $restoreRequired = $false
         $subKeyPath = "BROKENSYS_$targetOSDrive\Select"
         $regKey = $null
+        $systemRootKey = $null
 
         try {
             # Step 4 - Open via direct .NET API to eliminate PowerShell registry caching engine bugs
             $regKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($subKeyPath, $true)
             if ($null -eq $regKey) { throw "Failed to open Select key via explicit .NET path: HKLM:\$subKeyPath" }
 
+            $requiredSelectValues = @('current', 'default', 'failed', 'LastKnownGood')
+            $missingSelectValues = @($requiredSelectValues | Where-Object { $_ -notin $regKey.GetValueNames() })
+            if ($missingSelectValues.Count -gt 0) {
+                throw "SYSTEM hive Select key is missing required value(s): $($missingSelectValues -join ', ')."
+            }
+
             $currentVal    = [int]$regKey.GetValue('current')
             $defaultVal    = [int]$regKey.GetValue('default')
             $failedVal     = [int]$regKey.GetValue('failed')
             $lastKnownGood = [int]$regKey.GetValue('LastKnownGood')
 
+            $invalidBootReferences = @(@(
+                [pscustomobject]@{ Name = 'Current'; Value = $currentVal }
+                [pscustomobject]@{ Name = 'Default'; Value = $defaultVal }
+                [pscustomobject]@{ Name = 'LastKnownGood'; Value = $lastKnownGood }
+            ) | Where-Object { $_.Value -lt 1 })
+            if ($invalidBootReferences.Count -gt 0) {
+                $invalidValues = @($invalidBootReferences | ForEach-Object { "$($_.Name)=$($_.Value)" })
+                throw "SYSTEM hive Select contains invalid boot control-set reference(s): $($invalidValues -join ', '). No changes were attempted."
+            }
+
+            $systemRootKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey("BROKENSYS_$targetOSDrive", $false)
+            if ($null -eq $systemRootKey) {
+                throw "Failed to inspect control sets in HKLM:\BROKENSYS_$targetOSDrive."
+            }
+            $availableControlSets = @($systemRootKey.GetSubKeyNames() | Where-Object { $_ -match '^ControlSet\d{3}$' })
+            $availableControlSetNumbers = @($availableControlSets | ForEach-Object { [int]$_.Substring('ControlSet'.Length) })
+            Log-Info "[$targetOSDrive] AVAILABLE CONTROL SETS: $($availableControlSets -join ', ')"
+
+            $existingReferences = @(@($currentVal, $defaultVal, $failedVal, $lastKnownGood) |
+                Where-Object { $_ -gt 0 } | Sort-Object -Unique)
+            $invalidExistingReferences = @($existingReferences | Where-Object { $_ -notin $availableControlSetNumbers })
+            if ($invalidExistingReferences.Count -gt 0) {
+                $invalidNames = @($invalidExistingReferences | ForEach-Object { 'ControlSet{0:D3}' -f $_ })
+                throw "SYSTEM hive Select already references missing control set(s): $($invalidNames -join ', '). No changes were attempted."
+            }
+
+            foreach ($controlSetNumber in $existingReferences) {
+                $controlSetName = 'ControlSet{0:D3}' -f $controlSetNumber
+                foreach ($requiredSubKey in @('Control', 'Services')) {
+                    $validationKey = $systemRootKey.OpenSubKey("$controlSetName\$requiredSubKey", $false)
+                    if ($null -eq $validationKey) {
+                        throw "$controlSetName is incomplete: required $requiredSubKey tree is missing. No changes were attempted."
+                    }
+                    $validationKey.Dispose()
+                }
+            }
+
+            $before = [PSCustomObject]@{
+                Current       = $currentVal
+                Default       = $defaultVal
+                Failed        = $failedVal
+                LastKnownGood = $lastKnownGood
+            }
+
+            Write-LkgcTelemetry -Event Operation -Message "Starting LKGC restoration on drive $targetOSDrive" -Properties @{
+                DiskNumber   = "$diskNumber"
+                TargetDrive  = "$targetOSDrive"
+                SelectBefore = "$($before.Current),$($before.Default),$($before.Failed),$($before.LastKnownGood)"
+            }
+
             Log-Info "[$targetOSDrive] REGISTRY STATE [BEFORE]: Current=$currentVal, Default=$defaultVal, Failed=$failedVal, LKG=$lastKnownGood"
 
-            # Step 5 - Evaluate version thresholds using matching AND-logic sequences
-            $alreadySet = $false
-            if (($winosver -eq 10) -or ($winosver -ge 2016)) {
-                if (($currentVal -ge 2) -and ($defaultVal -ge 2) -and ($failedVal -ge 1) -and ($lastKnownGood -ge 2)) { $alreadySet = $true }
-            }
-            elseif ($winosver -eq 2012) {
-                if (($currentVal -ge 2) -and ($defaultVal -ge 2) -and ($failedVal -ge 1) -and ($lastKnownGood -ge 3)) { $alreadySet = $true }
-            }
-
-            if ($alreadySet) {
-                Log-Warning "[$targetOSDrive] LKGC WAS ALREADY SET, NO CHANGES DONE"
+            # Step 4 - Select the control set explicitly identified by LastKnownGood.
+            if ($lastKnownGood -eq $currentVal) {
+                Log-Warning "[$targetOSDrive] NO ALTERNATE LKGC EXISTS: LastKnownGood and Current both reference ControlSet$('{0:D3}' -f $currentVal)."
                 Log-Info "[$targetOSDrive] LKGC_APPLIED=false"
+                Write-LkgcTelemetry -Event Success -Message "No alternate LKGC is available on drive $targetOSDrive" -Properties @{
+                    DiskNumber  = "$diskNumber"
+                    TargetDrive = "$targetOSDrive"
+                    Changed     = 'false'
+                    Reason      = 'LastKnownGoodEqualsCurrent'
+                }
             }
             else {
-                # Step 6 - Increment configuration spaces via .NET context
-                $writeAttempted = $true
-                $regKey.SetValue('current', ($currentVal + 1), [Microsoft.Win32.RegistryValueKind]::DWord)
-                $regKey.SetValue('default', ($defaultVal + 1), [Microsoft.Win32.RegistryValueKind]::DWord)
-                $regKey.SetValue('failed', ($failedVal + 1), [Microsoft.Win32.RegistryValueKind]::DWord)
-                $regKey.SetValue('LastKnownGood', ($lastKnownGood + 1), [Microsoft.Win32.RegistryValueKind]::DWord)
+                # Step 5 - Point boot selection to the existing LastKnownGood control set.
+                $plannedCurrent = $lastKnownGood
+                $plannedDefault = $lastKnownGood
+                $plannedFailed = $currentVal
+                $plannedLastKnownGood = $lastKnownGood
 
-                # Step 7 - Validate downstream configurations
+                $writeAttempted = $true
+                $regKey.SetValue('current', $plannedCurrent, [Microsoft.Win32.RegistryValueKind]::DWord)
+                $regKey.SetValue('default', $plannedDefault, [Microsoft.Win32.RegistryValueKind]::DWord)
+                $regKey.SetValue('failed', $plannedFailed, [Microsoft.Win32.RegistryValueKind]::DWord)
+                $regKey.SetValue('LastKnownGood', $plannedLastKnownGood, [Microsoft.Win32.RegistryValueKind]::DWord)
+
+                # Step 6 - Validate downstream configurations
                 $afterCurrent = $regKey.GetValue('current')
                 $afterDefault = $regKey.GetValue('default')
                 $afterFailed  = $regKey.GetValue('failed')
                 $afterLKG     = $regKey.GetValue('LastKnownGood')
 
+                if (($afterCurrent -ne $plannedCurrent) -or
+                    ($afterDefault -ne $plannedDefault) -or
+                    ($afterFailed -ne $plannedFailed) -or
+                    ($afterLKG -ne $plannedLastKnownGood)) {
+                    throw 'SYSTEM hive Select values did not match the requested LKGC updates.'
+                }
+
+                $after = [PSCustomObject]@{
+                    Current       = $afterCurrent
+                    Default       = $afterDefault
+                    Failed        = $afterFailed
+                    LastKnownGood = $afterLKG
+                }
+
                 Log-Info "[$targetOSDrive] REGISTRY STATE [AFTER]: Current=$afterCurrent, Default=$afterDefault, Failed=$afterFailed, LKG=$afterLKG"
+
+                $telemetryProperties = @{
+                    DiskNumber  = "$diskNumber"
+                    TargetDrive = "$targetOSDrive"
+                    SelectAfter = "$($after.Current),$($after.Default),$($after.Failed),$($after.LastKnownGood)"
+                    Changed     = 'true'
+                }
+
+                Log-Output -Message "LKGC APPLIED"
+                Write-LkgcTelemetry -Event Success -Message "LKGC registry values updated on drive $targetOSDrive" -Properties $telemetryProperties
 
                 $lkgcAppliedAny = $true
                 $changedCount++
@@ -254,37 +933,135 @@ try {
         }
         catch {
             $failedCount++
+            $registryProcessingFailed = $true
             if ($writeAttempted) { $restoreRequired = $true }
-            Log-Error "[$targetOSDrive] Failed to process registry modifications: $($_.Exception.Message)"
+            Log-Error -Message "[$targetOSDrive] Failed to process registry modifications: $($_.Exception.Message)"
+            Write-LkgcTelemetry -Event Error -Message 'Failed to process registry modifications' -Properties @{
+                DiskNumber    = "$diskNumber"
+                TargetDrive   = "$targetOSDrive"
+                WriteAttempted = "$writeAttempted"
+                Error = $_.Exception.Message
+            }
             Log-Info "[$targetOSDrive] LKGC_APPLIED=false"
         }
         finally {
+            if ($null -ne $systemRootKey) {
+                try { $systemRootKey.Close() } catch {}
+                try { $systemRootKey.Dispose() } catch {}
+            }
             if ($null -ne $regKey) {
-                $regKey.Flush()
-                $regKey.Close()
-                $regKey.Dispose()
+                try {
+                    $regKey.Flush()
+                }
+                catch {
+                    if (-not $registryProcessingFailed) {
+                        $failedCount++
+                        $registryProcessingFailed = $true
+                    }
+                    $restoreRequired = $true
+                    Log-Error "[$targetOSDrive] Failed to flush the SYSTEM hive Select key: $($_.Exception.Message)"
+                }
+                finally {
+                    try { $regKey.Close() } catch {}
+                    try { $regKey.Dispose() } catch {}
+                }
             }
             [System.GC]::Collect()
             [System.GC]::WaitForPendingFinalizers()
             Start-Sleep -Seconds 2
 
-            # Step 8 - Unload the registry hive using the 3x safety retry array
+            # Step 7 - Unload the registry hive using the 3x safety retry array
             $unloaded = $false
             for ($i=1; $i -le 3; $i++) {
                 $unloadOutput = & reg.exe unload $sysHive 2>&1
                 if ($LASTEXITCODE -eq 0) { $unloaded = $true; break }
                 Start-Sleep -Seconds 5
             }
-            
-            if (-not $unloaded) { Log-Error "Could not unload $sysHive cleanly." }
+
+            if (-not $unloaded) {
+                if (-not $registryProcessingFailed) {
+                    $failedCount++
+                    $registryProcessingFailed = $true
+                }
+                $restoreRequired = $true
+                Log-Error "Could not unload $sysHive cleanly. The disk will not be reported as successfully processed."
+                $fixedDisks = @($fixedDisks | Where-Object { $_ -ne $targetOSDrive })
+            }
 
             if ($restoreRequired) {
-                try { Copy-Item -LiteralPath $systemHiveBackup -Destination $systemHivePath -Force -ErrorAction Stop } catch {}
+                if (-not $unloaded) {
+                    Log-Error "[$targetOSDrive] SYSTEM hive backup cannot be restored while $sysHive remains loaded. Manual recovery may be required from $systemHiveBackup."
+                }
+                else {
+                    try {
+                        Copy-Item -LiteralPath $systemHiveBackup -Destination $systemHivePath -Force -ErrorAction Stop
+                        Log-Warning "[$targetOSDrive] Restored SYSTEM hive backup after the failed write attempt."
+                    }
+                    catch {
+                        Log-Error "[$targetOSDrive] CRITICAL: Failed to restore SYSTEM hive backup '$systemHiveBackup': $($_.Exception.Message)"
+                    }
+                }
+            }
+        }
+        if (-not $registryProcessingFailed -and $unloaded -and $bootPolicyRestored) {
+            Remove-Item -LiteralPath $bootPolicyMarkerPath -Force -ErrorAction Stop
+            Log-Info "[$targetOSDrive] Removed consumed lab boot-policy marker: $bootPolicyMarkerPath"
+        }
+        }
+        catch {
+            $failedCount++
+            Log-Error "Disk $diskNumber failed during OS discovery or LKGC processing: $($_.Exception.Message)"
+            if ($bcdWriteStarted -and -not $bcdBackupRestored -and
+                $bcdBackup -and (Test-Path -LiteralPath $bcdBackup -PathType Leaf)) {
+                try {
+                    Copy-Item -LiteralPath $bcdBackup -Destination $bcdPath -Force -ErrorAction Stop
+                    $bcdBackupRestored = $true
+                    Log-Warning "Restored BCD backup after failed disk processing: $bcdBackup"
+                }
+                catch {
+                    Log-Error "CRITICAL: Failed to restore BCD backup '$bcdBackup': $($_.Exception.Message)"
+                }
+            }
+        }
+        finally {
+            if ($registryProcessingFailed -and $bcdWriteStarted -and
+                -not $bcdBackupRestored -and $bcdBackup -and
+                (Test-Path -LiteralPath $bcdBackup -PathType Leaf)) {
+                try {
+                    Copy-Item -LiteralPath $bcdBackup -Destination $bcdPath -Force -ErrorAction Stop
+                    $bcdBackupRestored = $true
+                    Log-Warning "Restored BCD backup because registry processing did not complete successfully: $bcdBackup"
+                }
+                catch {
+                    Log-Error "CRITICAL: Failed to restore BCD backup '$bcdBackup': $($_.Exception.Message)"
+                }
+            }
+            if ($tempBcdLetter) {
+                Log-Info "Removing temp BCD letter ${tempBcdLetter}: from Disk $tempBcdDiskNum Partition $tempBcdPartNum"
+                Invoke-LkgcDiskPart -Operation 'bcd-cleanup' -Commands @(
+                    "select disk $tempBcdDiskNum"
+                    "select partition $tempBcdPartNum"
+                    "remove letter=$tempBcdLetter noerr"
+                )
+            }
+            if ($tempOsLetter) {
+                Log-Info "Removing temp letter ${tempOsLetter}: from Disk $tempOsDiskNum Partition $tempOsPartNum"
+                $cleanupOutput = @(
+                    "select disk $tempOsDiskNum"
+                    "select partition $tempOsPartNum"
+                    "remove letter=$tempOsLetter noerr"
+                ) | diskpart 2>&1
+                foreach ($line in @($cleanupOutput)) {
+                    if ($line) { Log-Output "[diskpart][os-cleanup] $line" | Out-Null }
+                }
             }
         }
     }
 
-    if ($fixedDisks.Count -gt 0 -or $changedCount -gt 0) {
+    if ($failedCount -gt 0) {
+        throw "LKGC processing failed on $failedCount disk(s). Review the preceding disk errors."
+    }
+    elseif ($fixedDisks.Count -gt 0 -or $changedCount -gt 0) {
         if ($lkgcAppliedAny) {
             Log-Output "SCRIPT FINISHED PROPERLY, CHANGES_APPLIED=TRUE, LKGC APPLIED on drives: $($fixedDisks -join ', ')"
         } else {
@@ -301,6 +1078,74 @@ catch {
     $script_final_status = $STATUS_ERROR
 }
 finally {
+    $identityRestorationFailed = $false
+
+    if ($repairDiskIdentityRecord) {
+        foreach ($diskNumber in @($gptCollisionDiskNumbers | Sort-Object -Unique)) {
+            try {
+                Invoke-LkgcDiskPart -Operation 'source-before-repair-host-restore' -Commands @(
+                    "select disk $diskNumber"
+                    'offline disk'
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                $sourceDisk = Get-Disk -Number $diskNumber -ErrorAction Stop
+                $sourceIdentity = Get-LkgcDiskIdentity -DiskNumber $diskNumber
+                if (-not $sourceDisk.IsOffline -or
+                    $sourceIdentity.Value -ine $repairDiskIdentityRecord.OriginalValue) {
+                    throw "Source Disk $diskNumber was not offline with its unchanged original GPT identity."
+                }
+                Log-Info "Source Disk $diskNumber is offline with its original GPT identity verified."
+            }
+            catch {
+                $identityRestorationFailed = $true
+                Log-Error "CRITICAL: Could not safely offline and verify source Disk ${diskNumber}: $($_.Exception.Message)"
+            }
+        }
+
+        if (-not $identityRestorationFailed) {
+            try {
+                Restore-LkgcRepairDiskIdentity -Record $repairDiskIdentityRecord
+                Log-Info 'Repair VM OS disk GPT identity restored and verified.'
+            }
+            catch {
+                $identityRestorationFailed = $true
+                Log-Error "CRITICAL: Failed to restore the repair VM OS disk identity: $($_.Exception.Message)"
+            }
+        }
+    }
+
+    foreach ($record in @($collisionDiskRecords | Sort-Object DiskNumber -Descending)) {
+        try {
+            Restore-LkgcSourceDiskIdentity -Record $record
+            Log-Info "Disk $($record.DiskNumber) is offline with its verified original MBR identity restored."
+        }
+        catch {
+            $identityRestorationFailed = $true
+            Log-Error "CRITICAL: Failed to restore the original identity of Disk $($record.DiskNumber): $($_.Exception.Message)"
+        }
+    }
+    if ($identityRestorationFailed) {
+        $script_final_status = $STATUS_ERROR
+    }
+
+    $durationSeconds = [math]::Round(((Get-Date) - $script:ExecutionStarted).TotalSeconds, 3)
+    $finalTelemetryProperties = @{
+        FinalStatus    = "$script_final_status"
+        DurationSeconds = $durationSeconds
+        DisksProcessed = "$processedCount"
+        DisksChanged   = "$changedCount"
+        DisksSkipped   = "$skippedCount"
+        DisksFailed    = "$failedCount"
+    }
+
+    if ($script_final_status -eq $STATUS_SUCCESS) {
+        Write-LkgcTelemetry -Event Success -Message 'LKGC restoration script completed successfully' -Properties $finalTelemetryProperties
+    }
+    else {
+        Write-LkgcTelemetry -Event Error -Message 'LKGC restoration script completed with errors' -Properties $finalTelemetryProperties
+    }
+
+    Log-Info "[final_status] Status=$script_final_status"
     Log-Info "Summary: processed=$processedCount changed=$changedCount skipped=$skippedCount failed=$failedCount"
     Log-Info "Script ended at $(Get-Date)"
 }


### PR DESCRIPTION
v1.3: [Aug 2026] - Aligns disk collision handling with the latest SAC repair path.
                       Preserves the attached source disk identity, temporarily changes only the
                       disposable repair OS disk for matching Gen2 GPT collisions, and restores
                       and verifies every temporary identity before reporting success.
    v1.2.2: [Aug 2026] - Selects the existing LastKnownGood control set instead of incrementing
                       Select values and treats the absence of an alternate LKGC as a safe no-op.
                       Validates referenced control sets and their core Control and Services trees.
                       Prevents 0xc0000225 from missing or incomplete ControlSet references.
                       Adds logger-compatible JSON telemetry, SYSTEM hive backup, post-write
                       verification, unload retries, and backup rollback after failed writes.
                       Rejects invalid zero or negative boot control-set references before writes
                       and retries stale offline-hive cleanup before loading each SYSTEM hive.
                       Adds SAC-aligned repair-context detection, repair-disk exclusion, unlettered
                       Windows partition discovery, temporary drive assignment, and cleanup.
    v1.2.1: [Aug 2026] - Added structured VMRepair telemetry for LKGC restoration.
    Update [Jul 2026] - Partition Architecture Alignment: Refactored the core disk processing
                         loop to group by DiskNumber and map drive properties exactly like the
                         validated sac-enabler.ps1 framework.
    v1.2: [May - Jul 2026] - Production Hardening & Handle Updates