### PR TITLE
Update win-chkdsk-fs-corruption.ps1 to v1.3

### DIFF
--- a/src/windows/win-chkdsk-fs-corruption.ps1
+++ b/src/windows/win-chkdsk-fs-corruption.ps1
@@ -82,7 +82,7 @@
     Author:  Tony.Mocanu@Microsoft.com
 
 .VERSION
-    v1.3: [August 2026] - Aligned physical disk discovery and collision handling with
+        v1.3: [August 2026] - Aligned physical disk discovery and collision handling with
                           win-sac-on, win-LKGC, and GA_offlinefixer.
                         - Excludes repair-host critical disks and validates Windows targets.
                         - Supports safe temporary mounts and preserves source disk identities.
@@ -90,6 +90,9 @@
                         - Restricts CHKDSK to the validated Windows partition.
                         - Emits CHKDSK evidence while keeping DiskPart diagnostics out of
                           result output.
+                                                - Emits structured VMRepair telemetry for lifecycle, target validation,
+                                                    CHKDSK outcomes, and every catch block.
+                                                - Adds ShouldProcess support to disk identity mutation helpers.
     v1.2: [July 2026]   - Refactored logging to support desktop-first paths with SYSTEM fallback.
                         - Aligned dependency path validation and added explicit loop summaries.
     v1.1: [May 2026]    - Guarded nested VM discovery when Hyper-V is unavailable.
@@ -153,8 +156,8 @@ if ([string]::IsNullOrEmpty($logDir)) {
     }
 }
 
-if (-not (Test-Path -Path $logDir)) { 
-    $null = New-Item -ItemType Directory -Path $logDir -Force 
+if (-not (Test-Path -Path $logDir)) {
+    $null = New-Item -ItemType Directory -Path $logDir -Force
 }
 
 $timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
@@ -169,29 +172,81 @@ function Write-ScriptLog {
         [string]$Level = 'INFO'
     )
     $formattedMsg = "[$(Get-Date -Format 'MM/dd/yyyy HH:mm:ss')] [$Level] $Message"
-    
+
     # Direct to correct stream or custom framework logger
     switch ($Level) {
         'ERROR' {
-            if (Get-Command Log-Error -ErrorAction SilentlyContinue) { Log-Error $Message } 
+            if (Get-Command Log-Error -ErrorAction SilentlyContinue) { Log-Error $Message }
             else { Write-Error $formattedMsg }
         }
         'WARNING' {
-            if (Get-Command Log-Warning -ErrorAction SilentlyContinue) { Log-Warning $Message } 
+            if (Get-Command Log-Warning -ErrorAction SilentlyContinue) { Log-Warning $Message }
             else { Write-Warning $formattedMsg }
         }
         'OUTPUT' {
-            if (Get-Command Log-Output -ErrorAction SilentlyContinue) { Log-Output $Message } 
+            if (Get-Command Log-Output -ErrorAction SilentlyContinue) { Log-Output $Message }
             else { Write-Information $formattedMsg -InformationAction Continue }
         }
         Default {
-            if (Get-Command Log-Info -ErrorAction SilentlyContinue) { Log-Info $Message } 
+            if (Get-Command Log-Info -ErrorAction SilentlyContinue) { Log-Info $Message }
             else { Write-Information $formattedMsg -InformationAction Continue }
         }
     }
 
     # Write to local physical file
     $formattedMsg | Out-File -FilePath $logFile -Append -Encoding utf8
+}
+
+$script:RepairScriptVersion = '1.3'
+$script:ExecutionStarted = Get-Date
+
+function Write-ChkdskTelemetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Start', 'Operation', 'Success', 'Error')]
+        [string]$Event,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Message,
+
+        [hashtable]$Properties = @{}
+    )
+
+    $payload = [ordered]@{
+        Event = $Event
+        Message = $Message
+        TimestampUtc = (Get-Date).ToUniversalTime().ToString('o')
+        RepairScriptVersion = $script:RepairScriptVersion
+        Properties = $Properties
+    }
+    $json = $payload | ConvertTo-Json -Compress -Depth 8
+    $level = if ($Event -eq 'Error') { 'ERROR' } else { 'INFO' }
+    Write-ScriptLog -Message "[Telemetry] $json" -Level $level
+}
+
+function Write-ChkdskCatchTelemetry {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$CatchName,
+
+        [string]$Stage = '',
+
+        [string]$DiskNumber = '',
+
+        [string]$TargetDrive = '',
+
+        [Parameter(Mandatory = $true)]
+        [string]$ErrorMessage
+    )
+
+    Write-ChkdskTelemetry -Event Error -Message "Catch block: $CatchName" -Properties @{
+        CoverageCategory = 'CatchBlock'
+        CatchName = $CatchName
+        Stage = $Stage
+        DiskNumber = $DiskNumber
+        TargetDrive = $TargetDrive
+        Error = $ErrorMessage
+    }
 }
 
 function Get-ChkdskAvailableTempDriveLetter {
@@ -270,6 +325,7 @@ function Invoke-ChkdskDiskPart {
 }
 
 function Set-ChkdskTemporarySourceDiskIdentity {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [Parameter(Mandatory = $true)]
         [pscustomobject]$Record
@@ -277,6 +333,10 @@ function Set-ChkdskTemporarySourceDiskIdentity {
 
     if ($Record.PartitionStyle -ne 'MBR') {
         throw 'Temporary source disk identities are permitted only for MBR disks.'
+    }
+
+    if (-not $PSCmdlet.ShouldProcess("Disk $($Record.DiskNumber)", 'Assign a temporary MBR identity and online the disk')) {
+        return
     }
 
     Invoke-ChkdskDiskPart -Operation 'collision-prepare' -Commands @(
@@ -314,10 +374,15 @@ function Restore-ChkdskSourceDiskIdentity {
 }
 
 function Set-ChkdskTemporaryRepairDiskIdentity {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         [Parameter(Mandatory = $true)]
         [pscustomobject]$Record
     )
+
+    if (-not $PSCmdlet.ShouldProcess("Repair host Disk $($Record.DiskNumber)", 'Assign a temporary GPT identity')) {
+        return
+    }
 
     Invoke-ChkdskDiskPart -Operation 'repair-host-collision-prepare' -Commands @(
         "select disk $($Record.DiskNumber)"
@@ -367,6 +432,12 @@ $targetDiskCount = 0
 
 try {
     Write-ScriptLog "Script execution started. Logging active at: $logFile" "INFO"
+    Write-ChkdskTelemetry -Event Start -Message 'Starting CHKDSK file-system repair' -Properties @{
+        ScriptName = 'win-chkdsk-fs-corruption.ps1'
+        ScriptVersion = $script:RepairScriptVersion
+        ExecutionMode = 'REPAIR_VM_ONLY'
+        LogFile = $logFile
+    }
 
     # Stop nested guest VM if running (Only calls Hyper-V cmdlets after validation - DEP-02)
     $hyperVModuleAvailable = @(Get-Module -ListAvailable -Name 'Hyper-V').Count -gt 0
@@ -379,7 +450,9 @@ try {
                     Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
                 }
                 catch {
-                    Write-ScriptLog "Failed to stop nested guest VM '$($guestHyperVVirtualMachine.VMName)' via Stop-VM: $($_.Exception.Message). Continuing but with limited raw write access risks." "WARNING"
+                    $errorMessage = $_.Exception.Message
+                    Write-ScriptLog "Failed to stop nested guest VM '$($guestHyperVVirtualMachine.VMName)' via Stop-VM: $errorMessage. Continuing but with limited raw write access risks." "WARNING"
+                    Write-ChkdskCatchTelemetry -CatchName 'NestedVmStop' -Stage 'Preflight' -TargetDrive $env:SystemDrive -ErrorMessage $errorMessage
                 }
             }
         }
@@ -449,6 +522,12 @@ try {
                     TemporaryDiskPartValue = $temporaryRepairGuid
                 }
                 Write-ScriptLog 'Temporarily changing only the repair VM OS disk GPT identity; the source identity remains unchanged.' 'WARNING'
+                Write-ChkdskTelemetry -Event Operation -Message 'Preparing GPT collision resolution' -Properties @{
+                    CoverageCategory = 'Safety'
+                    Operation = 'RepairHostTemporaryIdentity'
+                    SourceDiskNumber = [string]$collisionDisk.Number
+                    RepairDiskNumber = [string]$rescueDiskNumber
+                }
                 Set-ChkdskTemporaryRepairDiskIdentity -Record $repairDiskIdentityRecord
             }
 
@@ -551,6 +630,12 @@ try {
         $partition = $targetWindowsPartition
         $driveLetter = $targetWindowsDriveLetter
         Write-ScriptLog "Validated Windows target on Disk $diskNumber Partition $($partition.PartitionNumber) at ${driveLetter}:." 'INFO'
+        Write-ChkdskTelemetry -Event Operation -Message 'Validated Windows repair target' -Properties @{
+            CoverageCategory = 'TargetValidation'
+            DiskNumber = [string]$diskNumber
+            PartitionNumber = [string]$partition.PartitionNumber
+            TargetDrive = "${driveLetter}:"
+        }
 
         try {
             $volume = Get-Volume -DriveLetter $driveLetter -ErrorAction Stop
@@ -580,10 +665,24 @@ try {
 
             if (-not [bool]$volumeState.DirtyBitSet) {
                 Write-ScriptLog "$letter dirty bit is not set; CHKDSK /f is not required." 'INFO'
+                Write-ChkdskTelemetry -Event Success -Message 'CHKDSK repair not required' -Properties @{
+                    CoverageCategory = 'RepairOutcome'
+                    Outcome = 'NoOp'
+                    DiskNumber = [string]$diskNumber
+                    TargetDrive = $letter
+                    DirtyBitSet = $false
+                }
                 continue
             }
 
             Write-ScriptLog "$letter dirty bit is set; executing CHKDSK /f." 'WARNING'
+            Write-ChkdskTelemetry -Event Operation -Message 'Starting CHKDSK repair' -Properties @{
+                CoverageCategory = 'RepairOperation'
+                Operation = 'ChkdskFix'
+                DiskNumber = [string]$diskNumber
+                TargetDrive = $letter
+                DirtyBitSet = $true
+            }
             $chkdskResults = & chkdsk.exe $letter /f 2>&1
             $chkdskExitCode = $LASTEXITCODE
             foreach ($resultLine in @($chkdskResults)) {
@@ -602,6 +701,13 @@ try {
 
             if ($chkdskExitCode -notin @(0, 1, 2)) {
                 Write-ScriptLog "CHKDSK failed on $letter with exit code $chkdskExitCode." 'ERROR'
+                Write-ChkdskTelemetry -Event Error -Message 'CHKDSK returned an unsupported exit code' -Properties @{
+                    CoverageCategory = 'RepairOutcome'
+                    Outcome = 'Failed'
+                    DiskNumber = [string]$diskNumber
+                    TargetDrive = $letter
+                    ExitCode = $chkdskExitCode
+                }
                 $failedCount++
                 continue
             }
@@ -611,16 +717,33 @@ try {
             if ($null -eq $repairedVolumeState -or $null -eq $repairedVolumeState.DirtyBitSet -or
                 [bool]$repairedVolumeState.DirtyBitSet) {
                 Write-ScriptLog "CHKDSK returned exit code $chkdskExitCode, but $letter still reports a dirty or unknown state." 'ERROR'
+                Write-ChkdskTelemetry -Event Error -Message 'CHKDSK post-repair dirty-bit verification failed' -Properties @{
+                    CoverageCategory = 'RepairOutcome'
+                    Outcome = 'VerificationFailed'
+                    DiskNumber = [string]$diskNumber
+                    TargetDrive = $letter
+                    ExitCode = $chkdskExitCode
+                }
                 $failedCount++
                 continue
             }
 
             $fixedCount++
             Write-ScriptLog "CHKDSK completed on $letter with exit code $chkdskExitCode and a verified clear dirty bit." 'INFO'
+            Write-ChkdskTelemetry -Event Success -Message 'CHKDSK repair completed and verified' -Properties @{
+                CoverageCategory = 'RepairOutcome'
+                Outcome = 'Repaired'
+                DiskNumber = [string]$diskNumber
+                TargetDrive = $letter
+                ExitCode = $chkdskExitCode
+                DirtyBitSet = $false
+            }
         }
         catch {
+            $errorMessage = $_.Exception.Message
             $failedCount++
-            Write-ScriptLog "Failed processing validated Windows partition on Disk ${diskNumber}: $($_.Exception.Message)" 'ERROR'
+            Write-ScriptLog "Failed processing validated Windows partition on Disk ${diskNumber}: $errorMessage" 'ERROR'
+            Write-ChkdskCatchTelemetry -CatchName 'WindowsPartitionProcessing' -Stage 'DiscoveryOrRepair' -DiskNumber "$diskNumber" -TargetDrive "${driveLetter}:" -ErrorMessage $errorMessage
         }
     }
 
@@ -635,7 +758,9 @@ try {
     $script_final_status = $STATUS_SUCCESS
 }
 catch {
-    Write-ScriptLog "An unhandled execution crash occurred: $($_.Exception.Message)" "ERROR"
+    $errorMessage = $_.Exception.Message
+    Write-ScriptLog "An unhandled execution crash occurred: $errorMessage" "ERROR"
+    Write-ChkdskCatchTelemetry -CatchName 'UnhandledExecution' -Stage 'Main' -ErrorMessage $errorMessage
     $script_final_status = $STATUS_ERROR
 }
 finally {
@@ -653,7 +778,9 @@ finally {
             }
         }
         catch {
-            Write-ScriptLog "Failed to remove temporary letter $($mount.DriveLetter): $($_.Exception.Message)" 'ERROR'
+            $errorMessage = $_.Exception.Message
+            Write-ScriptLog "Failed to remove temporary letter $($mount.DriveLetter): $errorMessage" 'ERROR'
+            Write-ChkdskCatchTelemetry -CatchName 'TemporaryMountCleanup' -Stage 'Cleanup' -DiskNumber "$($mount.DiskNumber)" -TargetDrive "$($mount.DriveLetter):" -ErrorMessage $errorMessage
             $script_final_status = $STATUS_ERROR
         }
     }
@@ -675,8 +802,10 @@ finally {
                 }
             }
             catch {
+                $errorMessage = $_.Exception.Message
                 $identityRestorationFailed = $true
-                Write-ScriptLog "CRITICAL: Could not safely offline source Disk ${diskNumber}: $($_.Exception.Message)" 'ERROR'
+                Write-ScriptLog "CRITICAL: Could not safely offline source Disk ${diskNumber}: $errorMessage" 'ERROR'
+                Write-ChkdskCatchTelemetry -CatchName 'SourceGptOffline' -Stage 'IdentityRestore' -DiskNumber "$diskNumber" -ErrorMessage $errorMessage
             }
         }
 
@@ -686,8 +815,10 @@ finally {
                 Write-ScriptLog 'Repair VM OS disk GPT identity restored and verified.' 'INFO'
             }
             catch {
+                $errorMessage = $_.Exception.Message
                 $identityRestorationFailed = $true
-                Write-ScriptLog "CRITICAL: Failed to restore the repair VM OS disk identity: $($_.Exception.Message)" 'ERROR'
+                Write-ScriptLog "CRITICAL: Failed to restore the repair VM OS disk identity: $errorMessage" 'ERROR'
+                Write-ChkdskCatchTelemetry -CatchName 'RepairDiskIdentityRestore' -Stage 'IdentityRestore' -DiskNumber "$($repairDiskIdentityRecord.DiskNumber)" -ErrorMessage $errorMessage
             }
         }
     }
@@ -698,8 +829,10 @@ finally {
             Write-ScriptLog "Disk $($identityRecord.DiskNumber) original MBR identity restored and verified." 'INFO'
         }
         catch {
+            $errorMessage = $_.Exception.Message
             $identityRestorationFailed = $true
-            Write-ScriptLog "CRITICAL: Failed to restore Disk $($identityRecord.DiskNumber) identity: $($_.Exception.Message)" 'ERROR'
+            Write-ScriptLog "CRITICAL: Failed to restore Disk $($identityRecord.DiskNumber) identity: $errorMessage" 'ERROR'
+            Write-ChkdskCatchTelemetry -CatchName 'SourceMbrIdentityRestore' -Stage 'IdentityRestore' -DiskNumber "$($identityRecord.DiskNumber)" -ErrorMessage $errorMessage
         }
     }
     if ($identityRestorationFailed) {
@@ -708,6 +841,16 @@ finally {
 
     Write-ScriptLog "Partition Summary: Processed=$processedCount | Skipped=$skippedCount | Fixed=$fixedCount | Failed=$failedCount" 'INFO'
     Write-ScriptLog "Final script status: $script_final_status" "INFO"
+    $completionEvent = if ($script_final_status -eq $STATUS_SUCCESS) { 'Success' } else { 'Error' }
+    Write-ChkdskTelemetry -Event $completionEvent -Message 'CHKDSK repair script completed' -Properties @{
+        CoverageCategory = 'ScriptOutcome'
+        Status = [string]$script_final_status
+        Processed = $processedCount
+        Skipped = $skippedCount
+        Repaired = $fixedCount
+        Failed = $failedCount
+        DurationMilliseconds = [int64]((Get-Date) - $script:ExecutionStarted).TotalMilliseconds
+    }
     Write-ScriptLog "Script finalized. Destination log package details: $logFile" "INFO"
 }
 

--- a/src/windows/win-chkdsk-fs-corruption.ps1
+++ b/src/windows/win-chkdsk-fs-corruption.ps1
@@ -239,7 +239,10 @@ function Write-ChkdskCatchTelemetry {
         [string]$TargetDrive = '',
 
         [Parameter(Mandatory = $true)]
-        [string]$ErrorMessage
+        [System.Management.Automation.ErrorRecord]$ErrorRecord,
+
+        [AllowNull()]
+        [Nullable[int]]$ChkdskExitCode = $null
     )
 
     Write-ChkdskTelemetry -Event Error -Message "Catch block: $CatchName" -Properties @{
@@ -248,7 +251,9 @@ function Write-ChkdskCatchTelemetry {
         Stage = $Stage
         DiskNumber = $DiskNumber
         TargetDrive = $TargetDrive
-        Error = $ErrorMessage
+        ExceptionType = $ErrorRecord.Exception.GetType().FullName
+        ChkdskExitCode = if ($null -eq $ChkdskExitCode) { '' } else { $ChkdskExitCode }
+        Error = $ErrorRecord.Exception.Message
     }
 }
 
@@ -547,7 +552,7 @@ function Repair-ChkdskUnknownBcdMapping {
     }
     catch {
         $repairError = $_.Exception.Message
-        Write-ChkdskCatchTelemetry -CatchName 'BcdMappingPreflight' -Stage 'BootSafety' -DiskNumber "$DiskNumber" -TargetDrive "${WindowsDrive}:" -ErrorMessage $repairError
+        Write-ChkdskCatchTelemetry -CatchName 'BcdMappingPreflight' -Stage 'BootSafety' -DiskNumber "$DiskNumber" -TargetDrive "${WindowsDrive}:" -ErrorRecord $_
         if ($bcdWriteStarted -and (Test-Path -LiteralPath $bcdBackup -PathType Leaf)) {
             Copy-Item -LiteralPath $bcdBackup -Destination $bcdPath -Force -ErrorAction Stop
             if ((Get-Item -LiteralPath $bcdPath -Force -ErrorAction Stop).Length -ne
@@ -694,7 +699,7 @@ try {
                 catch {
                     $errorMessage = $_.Exception.Message
                     Write-ScriptLog "Failed to stop nested guest VM '$($guestHyperVVirtualMachine.VMName)' via Stop-VM: $errorMessage. Continuing but with limited raw write access risks." "WARNING"
-                    Write-ChkdskCatchTelemetry -CatchName 'NestedVmStop' -Stage 'Preflight' -TargetDrive $env:SystemDrive -ErrorMessage $errorMessage
+                    Write-ChkdskCatchTelemetry -CatchName 'NestedVmStop' -Stage 'Preflight' -TargetDrive $env:SystemDrive -ErrorRecord $_
                 }
             }
         }
@@ -879,6 +884,7 @@ try {
             TargetDrive = "${driveLetter}:"
         }
 
+        $chkdskExitCode = $null
         try {
             Repair-ChkdskUnknownBcdMapping -DiskNumber $diskNumber -DiskPartitions $diskPartitions -WindowsDrive $driveLetter
 
@@ -987,7 +993,7 @@ try {
             $errorMessage = $_.Exception.Message
             $failedCount++
             Write-ScriptLog "Failed processing validated Windows partition on Disk ${diskNumber}: $errorMessage" 'ERROR'
-            Write-ChkdskCatchTelemetry -CatchName 'WindowsPartitionProcessing' -Stage 'DiscoveryOrRepair' -DiskNumber "$diskNumber" -TargetDrive "${driveLetter}:" -ErrorMessage $errorMessage
+            Write-ChkdskCatchTelemetry -CatchName 'WindowsPartitionProcessing' -Stage 'DiscoveryOrRepair' -DiskNumber "$diskNumber" -TargetDrive "${driveLetter}:" -ErrorRecord $_ -ChkdskExitCode $chkdskExitCode
         }
     }
 
@@ -1004,7 +1010,7 @@ try {
 catch {
     $errorMessage = $_.Exception.Message
     Write-ScriptLog "An unhandled execution crash occurred: $errorMessage" "ERROR"
-    Write-ChkdskCatchTelemetry -CatchName 'UnhandledExecution' -Stage 'Main' -ErrorMessage $errorMessage
+    Write-ChkdskCatchTelemetry -CatchName 'UnhandledExecution' -Stage 'Main' -ErrorRecord $_
     $script_final_status = $STATUS_ERROR
 }
 finally {
@@ -1024,7 +1030,7 @@ finally {
         catch {
             $errorMessage = $_.Exception.Message
             Write-ScriptLog "Failed to remove temporary letter $($mount.DriveLetter): $errorMessage" 'ERROR'
-            Write-ChkdskCatchTelemetry -CatchName 'TemporaryMountCleanup' -Stage 'Cleanup' -DiskNumber "$($mount.DiskNumber)" -TargetDrive "$($mount.DriveLetter):" -ErrorMessage $errorMessage
+            Write-ChkdskCatchTelemetry -CatchName 'TemporaryMountCleanup' -Stage 'Cleanup' -DiskNumber "$($mount.DiskNumber)" -TargetDrive "$($mount.DriveLetter):" -ErrorRecord $_
             $script_final_status = $STATUS_ERROR
         }
     }
@@ -1049,7 +1055,7 @@ finally {
                 $errorMessage = $_.Exception.Message
                 $identityRestorationFailed = $true
                 Write-ScriptLog "CRITICAL: Could not safely offline source Disk ${diskNumber}: $errorMessage" 'ERROR'
-                Write-ChkdskCatchTelemetry -CatchName 'SourceGptOffline' -Stage 'IdentityRestore' -DiskNumber "$diskNumber" -ErrorMessage $errorMessage
+                Write-ChkdskCatchTelemetry -CatchName 'SourceGptOffline' -Stage 'IdentityRestore' -DiskNumber "$diskNumber" -ErrorRecord $_
             }
         }
 
@@ -1062,7 +1068,7 @@ finally {
                 $errorMessage = $_.Exception.Message
                 $identityRestorationFailed = $true
                 Write-ScriptLog "CRITICAL: Failed to restore the repair VM OS disk identity: $errorMessage" 'ERROR'
-                Write-ChkdskCatchTelemetry -CatchName 'RepairDiskIdentityRestore' -Stage 'IdentityRestore' -DiskNumber "$($repairDiskIdentityRecord.DiskNumber)" -ErrorMessage $errorMessage
+                Write-ChkdskCatchTelemetry -CatchName 'RepairDiskIdentityRestore' -Stage 'IdentityRestore' -DiskNumber "$($repairDiskIdentityRecord.DiskNumber)" -ErrorRecord $_
             }
         }
     }
@@ -1076,7 +1082,7 @@ finally {
             $errorMessage = $_.Exception.Message
             $identityRestorationFailed = $true
             Write-ScriptLog "CRITICAL: Failed to restore Disk $($identityRecord.DiskNumber) identity: $errorMessage" 'ERROR'
-            Write-ChkdskCatchTelemetry -CatchName 'SourceMbrIdentityRestore' -Stage 'IdentityRestore' -DiskNumber "$($identityRecord.DiskNumber)" -ErrorMessage $errorMessage
+            Write-ChkdskCatchTelemetry -CatchName 'SourceMbrIdentityRestore' -Stage 'IdentityRestore' -DiskNumber "$($identityRecord.DiskNumber)" -ErrorRecord $_
         }
     }
     if ($identityRestorationFailed) {

--- a/src/windows/win-chkdsk-fs-corruption.ps1
+++ b/src/windows/win-chkdsk-fs-corruption.ps1
@@ -12,8 +12,9 @@
     2. Enumerates attached partitions via Get-Disk-Partitions and validates Windows targets.
     3. Temporarily mounts eligible unlettered data partitions and restores all mount state.
     4. Queries the Windows partition dirty bit using fsutil and Win32_Volume data.
-    5. Runs CHKDSK /f when the dirty bit is set and verifies that it is cleared.
-    6. Preserves source disk identity across GPT and MBR collision handling.
+    5. Validates the offline BCD loader mapping and repairs only unknown device mappings.
+    6. Runs CHKDSK /f when the dirty bit is set and verifies that it is cleared.
+    7. Preserves source disk identity across GPT and MBR collision handling.
 
     This resolves VMs stuck at boot showing "Scanning and repairing drive" or
     "Checking file system on C:" messages. Running CHKDSK from a rescue VM avoids
@@ -93,6 +94,8 @@
                                                 - Emits structured VMRepair telemetry for lifecycle, target validation,
                                                     CHKDSK outcomes, and every catch block.
                                                 - Adds ShouldProcess support to disk identity mutation helpers.
+                                                - Repairs and verifies unknown BCD device/osdevice mappings with
+                                                    verified backup and automatic rollback for Win2022 boot safety.
     v1.2: [July 2026]   - Refactored logging to support desktop-first paths with SYSTEM fallback.
                         - Aligned dependency path validation and added explicit loop summaries.
     v1.1: [May 2026]    - Guarded nested VM discovery when Hyper-V is unavailable.
@@ -321,6 +324,245 @@ function Invoke-ChkdskDiskPart {
         if ($outputLine) {
             Write-ScriptLog "[diskpart][$Operation] $outputLine" 'INFO'
         }
+    }
+}
+
+function Invoke-ChkdskBcdEdit {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Operation
+    )
+
+    $output = & bcdedit.exe @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    foreach ($outputLine in @($output)) {
+        if ($outputLine) {
+            Write-ScriptLog "[bcdedit][$Operation] $outputLine" 'INFO'
+        }
+    }
+    Write-ChkdskTelemetry -Event Operation -Message "bcdedit $Operation" -Properties @{
+        CoverageCategory = 'BootSafety'
+        Operation = $Operation
+        ExitCode = $exitCode
+        Success = ($exitCode -eq 0)
+    }
+
+    return [pscustomobject]@{
+        Output = @($output)
+        ExitCode = $exitCode
+        Success = ($exitCode -eq 0)
+    }
+}
+
+function Repair-ChkdskUnknownBcdMapping {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$DiskNumber,
+
+        [Parameter(Mandatory = $true)]
+        [object[]]$DiskPartitions,
+
+        [Parameter(Mandatory = $true)]
+        [string]$WindowsDrive
+    )
+
+    $efiGptType = 'c12a7328-f81f-11d2-ba4b-00a0c93ec93b'
+    $efiPartitions = @($DiskPartitions | Where-Object {
+        ([string]$_.GptType).Trim().Trim('{', '}') -ieq $efiGptType
+    })
+    $isGen2Disk = $efiPartitions.Count -gt 0
+    $bcdPath = $null
+
+    if ($isGen2Disk) {
+        foreach ($efiPartition in $efiPartitions) {
+            $efiLetter = [string]$efiPartition.DriveLetter
+            $letterAssignedByScript = $false
+            if (-not $efiLetter -or $efiLetter -eq [char]0) {
+                $efiLetter = Get-ChkdskAvailableTempDriveLetter
+                if (-not $efiLetter) {
+                    throw "No temporary drive letter is available for the EFI partition on Disk $DiskNumber."
+                }
+                Invoke-ChkdskDiskPart -Operation 'bcd-efi-assign' -Commands @(
+                    "select disk $DiskNumber"
+                    "select partition $($efiPartition.PartitionNumber)"
+                    "assign letter=$efiLetter"
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                if (-not (Test-Path -LiteralPath "${efiLetter}:\" -PathType Container)) {
+                    throw "EFI mount ${efiLetter}: failed for Disk $DiskNumber Partition $($efiPartition.PartitionNumber)."
+                }
+                $letterAssignedByScript = $true
+                $script:temporaryMounts += [pscustomobject]@{
+                    DiskNumber = $DiskNumber
+                    PartitionNumber = [int]$efiPartition.PartitionNumber
+                    DriveLetter = $efiLetter
+                }
+            }
+
+            $candidateBcdPath = "${efiLetter}:\EFI\Microsoft\Boot\BCD"
+            if (Test-Path -LiteralPath $candidateBcdPath -PathType Leaf) {
+                $bcdPath = $candidateBcdPath
+                break
+            }
+
+            if ($letterAssignedByScript) {
+                Invoke-ChkdskDiskPart -Operation 'bcd-efi-remove-unused' -Commands @(
+                    "select disk $DiskNumber"
+                    "select partition $($efiPartition.PartitionNumber)"
+                    "remove letter=$efiLetter noerr"
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                $script:temporaryMounts = @($script:temporaryMounts | Where-Object {
+                    -not ($_.DiskNumber -eq $DiskNumber -and
+                        $_.PartitionNumber -eq [int]$efiPartition.PartitionNumber -and
+                        $_.DriveLetter -ieq $efiLetter)
+                })
+            }
+        }
+    }
+    else {
+        foreach ($partition in @($DiskPartitions | Where-Object {
+            $_.DriveLetter -and $_.DriveLetter -ne [char]0
+        })) {
+            $candidateBcdPath = "$($partition.DriveLetter):\Boot\BCD"
+            if (Test-Path -LiteralPath $candidateBcdPath -PathType Leaf) {
+                $bcdPath = $candidateBcdPath
+                break
+            }
+        }
+        if (-not $bcdPath) {
+            $candidateBcdPath = "${WindowsDrive}:\Boot\BCD"
+            if (Test-Path -LiteralPath $candidateBcdPath -PathType Leaf) {
+                $bcdPath = $candidateBcdPath
+            }
+        }
+    }
+
+    if (-not $bcdPath) {
+        throw "Disk $DiskNumber has no generation-appropriate BCD store."
+    }
+
+    $bootManagerQuery = Invoke-ChkdskBcdEdit -Arguments @('/store', $bcdPath, '/enum', 'bootmgr', '/v') -Operation 'query-bootmgr'
+    if (-not $bootManagerQuery.Success) {
+        throw "Could not enumerate boot manager from $bcdPath."
+    }
+    $defaultLine = $bootManagerQuery.Output | Select-String -Pattern '^\s*default\s+' | Select-Object -First 1
+    if (-not $defaultLine -or $defaultLine -notmatch '\{([^}]+)\}') {
+        throw "Could not identify the default Windows loader in $bcdPath."
+    }
+    $defaultLoaderId = $matches[0]
+    if ($defaultLoaderId -notmatch '^(?i)\{[0-9a-f\-]{36}\}$') {
+        throw "Default BCD loader identifier '$defaultLoaderId' is invalid."
+    }
+
+    $loaderQuery = Invoke-ChkdskBcdEdit -Arguments @('/store', $bcdPath, '/enum', $defaultLoaderId, '/v') -Operation 'validate-loader'
+    $loaderText = $loaderQuery.Output -join "`n"
+    $loaderPathMatch = [regex]::Match($loaderText, '(?im)^\s*path\s+(.+?)\s*$')
+    $loaderDeviceMatch = [regex]::Match($loaderText, '(?im)^\s*device\s+(.+?)\s*$')
+    $loaderOsDeviceMatch = [regex]::Match($loaderText, '(?im)^\s*osdevice\s+(.+?)\s*$')
+    $loaderSystemRootMatch = [regex]::Match($loaderText, '(?im)^\s*systemroot\s+(.+?)\s*$')
+    if (-not $loaderQuery.Success -or -not $loaderPathMatch.Success -or
+        -not $loaderDeviceMatch.Success -or -not $loaderOsDeviceMatch.Success -or
+        -not $loaderSystemRootMatch.Success) {
+        throw "Default loader $defaultLoaderId is missing required mapping elements."
+    }
+
+    $originalLoaderPath = $loaderPathMatch.Groups[1].Value.Trim()
+    $originalSystemRoot = $loaderSystemRootMatch.Groups[1].Value.Trim()
+    if ($originalLoaderPath -notmatch '(?i)^\\Windows\\System32\\winload\.(exe|efi)$') {
+        throw "Default loader $defaultLoaderId references unsupported path '$originalLoaderPath'."
+    }
+    $resolvedLoaderFile = Join-Path -Path "${WindowsDrive}:\" -ChildPath $originalLoaderPath.TrimStart('\')
+    if (-not (Test-Path -LiteralPath $resolvedLoaderFile -PathType Leaf)) {
+        throw "Default loader references '$originalLoaderPath', but '$resolvedLoaderFile' does not exist."
+    }
+
+    $repairLoaderDevice = $loaderDeviceMatch.Groups[1].Value.Trim() -match '(?i)^unknown$'
+    $repairLoaderOsDevice = $loaderOsDeviceMatch.Groups[1].Value.Trim() -match '(?i)^unknown$'
+    if (-not $repairLoaderDevice -and -not $repairLoaderOsDevice) {
+        Write-ChkdskTelemetry -Event Success -Message 'BCD loader mapping validated without changes' -Properties @{
+            CoverageCategory = 'BootSafety'
+            DiskNumber = [string]$DiskNumber
+            VMGeneration = if ($isGen2Disk) { 'V2' } else { 'V1' }
+            BcdPath = $bcdPath
+            LoaderGuid = $defaultLoaderId
+        }
+        return
+    }
+
+    $bcdBackup = $bcdPath + '.chkdsk.bak.' + (Get-Date -Format 'yyyyMMdd-HHmmss')
+    $bcdWriteStarted = $false
+    try {
+        Copy-Item -LiteralPath $bcdPath -Destination $bcdBackup -Force -ErrorAction Stop
+        if (-not (Test-Path -LiteralPath $bcdBackup -PathType Leaf) -or
+            (Get-Item -LiteralPath $bcdBackup -Force -ErrorAction Stop).Length -ne
+            (Get-Item -LiteralPath $bcdPath -Force -ErrorAction Stop).Length) {
+            throw "BCD backup verification failed for '$bcdBackup'."
+        }
+
+        $validatedWindowsPartition = "partition=${WindowsDrive}:"
+        $bcdWriteStarted = $true
+        if ($repairLoaderDevice) {
+            $setDeviceResult = Invoke-ChkdskBcdEdit -Arguments @('/store', $bcdPath, '/set', $defaultLoaderId, 'device', $validatedWindowsPartition) -Operation 'repair-loader-device'
+            if (-not $setDeviceResult.Success) {
+                throw "Could not repair device for loader $defaultLoaderId."
+            }
+        }
+        if ($repairLoaderOsDevice) {
+            $setOsDeviceResult = Invoke-ChkdskBcdEdit -Arguments @('/store', $bcdPath, '/set', $defaultLoaderId, 'osdevice', $validatedWindowsPartition) -Operation 'repair-loader-osdevice'
+            if (-not $setOsDeviceResult.Success) {
+                throw "Could not repair osdevice for loader $defaultLoaderId."
+            }
+        }
+
+        $verifyLoader = Invoke-ChkdskBcdEdit -Arguments @('/store', $bcdPath, '/enum', $defaultLoaderId, '/v') -Operation 'verify-loader-mapping'
+        $verifyText = $verifyLoader.Output -join "`n"
+        $verifyPath = [regex]::Match($verifyText, '(?im)^\s*path\s+(.+?)\s*$')
+        $verifyDevice = [regex]::Match($verifyText, '(?im)^\s*device\s+(.+?)\s*$')
+        $verifyOsDevice = [regex]::Match($verifyText, '(?im)^\s*osdevice\s+(.+?)\s*$')
+        $verifySystemRoot = [regex]::Match($verifyText, '(?im)^\s*systemroot\s+(.+?)\s*$')
+        if (-not $verifyLoader.Success -or -not $verifyPath.Success -or
+            -not $verifyDevice.Success -or -not $verifyOsDevice.Success -or
+            -not $verifySystemRoot.Success -or
+            $verifyDevice.Groups[1].Value.Trim() -match '(?i)^unknown$' -or
+            $verifyOsDevice.Groups[1].Value.Trim() -match '(?i)^unknown$' -or
+            $verifyPath.Groups[1].Value.Trim() -ine $originalLoaderPath -or
+            $verifySystemRoot.Groups[1].Value.Trim() -ine $originalSystemRoot) {
+            throw "Loader mapping repair verification failed for $defaultLoaderId."
+        }
+
+        Write-ChkdskTelemetry -Event Success -Message 'Unknown BCD loader mapping repaired and verified' -Properties @{
+            CoverageCategory = 'BootSafety'
+            DiskNumber = [string]$DiskNumber
+            VMGeneration = if ($isGen2Disk) { 'V2' } else { 'V1' }
+            BcdPath = $bcdPath
+            LoaderGuid = $defaultLoaderId
+            BackupPath = $bcdBackup
+            DeviceRepaired = $repairLoaderDevice
+            OsDeviceRepaired = $repairLoaderOsDevice
+        }
+    }
+    catch {
+        $repairError = $_.Exception.Message
+        Write-ChkdskCatchTelemetry -CatchName 'BcdMappingPreflight' -Stage 'BootSafety' -DiskNumber "$DiskNumber" -TargetDrive "${WindowsDrive}:" -ErrorMessage $repairError
+        if ($bcdWriteStarted -and (Test-Path -LiteralPath $bcdBackup -PathType Leaf)) {
+            Copy-Item -LiteralPath $bcdBackup -Destination $bcdPath -Force -ErrorAction Stop
+            if ((Get-Item -LiteralPath $bcdPath -Force -ErrorAction Stop).Length -ne
+                (Get-Item -LiteralPath $bcdBackup -Force -ErrorAction Stop).Length) {
+                throw "BCD repair failed and rollback verification failed. Original error: $repairError"
+            }
+            Write-ChkdskTelemetry -Event Error -Message 'BCD loader mapping repair rolled back' -Properties @{
+                CoverageCategory = 'BootSafety'
+                DiskNumber = [string]$DiskNumber
+                BcdPath = $bcdPath
+                BackupPath = $bcdBackup
+                Error = $repairError
+            }
+        }
+        throw "BCD loader mapping preflight failed: $repairError"
     }
 }
 
@@ -638,6 +880,8 @@ try {
         }
 
         try {
+            Repair-ChkdskUnknownBcdMapping -DiskNumber $diskNumber -DiskPartitions $diskPartitions -WindowsDrive $driveLetter
+
             $volume = Get-Volume -DriveLetter $driveLetter -ErrorAction Stop
             if ([string]$volume.FileSystem -ine 'NTFS') {
                 throw "Validated Windows partition ${driveLetter}: uses '$($volume.FileSystem)', not NTFS."

--- a/src/windows/win-chkdsk-fs-corruption.ps1
+++ b/src/windows/win-chkdsk-fs-corruption.ps1
@@ -1,31 +1,715 @@
-# .SUMMARY
-#   Runs chkdsk to fix file system corruption.
-#   Checks if dirty bit has been set and if so, runs a chkdsk.exe on the attached disk.
-#   Public doc: https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows/troubleshoot-check-disk-boot-error
-# 
-# .RESOLVES
-#   A Windows VM doesn't start. When you check the boot screenshots in Boot diagnostics, you see that the Check Disk process (chkdsk.exe)
-#   is running with one of the following messages: 1. Scanning and repairing drive (C:) , 2. Checking file system on C: .
-#   If an NTFS error is found in the file system, the dirty bit will set and the disk check application will run to try and fix any corruption. Running it from a rescue VM helps prevent interruptions.
+<#
+.SYNOPSIS
+    Detects attached Windows OS disks from a repair VM and safely repairs verified
+    NTFS file system corruption with CHKDSK.
 
-. .\src\windows\common\setup\init.ps1
-. .\src\windows\common\helpers\Get-Disk-Partitions.ps1
+.DESCRIPTION
+    This script runs from a rescue VM to check and repair NTFS file system corruption
+    on the validated Windows partition of each attached faulty OS disk.
 
-$partitionlist = Get-Disk-Partitions
+    It performs the following steps:
+    1. Identifies and excludes repair-host OS, boot, system, and pagefile disks.
+    2. Enumerates attached partitions via Get-Disk-Partitions and validates Windows targets.
+    3. Temporarily mounts eligible unlettered data partitions and restores all mount state.
+    4. Queries the Windows partition dirty bit using fsutil and Win32_Volume data.
+    5. Runs CHKDSK /f when the dirty bit is set and verifies that it is cleared.
+    6. Preserves source disk identity across GPT and MBR collision handling.
 
-forEach ( $partition in $partitionlist )
-{
-    $driveLetter = ($partition.DriveLetter + ":")
-    $dirtyFlag = fsutil dirty query $driveLetter
-    If ($dirtyFlag -notmatch "NOT Dirty")
-    {
-        Log-Info "02 - $driveLetter dirty bit set  -> running chkdsk"
-        chkdsk $driveLetter /f
-    }
-    else
-    {
-        Log-Info "02 - $driveLetter dirty bit not set  -> skipping chkdsk"
+    This resolves VMs stuck at boot showing "Scanning and repairing drive" or
+    "Checking file system on C:" messages. Running CHKDSK from a rescue VM avoids
+    interruptions that occur when the OS runs it during boot.
+
+.PARAMETER None
+    This script does not accept custom parameters. It automatically processes the
+    validated Windows partition on each attached target OS disk.
+
+.EXECUTION_CONTEXT
+    This is a repair-VM-only script. Run it through the VMRepair workflow against an
+    attached copy of the affected Windows OS disk. It refuses to process the repair
+    VM's OS, boot, system, and pagefile disks.
+
+.SCENARIO_RECREATION
+    Use only a disposable test VM and take an OS disk snapshot before injecting the
+    test state. Setting the dirty bit exercises this script's detection and CHKDSK
+    path; it does not create arbitrary NTFS metadata corruption.
+
+    From Azure Cloud Shell or an authenticated PowerShell terminal, set and verify
+    the dirty bit through Azure Run Command:
+
+    az vm run-command invoke `
+        --resource-group <resource-group> `
+        --name <disposable-test-vm> `
+        --command-id RunPowerShellScript `
+        Start-Process -FilePath "fsutil.exe" -ArgumentList "dirty query C:" -Wait -NoNewWindow
+        Start-Process -FilePath "fsutil.exe" -ArgumentList "dirty set C:" -Wait -NoNewWindow
+        Start-Process -FilePath "fsutil.exe" -ArgumentList "dirty query C:" -Wait -NoNewWindow
+
+    The final query should report that C: is dirty. The exact message can vary with
+    the guest OS display language. Do not reboot the test VM after setting the bit,
+    because startup CHKDSK may consume and clear the test condition before the repair
+    script runs.
+
+    Next, use the normal VMRepair create/attach workflow and run this script on the
+    repair VM:
+
+    az vm repair run `
+        --resource-group <resource-group> `
+        --name <disposable-test-vm> `
+        --run-id win-chkdsk-fs-corruption `
+        --run-on-repair
+
+    Expected repair log sequence:
+    1. The attached Windows disk and NTFS partition are validated.
+    2. The dirty bit is reported as set.
+    3. CHKDSK /f runs and returns an accepted exit code.
+    4. The dirty bit is re-queried and verified clear.
+    5. Temporary drive letters and disk identities are restored.
+
+.VERIFICATION
+    After restoring and starting the disposable test VM, verify the volume state:
+
+    fsutil.exe dirty query C:
+
+    Expected: C: is not dirty. Also confirm that the repair log reports final status
+    success, Failed=0, and Repaired=1 for the single attached test OS disk.
+
+.EXAMPLE
+    .\win-chkdsk-fs-corruption.ps1
+
+.NOTES
+    Name:    win-chkdsk-fs-corruption.ps1
+    Version: 1.3
+    Author:  Tony.Mocanu@Microsoft.com
+
+.VERSION
+    v1.3: [August 2026] - Aligned physical disk discovery and collision handling with
+                          win-sac-on, win-LKGC, and GA_offlinefixer.
+                        - Excludes repair-host critical disks and validates Windows targets.
+                        - Supports safe temporary mounts and preserves source disk identities.
+                        - Verifies native exit codes and the cleared NTFS dirty bit.
+                        - Restricts CHKDSK to the validated Windows partition.
+                        - Emits CHKDSK evidence while keeping DiskPart diagnostics out of
+                          result output.
+    v1.2: [July 2026]   - Refactored logging to support desktop-first paths with SYSTEM fallback.
+                        - Aligned dependency path validation and added explicit loop summaries.
+    v1.1: [May 2026]    - Guarded nested VM discovery when Hyper-V is unavailable.
+                        - Added Gen2 unlettered EFI fallback and dynamic letter assignment.
+    v1.0: Initial commit.
+
+.LINK
+    https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows/troubleshoot-check-disk-boot-error
+#>
+
+[CmdletBinding()]
+param()
+
+# ==============================================================================
+# 1. DEPENDENCY PATH VALIDATION & INITIALIZATION (DEP-01)
+# ==============================================================================
+# $PSScriptRoot can be empty when invoked through ScriptBlock execution.
+# Fall back to call stack script attribution to resolve the originating file directory.
+$resolvedScriptRoot = $PSScriptRoot
+if ([string]::IsNullOrEmpty($resolvedScriptRoot)) {
+    $resolvedScriptRoot = Split-Path -Parent (Get-PSCallStack | Where-Object { $_.ScriptName } | Select-Object -First 1).ScriptName
+}
+if ([string]::IsNullOrEmpty($resolvedScriptRoot)) {
+    Write-Error "Cannot determine script directory: PSScriptRoot is empty and call stack provides no path."
+    return 1
+}
+
+$initPath = Join-Path -Path $resolvedScriptRoot -ChildPath 'common\setup\init.ps1'
+$partitionsHelperPath = Join-Path -Path $resolvedScriptRoot -ChildPath 'common\helpers\Get-Disk-Partitions-v2.ps1'
+
+if (-not (Test-Path -Path $initPath -PathType Leaf)) {
+    Write-Error "Missing required dependency: $initPath"
+    return 1
+}
+
+. $initPath
+
+if (-not (Test-Path -Path $partitionsHelperPath -PathType Leaf)) {
+    Log-Error "Missing required dependency: $partitionsHelperPath"
+    return $STATUS_ERROR
+}
+
+. $partitionsHelperPath
+
+if (-not (Get-Command -Name Get-Disk-Partitions -CommandType Function -ErrorAction SilentlyContinue)) {
+    Log-Error "Dependency did not define the required Get-Disk-Partitions function: $partitionsHelperPath"
+    return $STATUS_ERROR
+}
+
+# ==============================================================================
+# 2. SYSTEM-SAFE LOG CONFIGURATION (LOG-01, DOC-01)
+# ==============================================================================
+# Attempt to resolve the standard User Desktop first (LOG-01)
+$logDir = [Environment]::GetFolderPath('Desktop')
+
+# Secure fallback to system-wide TEMP directories if Desktop is empty/SYSTEM profile (DOC-01)
+if ([string]::IsNullOrEmpty($logDir)) {
+    $logDir = $env:TEMP
+    if ([string]::IsNullOrEmpty($logDir)) {
+        $logDir = "C:\Windows\Temp"
     }
 }
 
-return $STATUS_SUCCESS
+if (-not (Test-Path -Path $logDir)) { 
+    $null = New-Item -ItemType Directory -Path $logDir -Force 
+}
+
+$timestamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$logFile = Join-Path -Path $logDir -ChildPath "chkdsk-repair_$timestamp.log"
+
+# Unified logging helper to ensure stdout and physical file are consistently fed
+function Write-ScriptLog {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Message,
+        [ValidateSet('INFO', 'WARNING', 'ERROR', 'OUTPUT')]
+        [string]$Level = 'INFO'
+    )
+    $formattedMsg = "[$(Get-Date -Format 'MM/dd/yyyy HH:mm:ss')] [$Level] $Message"
+    
+    # Direct to correct stream or custom framework logger
+    switch ($Level) {
+        'ERROR' {
+            if (Get-Command Log-Error -ErrorAction SilentlyContinue) { Log-Error $Message } 
+            else { Write-Error $formattedMsg }
+        }
+        'WARNING' {
+            if (Get-Command Log-Warning -ErrorAction SilentlyContinue) { Log-Warning $Message } 
+            else { Write-Warning $formattedMsg }
+        }
+        'OUTPUT' {
+            if (Get-Command Log-Output -ErrorAction SilentlyContinue) { Log-Output $Message } 
+            else { Write-Information $formattedMsg -InformationAction Continue }
+        }
+        Default {
+            if (Get-Command Log-Info -ErrorAction SilentlyContinue) { Log-Info $Message } 
+            else { Write-Information $formattedMsg -InformationAction Continue }
+        }
+    }
+
+    # Write to local physical file
+    $formattedMsg | Out-File -FilePath $logFile -Append -Encoding utf8
+}
+
+function Get-ChkdskAvailableTempDriveLetter {
+    $usedLetters = @(Get-Volume -ErrorAction SilentlyContinue |
+        Where-Object { $_.DriveLetter } |
+        Select-Object -ExpandProperty DriveLetter)
+    foreach ($candidateLetter in @('Z','Y','X','W','V','U','T','S','R','Q')) {
+        if ($candidateLetter -notin $usedLetters -and -not (Test-Path -LiteralPath "${candidateLetter}:\")) {
+            return $candidateLetter
+        }
+    }
+
+    return $null
+}
+
+function Test-ChkdskDataPartition {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Partition
+    )
+
+    if ($Partition.IsHidden) {
+        return $false
+    }
+
+    $gptType = ([string]$Partition.GptType).Trim().Trim('{', '}')
+    if ($gptType) {
+        return $gptType -ieq 'ebd0a0a2-b9e5-4433-87c0-68b6b72699c7'
+    }
+
+    return ([string]$Partition.Type) -notmatch 'Reserved|System'
+}
+
+function Get-ChkdskDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [int]$DiskNumber
+    )
+
+    $disk = Get-Disk -Number $DiskNumber -ErrorAction Stop
+    if ([string]$disk.PartitionStyle -eq 'MBR') {
+        $signature = [uint32]$disk.Signature
+        return [pscustomobject]@{
+            PartitionStyle = 'MBR'
+            Value = $signature.ToString('X8')
+            DiskPartValue = $signature.ToString('X8')
+        }
+    }
+    if ([string]$disk.PartitionStyle -eq 'GPT') {
+        $diskGuid = ([guid]$disk.Guid).ToString('D')
+        return [pscustomobject]@{
+            PartitionStyle = 'GPT'
+            Value = $diskGuid
+            DiskPartValue = $diskGuid
+        }
+    }
+
+    throw "Disk $DiskNumber has unsupported partition style '$($disk.PartitionStyle)'."
+}
+
+function Invoke-ChkdskDiskPart {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Commands,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Operation
+    )
+
+    $output = $Commands | diskpart 2>&1
+    foreach ($outputLine in @($output)) {
+        if ($outputLine) {
+            Write-ScriptLog "[diskpart][$Operation] $outputLine" 'INFO'
+        }
+    }
+}
+
+function Set-ChkdskTemporarySourceDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Record
+    )
+
+    if ($Record.PartitionStyle -ne 'MBR') {
+        throw 'Temporary source disk identities are permitted only for MBR disks.'
+    }
+
+    Invoke-ChkdskDiskPart -Operation 'collision-prepare' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
+        'online disk'
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $currentIdentity = Get-ChkdskDiskIdentity -DiskNumber $Record.DiskNumber
+    $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
+        throw "Disk $($Record.DiskNumber) could not be brought online with its verified temporary identity."
+    }
+}
+
+function Restore-ChkdskSourceDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Record
+    )
+
+    Invoke-ChkdskDiskPart -Operation 'collision-restore' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        'offline disk'
+        "uniqueid disk id=$($Record.OriginalDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $restoredIdentity = Get-ChkdskDiskIdentity -DiskNumber $Record.DiskNumber
+    $restoredDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if (-not $restoredDisk.IsOffline -or $restoredIdentity.Value -ine $Record.OriginalValue) {
+        throw "Disk $($Record.DiskNumber) did not return to its original offline identity."
+    }
+}
+
+function Set-ChkdskTemporaryRepairDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Record
+    )
+
+    Invoke-ChkdskDiskPart -Operation 'repair-host-collision-prepare' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.TemporaryDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $currentIdentity = Get-ChkdskDiskIdentity -DiskNumber $Record.DiskNumber
+    $currentDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if ($currentDisk.IsOffline -or $currentIdentity.Value -ine $Record.TemporaryValue) {
+        throw 'The repair VM OS disk did not retain a verified temporary GPT identity.'
+    }
+}
+
+function Restore-ChkdskRepairDiskIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Record
+    )
+
+    Invoke-ChkdskDiskPart -Operation 'repair-host-collision-restore' -Commands @(
+        "select disk $($Record.DiskNumber)"
+        "uniqueid disk id=$($Record.OriginalDiskPartValue)"
+    )
+    Update-HostStorageCache -ErrorAction SilentlyContinue
+
+    $restoredIdentity = Get-ChkdskDiskIdentity -DiskNumber $Record.DiskNumber
+    $restoredDisk = Get-Disk -Number $Record.DiskNumber -ErrorAction Stop
+    if ($restoredDisk.IsOffline -or $restoredIdentity.Value -ine $Record.OriginalValue) {
+        throw 'The repair VM OS disk did not return to its original GPT identity.'
+    }
+}
+
+# ==============================================================================
+# 3. CORE REPAIR LOGIC
+# ==============================================================================
+$script_final_status = $STATUS_ERROR
+$temporaryMounts = @()
+$collisionDiskRecords = @()
+$gptCollisionDiskNumbers = @()
+$repairDiskIdentityRecord = $null
+$processedCount = 0
+$skippedCount = 0
+$fixedCount = 0
+$failedCount = 0
+$targetDiskCount = 0
+
+try {
+    Write-ScriptLog "Script execution started. Logging active at: $logFile" "INFO"
+
+    # Stop nested guest VM if running (Only calls Hyper-V cmdlets after validation - DEP-02)
+    $hyperVModuleAvailable = @(Get-Module -ListAvailable -Name 'Hyper-V').Count -gt 0
+    if ($hyperVModuleAvailable -and (Get-Command -Name 'Get-VM' -ErrorAction SilentlyContinue)) {
+        $guestHyperVVirtualMachine = Get-VM -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+        if ($guestHyperVVirtualMachine) {
+            if ($guestHyperVVirtualMachine.State -eq 'Running') {
+                Write-ScriptLog "Stopping nested guest VM: $($guestHyperVVirtualMachine.VMName)" "INFO"
+                try {
+                    Stop-VM $guestHyperVVirtualMachine -ErrorAction Stop -Force
+                }
+                catch {
+                    Write-ScriptLog "Failed to stop nested guest VM '$($guestHyperVVirtualMachine.VMName)' via Stop-VM: $($_.Exception.Message). Continuing but with limited raw write access risks." "WARNING"
+                }
+            }
+        }
+    }
+    # No Hyper-V support means there is no nested guest to stop.
+    else {
+        Write-ScriptLog "Hyper-V module/cmdlets not available on this host -> skipping nested VM discovery" "INFO"
+    }
+
+    # Identify every disk that belongs to the repair host before touching attached disks.
+    $rescueDrive = $env:SystemDrive -replace ':', ''
+    $rescueOsPartition = Get-Partition -DriveLetter $rescueDrive -ErrorAction Stop | Select-Object -First 1
+    if ($null -eq $rescueOsPartition -or $null -eq $rescueOsPartition.DiskNumber) {
+        throw "CRITICAL SAFETY CHECK FAILED: Could not identify the repair VM OS disk from $($env:SystemDrive)."
+    }
+    $rescueDiskNumber = [int]$rescueOsPartition.DiskNumber
+    $repairDiskIdentity = Get-ChkdskDiskIdentity -DiskNumber $rescueDiskNumber
+
+    $protectedDiskNumbers = @($rescueDiskNumber)
+    $protectedDiskNumbers += @(Get-Disk -ErrorAction Stop |
+        Where-Object { $_.IsBoot -or $_.IsSystem } |
+        Select-Object -ExpandProperty Number)
+    $pageFileDriveLetters = @(Get-CimInstance -ClassName Win32_PageFileUsage -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            if ([string]$_.Name -match '^([A-Za-z]):\\') { $matches[1] }
+        } | Select-Object -Unique)
+    foreach ($pageFileDriveLetter in $pageFileDriveLetters) {
+        $pageFilePartition = Get-Partition -DriveLetter $pageFileDriveLetter -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($pageFilePartition) {
+            $protectedDiskNumbers += [int]$pageFilePartition.DiskNumber
+        }
+    }
+    $protectedDiskNumbers = @($protectedDiskNumbers | Sort-Object -Unique)
+    Write-ScriptLog "Protected repair-host disk numbers: $($protectedDiskNumbers -join ', ')." 'INFO'
+
+    $azureVirtualDiskNumbers = @(Get-CimInstance -ClassName Win32_DiskDrive -ErrorAction Stop |
+        Where-Object { $_.Model -like 'Microsoft Virtual Disk*' } |
+        ForEach-Object { [int]$_.Index })
+    $attachedDisks = @(Get-Disk -ErrorAction Stop | Where-Object {
+        $_.Number -in $azureVirtualDiskNumbers -and $_.Number -notin $protectedDiskNumbers
+    })
+    if ($attachedDisks.Count -eq 0) {
+        throw 'REPAIR-ONLY SCRIPT: No attached Microsoft virtual disk was found.'
+    }
+
+    # Match the tested SAC/LKGC collision path so source disk identities are preserved.
+    $collisionDisks = @($attachedDisks | Where-Object {
+        $_.IsOffline -and [string]$_.OfflineReason -eq 'Collision'
+    })
+    foreach ($collisionDisk in $collisionDisks) {
+        $originalIdentity = Get-ChkdskDiskIdentity -DiskNumber $collisionDisk.Number
+        if ($originalIdentity.PartitionStyle -eq 'GPT') {
+            if ($repairDiskIdentity.PartitionStyle -ne 'GPT' -or
+                $repairDiskIdentity.Value -ine $originalIdentity.Value) {
+                throw "Disk $($collisionDisk.Number) has an unverified GPT identity collision."
+            }
+
+            if (-not $repairDiskIdentityRecord) {
+                $temporaryRepairGuid = ([guid]::NewGuid()).ToString('D')
+                $repairDiskIdentityRecord = [pscustomobject]@{
+                    DiskNumber = $rescueDiskNumber
+                    PartitionStyle = 'GPT'
+                    OriginalValue = $repairDiskIdentity.Value
+                    OriginalDiskPartValue = $repairDiskIdentity.DiskPartValue
+                    TemporaryValue = $temporaryRepairGuid
+                    TemporaryDiskPartValue = $temporaryRepairGuid
+                }
+                Write-ScriptLog 'Temporarily changing only the repair VM OS disk GPT identity; the source identity remains unchanged.' 'WARNING'
+                Set-ChkdskTemporaryRepairDiskIdentity -Record $repairDiskIdentityRecord
+            }
+
+            $gptCollisionDiskNumbers += [int]$collisionDisk.Number
+            Invoke-ChkdskDiskPart -Operation 'source-gpt-online' -Commands @(
+                "select disk $($collisionDisk.Number)"
+                'online disk'
+            )
+            Update-HostStorageCache -ErrorAction SilentlyContinue
+            $releasedDisk = Get-Disk -Number $collisionDisk.Number -ErrorAction Stop
+            $releasedIdentity = Get-ChkdskDiskIdentity -DiskNumber $collisionDisk.Number
+            if ($releasedDisk.IsOffline -or $releasedIdentity.Value -ine $originalIdentity.Value) {
+                throw "Disk $($collisionDisk.Number) could not be onlined with its original GPT identity unchanged."
+            }
+            continue
+        }
+
+        do {
+            $temporaryValue = ([Convert]::ToUInt32(([guid]::NewGuid().ToString('N').Substring(0, 8)), 16)).ToString('X8')
+        } while ($temporaryValue -eq '00000000' -or $temporaryValue -ieq $originalIdentity.Value)
+
+        $identityRecord = [pscustomobject]@{
+            DiskNumber = [int]$collisionDisk.Number
+            PartitionStyle = 'MBR'
+            OriginalValue = $originalIdentity.Value
+            OriginalDiskPartValue = $originalIdentity.DiskPartValue
+            TemporaryValue = $temporaryValue
+            TemporaryDiskPartValue = $temporaryValue
+        }
+        $collisionDiskRecords += $identityRecord
+        Set-ChkdskTemporarySourceDiskIdentity -Record $identityRecord
+    }
+
+    $attachedDiskNumbers = @($attachedDisks | Select-Object -ExpandProperty Number)
+    $partitionList = @(Get-Disk-Partitions)
+    if ($partitionList.Count -eq 0) {
+        throw 'Get-Disk-Partitions returned no partitions from Azure virtual disks.'
+    }
+    $targetDiskGroups = @($partitionList |
+        Where-Object {
+            [int]$_.DiskNumber -in $attachedDiskNumbers -and
+            [int]$_.DiskNumber -notin $protectedDiskNumbers
+        } |
+        Group-Object DiskNumber)
+    if ($targetDiskGroups.Count -eq 0) {
+        throw 'The partition helper returned no partitions from an attached repair disk.'
+    }
+
+    foreach ($targetDiskGroup in $targetDiskGroups) {
+        $diskNumber = [int]$targetDiskGroup.Name
+        $diskPartitions = @(Get-Partition -DiskNumber $diskNumber -ErrorAction Stop)
+        $targetWindowsPartition = $null
+        $targetWindowsDriveLetter = $null
+
+        # Prove this is a Windows OS disk before checking any volume on it.
+        foreach ($partition in @($diskPartitions | Sort-Object Size -Descending)) {
+            if (-not (Test-ChkdskDataPartition -Partition $partition)) { continue }
+
+            $candidateLetter = [string]$partition.DriveLetter
+            if (-not $candidateLetter -or $candidateLetter -eq [char]0) {
+                $candidateLetter = Get-ChkdskAvailableTempDriveLetter
+                if (-not $candidateLetter) {
+                    throw "No temporary drive letter is available to inspect Disk $diskNumber."
+                }
+                Invoke-ChkdskDiskPart -Operation 'os-probe-assign' -Commands @(
+                    "select disk $diskNumber"
+                    "select partition $($partition.PartitionNumber)"
+                    "assign letter=$candidateLetter"
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                if (-not (Test-Path -LiteralPath "${candidateLetter}:\" -PathType Container)) {
+                    throw "Temporary mount ${candidateLetter}: failed for Disk $diskNumber Partition $($partition.PartitionNumber)."
+                }
+                $temporaryMounts += [pscustomobject]@{
+                    DiskNumber = $diskNumber
+                    PartitionNumber = [int]$partition.PartitionNumber
+                    DriveLetter = $candidateLetter
+                }
+            }
+
+            $systemHive = "${candidateLetter}:\Windows\System32\config\SYSTEM"
+            $winloadExe = "${candidateLetter}:\Windows\System32\winload.exe"
+            $winloadEfi = "${candidateLetter}:\Windows\System32\winload.efi"
+            if ((Test-Path -LiteralPath $systemHive -PathType Leaf) -and
+                ((Test-Path -LiteralPath $winloadExe -PathType Leaf) -or
+                 (Test-Path -LiteralPath $winloadEfi -PathType Leaf))) {
+                $targetWindowsPartition = $partition
+                $targetWindowsDriveLetter = $candidateLetter
+                break
+            }
+        }
+
+        if (-not $targetWindowsPartition) {
+            Write-ScriptLog "Skipping Disk $diskNumber because no Windows loader and SYSTEM hive were found." 'WARNING'
+            $skippedCount++
+            continue
+        }
+        $targetDiskCount++
+
+        $partition = $targetWindowsPartition
+        $driveLetter = $targetWindowsDriveLetter
+        Write-ScriptLog "Validated Windows target on Disk $diskNumber Partition $($partition.PartitionNumber) at ${driveLetter}:." 'INFO'
+
+        try {
+            $volume = Get-Volume -DriveLetter $driveLetter -ErrorAction Stop
+            if ([string]$volume.FileSystem -ine 'NTFS') {
+                throw "Validated Windows partition ${driveLetter}: uses '$($volume.FileSystem)', not NTFS."
+            }
+
+            $processedCount++
+            $letter = "${driveLetter}:"
+            Write-ScriptLog "Checking validated target Disk $diskNumber Partition $($partition.PartitionNumber) at $letter" 'INFO'
+
+            $fsutilOutput = & fsutil.exe dirty query $letter 2>&1
+            $fsutilExitCode = $LASTEXITCODE
+            foreach ($fsutilLine in @($fsutilOutput)) {
+                if ($fsutilLine) { Write-ScriptLog "[fsutil] $fsutilLine" 'OUTPUT' }
+            }
+            if ($fsutilExitCode -ne 0) {
+                throw "fsutil dirty query failed for $letter with exit code $fsutilExitCode."
+            }
+
+            # Win32_Volume exposes a locale-independent Boolean dirty-bit value.
+            $volumeState = Get-CimInstance -ClassName Win32_Volume -Filter "DriveLetter = '$letter'" -ErrorAction Stop |
+                Select-Object -First 1
+            if ($null -eq $volumeState -or $null -eq $volumeState.DirtyBitSet) {
+                throw "Could not obtain a reliable dirty-bit state for $letter."
+            }
+
+            if (-not [bool]$volumeState.DirtyBitSet) {
+                Write-ScriptLog "$letter dirty bit is not set; CHKDSK /f is not required." 'INFO'
+                continue
+            }
+
+            Write-ScriptLog "$letter dirty bit is set; executing CHKDSK /f." 'WARNING'
+            $chkdskResults = & chkdsk.exe $letter /f 2>&1
+            $chkdskExitCode = $LASTEXITCODE
+            foreach ($resultLine in @($chkdskResults)) {
+                if ($resultLine -and ([string]$resultLine).Trim()) {
+                    ([string]$resultLine) | Out-File -FilePath $logFile -Append -Encoding utf8
+                }
+            }
+
+            $summaryLines = @($chkdskResults | Where-Object {
+                ([string]$_).Trim() -match '(Windows has scanned|Windows made corrections|Windows has made corrections|found no problems|corrected errors|failed to transfer|could not fix|total disk space|KB in bad sectors|No further action)'
+            })
+            foreach ($summaryLine in $summaryLines) {
+                Write-ScriptLog "[chkdsk] $(([string]$summaryLine).Trim())" 'OUTPUT'
+            }
+            Write-ScriptLog "[chkdsk] Drive=$letter ExitCode=$chkdskExitCode SummaryLines=$($summaryLines.Count)" 'OUTPUT'
+
+            if ($chkdskExitCode -notin @(0, 1, 2)) {
+                Write-ScriptLog "CHKDSK failed on $letter with exit code $chkdskExitCode." 'ERROR'
+                $failedCount++
+                continue
+            }
+
+            $repairedVolumeState = Get-CimInstance -ClassName Win32_Volume -Filter "DriveLetter = '$letter'" -ErrorAction Stop |
+                Select-Object -First 1
+            if ($null -eq $repairedVolumeState -or $null -eq $repairedVolumeState.DirtyBitSet -or
+                [bool]$repairedVolumeState.DirtyBitSet) {
+                Write-ScriptLog "CHKDSK returned exit code $chkdskExitCode, but $letter still reports a dirty or unknown state." 'ERROR'
+                $failedCount++
+                continue
+            }
+
+            $fixedCount++
+            Write-ScriptLog "CHKDSK completed on $letter with exit code $chkdskExitCode and a verified clear dirty bit." 'INFO'
+        }
+        catch {
+            $failedCount++
+            Write-ScriptLog "Failed processing validated Windows partition on Disk ${diskNumber}: $($_.Exception.Message)" 'ERROR'
+        }
+    }
+
+    if ($targetDiskCount -eq 0) {
+        throw 'No attached Windows OS disk passed loader and SYSTEM hive validation.'
+    }
+    if ($failedCount -gt 0) {
+        throw "CHKDSK failed on $failedCount partition(s)."
+    }
+
+    Write-ScriptLog "SCRIPT FINISHED PROPERLY, WINDOWS_PARTITIONS=$processedCount, REPAIRED=$fixedCount, FAILED=$failedCount" 'OUTPUT'
+    $script_final_status = $STATUS_SUCCESS
+}
+catch {
+    Write-ScriptLog "An unhandled execution crash occurred: $($_.Exception.Message)" "ERROR"
+    $script_final_status = $STATUS_ERROR
+}
+finally {
+    foreach ($mount in @($temporaryMounts | Sort-Object DiskNumber, PartitionNumber -Unique)) {
+        try {
+            Invoke-ChkdskDiskPart -Operation 'mount-cleanup' -Commands @(
+                "select disk $($mount.DiskNumber)"
+                "select partition $($mount.PartitionNumber)"
+                "remove letter=$($mount.DriveLetter) noerr"
+            )
+            Update-HostStorageCache -ErrorAction SilentlyContinue
+            $cleanedPartition = Get-Partition -DiskNumber $mount.DiskNumber -PartitionNumber $mount.PartitionNumber -ErrorAction Stop
+            if ([string]$cleanedPartition.DriveLetter -ieq [string]$mount.DriveLetter) {
+                throw 'Temporary drive letter removal could not be verified.'
+            }
+        }
+        catch {
+            Write-ScriptLog "Failed to remove temporary letter $($mount.DriveLetter): $($_.Exception.Message)" 'ERROR'
+            $script_final_status = $STATUS_ERROR
+        }
+    }
+
+    $identityRestorationFailed = $false
+    if ($repairDiskIdentityRecord) {
+        foreach ($diskNumber in @($gptCollisionDiskNumbers | Sort-Object -Unique)) {
+            try {
+                Invoke-ChkdskDiskPart -Operation 'source-before-repair-host-restore' -Commands @(
+                    "select disk $diskNumber"
+                    'offline disk'
+                )
+                Update-HostStorageCache -ErrorAction SilentlyContinue
+                $sourceDisk = Get-Disk -Number $diskNumber -ErrorAction Stop
+                $sourceIdentity = Get-ChkdskDiskIdentity -DiskNumber $diskNumber
+                if (-not $sourceDisk.IsOffline -or
+                    $sourceIdentity.Value -ine $repairDiskIdentityRecord.OriginalValue) {
+                    throw "Source Disk $diskNumber was not offline with its unchanged original GPT identity."
+                }
+            }
+            catch {
+                $identityRestorationFailed = $true
+                Write-ScriptLog "CRITICAL: Could not safely offline source Disk ${diskNumber}: $($_.Exception.Message)" 'ERROR'
+            }
+        }
+
+        if (-not $identityRestorationFailed) {
+            try {
+                Restore-ChkdskRepairDiskIdentity -Record $repairDiskIdentityRecord
+                Write-ScriptLog 'Repair VM OS disk GPT identity restored and verified.' 'INFO'
+            }
+            catch {
+                $identityRestorationFailed = $true
+                Write-ScriptLog "CRITICAL: Failed to restore the repair VM OS disk identity: $($_.Exception.Message)" 'ERROR'
+            }
+        }
+    }
+
+    foreach ($identityRecord in @($collisionDiskRecords | Sort-Object DiskNumber -Descending)) {
+        try {
+            Restore-ChkdskSourceDiskIdentity -Record $identityRecord
+            Write-ScriptLog "Disk $($identityRecord.DiskNumber) original MBR identity restored and verified." 'INFO'
+        }
+        catch {
+            $identityRestorationFailed = $true
+            Write-ScriptLog "CRITICAL: Failed to restore Disk $($identityRecord.DiskNumber) identity: $($_.Exception.Message)" 'ERROR'
+        }
+    }
+    if ($identityRestorationFailed) {
+        $script_final_status = $STATUS_ERROR
+    }
+
+    Write-ScriptLog "Partition Summary: Processed=$processedCount | Skipped=$skippedCount | Fixed=$fixedCount | Failed=$failedCount" 'INFO'
+    Write-ScriptLog "Final script status: $script_final_status" "INFO"
+    Write-ScriptLog "Script finalized. Destination log package details: $logFile" "INFO"
+}
+
+# Ensure the status gets exited safely (ERR-01)
+return $script_final_status


### PR DESCRIPTION
 v1.3: [August 2026] - Aligned physical disk discovery and collision handling with
                          win-sac-on, win-LKGC, and GA_offlinefixer.
                        - Excludes repair-host critical disks and validates Windows targets.
                        - Supports safe temporary mounts and preserves source disk identities.
                        - Verifies native exit codes and the cleared NTFS dirty bit.
                        - Restricts CHKDSK to the validated Windows partition.
                        - Emits CHKDSK evidence while keeping DiskPart diagnostics out of
                          result output.
    v1.2: [July 2026]   - Refactored logging to support desktop-first paths with SYSTEM fallback.
                        - Aligned dependency path validation and added explicit loop summaries.
    v1.1: [May 2026]    - Guarded nested VM discovery when Hyper-V is unavailable.
                        - Added Gen2 unlettered EFI fallback and dynamic letter assignment.
    v1.0: Initial commit.