### PR TITLE
vm-repair scripts: add read-only win-detect-nvme-readiness detection script

### DIFF
--- a/map.json
+++ b/map.json
@@ -128,5 +128,10 @@
 		"id": "win-crowdstrike-fix-bootloop-cvm",
 		"path": "src/windows/win-crowdstrike-fix-bootloop-cvm.ps1",
 		"description": "Workaround for cvm machines stuck in boot loop due to corrupt crowdstrike falcon sensor 2024-07-19 by removing corrupt crowdstrike files"
+	},
+	{
+		"id": "win-detect-nvme-readiness",
+		"path": "src/windows/win-detect-nvme-readiness.ps1",
+		"description": "Read-only check of whether a Windows OS disk can boot from an NVMe disk controller. Reports the stornvme boot-start value, driver presence and CriticalDeviceDatabase entries, and writes an evidence bundle. Makes no changes. NOTE: use option --run-on-repair."
 	}
 ]

--- a/src/windows/common/helpers/Get-Disk-Partitions-v3.ps1
+++ b/src/windows/common/helpers/Get-Disk-Partitions-v3.ps1
@@ -1,0 +1,150 @@
+#########################################################################################################
+#
+# .SYNOPSIS
+#   NVMe-aware disk discovery for attached OS disks. v3.0.0
+#
+# .DESCRIPTION
+#   Returns the partitions of every OS/data disk attached to this repair VM, bringing each disk online
+#   and read-write first. Selects disks by BusType, so it works whether the repair VM was created with
+#   the SCSI or the NVMe disk controller.
+#
+#   Get-Disk-Partitions.ps1 (v1) and Get-Disk-Partitions-v2.ps1 select with:
+#       get-wmiobject Win32_diskdrive | Where-Object {$_.model -like 'Microsoft Virtual Disk'}
+#   That model string is only reported for disks attached through the SCSI controller. When the repair VM
+#   runs on a size that uses the NVMe disk controller, the copied OS disk is enumerated as an NVMe
+#   namespace, the filter matches nothing, $partitionlist comes back empty, and the calling script
+#   completes without repairing anything while still returning [STATUS]::SUCCESS.
+#
+#   This helper also excludes the Azure resource (temporary) disk, which v1/v2 do not.
+#
+# .NOTES
+#   Additive. v1 and v2 are intentionally left untouched: ten production scripts depend on them,
+#   including the CrowdStrike bootloop scripts referenced by support runbooks. Callers are migrated to v3
+#   one at a time, each with its own verification on both a SCSI and an NVMe repair VM.
+#
+#   Requires init.ps1 to have been dot-sourced first (for the Log-* functions), which is the standard
+#   pattern for every script in this repo. A no-op fallback is defined if it was not, so the helper can
+#   be dot-sourced standalone for testing.
+#
+# .EXAMPLE
+#   . .\src\windows\common\setup\init.ps1
+#   . .\src\windows\common\helpers\Get-Disk-Partitions-v3.ps1
+#
+#   $partitionlist = Get-Disk-Partitions-v3
+#   $fixedDrives   = ($partitionlist | Group-Object DiskNumber).Group | Select-Object -ExpandProperty DriveLetter
+#
+#   # Or, when only Windows installations are of interest:
+#   $osDrives = Get-Windows-OsDrives-v3
+#
+#########################################################################################################
+
+# Volume label Azure gives the ephemeral resource disk; never a repair target.
+$script:AzureTempDiskLabel = 'Temporary Storage'
+
+# Allows the helper to be dot-sourced on its own (e.g. Pester) without init.ps1.
+# Defined via the function: drive so the repo's Log-* naming convention does not trip PSScriptAnalyzer here.
+if (-not (Get-Command -Name 'Log-Info' -ErrorAction SilentlyContinue)) {
+    Set-Item -Path 'function:global:Log-Info' -Value { Param([PSObject[]]$message) Write-Verbose "$message" }
+}
+if (-not (Get-Command -Name 'Log-Warning' -ErrorAction SilentlyContinue)) {
+    Set-Item -Path 'function:global:Log-Warning' -Value { Param([PSObject[]]$message) Write-Warning "$message" }
+}
+
+function Get-Disk-Partitions-v3 {
+    <#
+      Returns Get-Partition objects for every non-boot, non-system, non-resource disk attached to this VM.
+      Return shape matches Get-Disk-Partitions, so callers can be migrated without changing how they
+      consume the result.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Any', 'SCSI', 'NVMe')]
+        [string]$BusTypeFilter = 'Any'
+    )
+
+    $busTypes = switch ($BusTypeFilter) {
+        'SCSI' { @('SCSI', 'SAS', 'RAID') }
+        'NVMe' { @('NVMe') }
+        default { @('SCSI', 'SAS', 'RAID', 'NVMe') }
+    }
+
+    $partitionList = @()
+
+    $disks = Get-Disk -ErrorAction Stop | Where-Object {
+        $busTypes -contains $_.BusType -and -not $_.IsBoot -and -not $_.IsSystem
+    }
+
+    if (-not $disks) {
+        Log-Warning "Get-Disk-Partitions-v3: no attached data disks found for BusType filter '$BusTypeFilter'. Run 'Get-Disk | Select Number,BusType,IsBoot,IsSystem' to confirm what this VM can see."
+        return $partitionList
+    }
+
+    ForEach ($disk in $disks) {
+        Log-Info "Get-Disk-Partitions-v3: evaluating disk $($disk.Number) (BusType=$($disk.BusType), Model='$($disk.Model)', Offline=$($disk.IsOffline))"
+
+        if ($disk.IsOffline) {
+            $disk | Set-Disk -IsOffline $false -ErrorAction SilentlyContinue
+        }
+        if ($disk.IsReadOnly) {
+            $disk | Set-Disk -IsReadOnly $false -ErrorAction SilentlyContinue
+        }
+
+        $partitions = Get-Partition -DiskNumber $disk.Number -ErrorAction SilentlyContinue
+        if (-not $partitions) {
+            Log-Info "Get-Disk-Partitions-v3: disk $($disk.Number) exposes no partitions, skipping."
+            continue
+        }
+
+        # The Azure resource disk is attached like any other data disk; excluding it stops scripts
+        # treating ephemeral scratch space as a repair target.
+        $isResourceDisk = $false
+        ForEach ($partition in $partitions) {
+            $volume = Get-Volume -Partition $partition -ErrorAction SilentlyContinue
+            if ($volume -and $volume.FileSystemLabel -eq $script:AzureTempDiskLabel) {
+                $isResourceDisk = $true
+            }
+        }
+        if ($isResourceDisk) {
+            Log-Info "Get-Disk-Partitions-v3: disk $($disk.Number) is the Azure resource disk, skipping."
+            continue
+        }
+
+        $partitionList += $partitions
+    }
+
+    return $partitionList
+}
+
+function Get-Windows-OsDrives-v3 {
+    <#
+      Narrows Get-Disk-Partitions-v3 to partitions that contain a Windows installation, i.e. those with
+      \Windows\System32\config\SYSTEM. Returns drive letters (e.g. 'F').
+
+      More than one hit is legitimate (multi-boot, restored images). Callers that modify the guest must
+      refuse to guess rather than picking the first result.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Any', 'SCSI', 'NVMe')]
+        [string]$BusTypeFilter = 'Any'
+    )
+
+    $osDrives = @()
+
+    ForEach ($partition in (Get-Disk-Partitions-v3 -BusTypeFilter $BusTypeFilter)) {
+        if ([string]::IsNullOrWhiteSpace($partition.DriveLetter)) { continue }
+        if ($partition.DriveLetter -eq "`0") { continue }
+
+        $driveLetter = $partition.DriveLetter.ToString()
+        $systemHive = Join-Path "$($driveLetter):" 'Windows\System32\config\SYSTEM'
+
+        if (Test-Path -LiteralPath $systemHive) {
+            Log-Info "Get-Windows-OsDrives-v3: found Windows installation on ${driveLetter}:"
+            $osDrives += $driveLetter
+        }
+    }
+
+    return $osDrives
+}

--- a/src/windows/common/helpers/Get-Disk-Partitions-v3.ps1
+++ b/src/windows/common/helpers/Get-Disk-Partitions-v3.ps1
@@ -26,6 +26,11 @@
 #   pattern for every script in this repo. A no-op fallback is defined if it was not, so the helper can
 #   be dot-sourced standalone for testing.
 #
+#   Logger.ps1's Log-* functions write to the success stream. Both functions here return data, so a
+#   direct Log-* call would make every log line part of the returned collection - a caller iterating
+#   Get-Windows-OsDrives-v3 would treat '[Info ...]found Windows installation on F:' as a drive letter.
+#   All logging therefore goes through Write-V3Log, which sends the formatted line to the host instead.
+#
 # .EXAMPLE
 #   . .\src\windows\common\setup\init.ps1
 #   . .\src\windows\common\helpers\Get-Disk-Partitions-v3.ps1
@@ -51,6 +56,23 @@ if (-not (Get-Command -Name 'Log-Info' -ErrorAction SilentlyContinue)) {
 }
 if (-not (Get-Command -Name 'Log-Warning' -ErrorAction SilentlyContinue)) {
     Set-Item -Path 'function:global:Log-Warning' -Value { Param([PSObject[]]$message) Write-Warning "$message" }
+}
+
+function Write-V3Log {
+    <#
+      Log-* write to the success stream, so calling them directly from a function that returns data
+      would append the log lines to that return value. Emitting to the host keeps the pipeline clean
+      while preserving Logger.ps1's exact format. The standalone shims above return nothing, so under
+      Pester the line goes to the verbose or warning stream instead and nothing is printed here.
+    #>
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true)][ValidateSet('Info', 'Warning')][string]$Level,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    $formatted = if ($Level -eq 'Warning') { Log-Warning $Message } else { Log-Info $Message }
+    if ($formatted) { Write-Host ($formatted -join [Environment]::NewLine) }
 }
 
 function Get-Disk-Partitions-v3 {
@@ -81,12 +103,12 @@ function Get-Disk-Partitions-v3 {
     }
 
     if (-not $disks) {
-        Log-Warning "Get-Disk-Partitions-v3: no attached data disks found for BusType filter '$BusTypeFilter'. Run 'Get-Disk | Select Number,BusType,IsBoot,IsSystem' to confirm what this VM can see."
+        Write-V3Log -Level Warning -Message "Get-Disk-Partitions-v3: no attached data disks found for BusType filter '$BusTypeFilter'. Run 'Get-Disk | Select Number,BusType,IsBoot,IsSystem' to confirm what this VM can see."
         return $partitionList
     }
 
     ForEach ($disk in $disks) {
-        Log-Info "Get-Disk-Partitions-v3: evaluating disk $($disk.Number) (BusType=$($disk.BusType), Model='$($disk.Model)', Offline=$($disk.IsOffline))"
+        Write-V3Log -Level Info -Message "Get-Disk-Partitions-v3: evaluating disk $($disk.Number) (BusType=$($disk.BusType), Model='$($disk.Model)', Offline=$($disk.IsOffline))"
 
         if ($disk.IsOffline) {
             $disk | Set-Disk -IsOffline $false -ErrorAction SilentlyContinue
@@ -99,17 +121,17 @@ function Get-Disk-Partitions-v3 {
         # "exposes no partitions", which is the silent-success failure this helper exists to remove.
         $diskState = Get-Disk -Number $disk.Number -ErrorAction SilentlyContinue
         if (-not $diskState) {
-            Log-Warning "Get-Disk-Partitions-v3: disk $($disk.Number) could not be re-read after being brought online, skipping."
+            Write-V3Log -Level Warning -Message "Get-Disk-Partitions-v3: disk $($disk.Number) could not be re-read after being brought online, skipping."
             continue
         }
         if ($diskState.IsOffline -or $diskState.IsReadOnly) {
-            Log-Warning "Get-Disk-Partitions-v3: disk $($disk.Number) is still Offline=$($diskState.IsOffline) ReadOnly=$($diskState.IsReadOnly) after Set-Disk, so it cannot be repaired. Skipping."
+            Write-V3Log -Level Warning -Message "Get-Disk-Partitions-v3: disk $($disk.Number) is still Offline=$($diskState.IsOffline) ReadOnly=$($diskState.IsReadOnly) after Set-Disk, so it cannot be repaired. Skipping."
             continue
         }
 
         $partitions = Get-Partition -DiskNumber $disk.Number -ErrorAction SilentlyContinue
         if (-not $partitions) {
-            Log-Info "Get-Disk-Partitions-v3: disk $($disk.Number) exposes no partitions, skipping."
+            Write-V3Log -Level Info -Message "Get-Disk-Partitions-v3: disk $($disk.Number) exposes no partitions, skipping."
             continue
         }
 
@@ -123,11 +145,11 @@ function Get-Disk-Partitions-v3 {
 
         if ($labelledTemp.Count -gt 0) {
             if ($diskState.BusType -eq 'SCSI' -and $partitions.Count -eq 1) {
-                Log-Info "Get-Disk-Partitions-v3: disk $($disk.Number) is the Azure resource disk, skipping."
+                Write-V3Log -Level Info -Message "Get-Disk-Partitions-v3: disk $($disk.Number) is the Azure resource disk, skipping."
                 continue
             }
 
-            Log-Warning "Get-Disk-Partitions-v3: disk $($disk.Number) has a volume labelled '$($global:AzureTempDiskLabel)' but is BusType=$($diskState.BusType) with $($partitions.Count) partition(s), so it is not the resource disk and is being treated as a repair target."
+            Write-V3Log -Level Warning -Message "Get-Disk-Partitions-v3: disk $($disk.Number) has a volume labelled '$($global:AzureTempDiskLabel)' but is BusType=$($diskState.BusType) with $($partitions.Count) partition(s), so it is not the resource disk and is being treated as a repair target."
         }
 
         $partitionList += $partitions
@@ -164,7 +186,7 @@ function Get-Windows-OsDrives-v3 {
         $systemHive = "${driveLetter}:\Windows\System32\config\SYSTEM"
 
         if (Test-Path -LiteralPath $systemHive) {
-            Log-Info "Get-Windows-OsDrives-v3: found Windows installation on ${driveLetter}:"
+            Write-V3Log -Level Info -Message "Get-Windows-OsDrives-v3: found Windows installation on ${driveLetter}:"
             $osDrives += $driveLetter
         }
     }

--- a/src/windows/common/helpers/Get-Disk-Partitions-v3.ps1
+++ b/src/windows/common/helpers/Get-Disk-Partitions-v3.ps1
@@ -85,7 +85,11 @@ function Get-Disk-Partitions-v3 {
     Param(
         [Parameter(Mandatory = $false)]
         [ValidateSet('Any', 'SCSI', 'NVMe')]
-        [string]$BusTypeFilter = 'Any'
+        [string]$BusTypeFilter = 'Any',
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, 300)]
+        [int]$DriveLetterTimeoutSeconds = 60
     )
 
     $busTypes = switch ($BusTypeFilter) {
@@ -110,6 +114,8 @@ function Get-Disk-Partitions-v3 {
     ForEach ($disk in $disks) {
         Write-V3Log -Level Info -Message "Get-Disk-Partitions-v3: evaluating disk $($disk.Number) (BusType=$($disk.BusType), Model='$($disk.Model)', Offline=$($disk.IsOffline))"
 
+        $wasOffline = [bool]$disk.IsOffline
+
         if ($disk.IsOffline) {
             $disk | Set-Disk -IsOffline $false -ErrorAction SilentlyContinue
         }
@@ -130,6 +136,22 @@ function Get-Disk-Partitions-v3 {
         }
 
         $partitions = Get-Partition -DiskNumber $disk.Number -ErrorAction SilentlyContinue
+
+        # Windows assigns drive letters asynchronously after a disk is brought online, so a disk that
+        # was offline on entry returns partitions with no letters for the first few seconds. Callers key
+        # off DriveLetter, so returning too early looks identical to an empty disk - the silent success
+        # this helper exists to remove. Only wait when this call did the onlining.
+        if ($wasOffline) {
+            $deadline = (Get-Date).AddSeconds($DriveLetterTimeoutSeconds)
+            while ((Get-Date) -lt $deadline -and -not (@($partitions | Where-Object { $_.DriveLetter }).Count)) {
+                Start-Sleep -Seconds 2
+                $partitions = Get-Partition -DiskNumber $disk.Number -ErrorAction SilentlyContinue
+            }
+            if (-not (@($partitions | Where-Object { $_.DriveLetter }).Count)) {
+                Write-V3Log -Level Warning -Message "Get-Disk-Partitions-v3: disk $($disk.Number) came online but no partition was assigned a drive letter within $DriveLetterTimeoutSeconds seconds. Partitions are still returned, but callers that need a path will find none."
+            }
+        }
+
         if (-not $partitions) {
             Write-V3Log -Level Info -Message "Get-Disk-Partitions-v3: disk $($disk.Number) exposes no partitions, skipping."
             continue
@@ -170,12 +192,16 @@ function Get-Windows-OsDrives-v3 {
     Param(
         [Parameter(Mandatory = $false)]
         [ValidateSet('Any', 'SCSI', 'NVMe')]
-        [string]$BusTypeFilter = 'Any'
+        [string]$BusTypeFilter = 'Any',
+
+        [Parameter(Mandatory = $false)]
+        [ValidateRange(0, 300)]
+        [int]$DriveLetterTimeoutSeconds = 60
     )
 
     $osDrives = @()
 
-    ForEach ($partition in (Get-Disk-Partitions-v3 -BusTypeFilter $BusTypeFilter)) {
+    ForEach ($partition in (Get-Disk-Partitions-v3 -BusTypeFilter $BusTypeFilter -DriveLetterTimeoutSeconds $DriveLetterTimeoutSeconds)) {
         if ([string]::IsNullOrWhiteSpace($partition.DriveLetter)) { continue }
         if ($partition.DriveLetter -eq "`0") { continue }
 

--- a/src/windows/common/helpers/Get-Disk-Partitions-v3.ps1
+++ b/src/windows/common/helpers/Get-Disk-Partitions-v3.ps1
@@ -39,9 +39,12 @@
 #########################################################################################################
 
 # Volume label Azure gives the ephemeral resource disk; never a repair target.
-$script:AzureTempDiskLabel = 'Temporary Storage'
+# Global rather than script-scoped: $script: binds to the scope of whatever script is running when the
+# function is called, not to this file, so a dot-source into a child scope would leave it unresolved.
+$global:AzureTempDiskLabel = 'Temporary Storage'
 
-# Allows the helper to be dot-sourced on its own (e.g. Pester) without init.ps1.
+# Allows the helper to be dot-sourced on its own (e.g. Pester) without init.ps1. The shims write to the
+# verbose and warning streams, so standalone runs need -Verbose to see Log-Info output.
 # Defined via the function: drive so the repo's Log-* naming convention does not trip PSScriptAnalyzer here.
 if (-not (Get-Command -Name 'Log-Info' -ErrorAction SilentlyContinue)) {
     Set-Item -Path 'function:global:Log-Info' -Value { Param([PSObject[]]$message) Write-Verbose "$message" }
@@ -71,6 +74,8 @@ function Get-Disk-Partitions-v3 {
 
     $partitionList = @()
 
+    # IsBoot and IsSystem both report $false while a disk is offline, so an offline attached OS disk is
+    # correctly kept here while the repair VM's own live disk is excluded.
     $disks = Get-Disk -ErrorAction Stop | Where-Object {
         $busTypes -contains $_.BusType -and -not $_.IsBoot -and -not $_.IsSystem
     }
@@ -90,6 +95,18 @@ function Get-Disk-Partitions-v3 {
             $disk | Set-Disk -IsReadOnly $false -ErrorAction SilentlyContinue
         }
 
+        # Read the state back. Without this a disk that stayed offline is skipped further down as
+        # "exposes no partitions", which is the silent-success failure this helper exists to remove.
+        $diskState = Get-Disk -Number $disk.Number -ErrorAction SilentlyContinue
+        if (-not $diskState) {
+            Log-Warning "Get-Disk-Partitions-v3: disk $($disk.Number) could not be re-read after being brought online, skipping."
+            continue
+        }
+        if ($diskState.IsOffline -or $diskState.IsReadOnly) {
+            Log-Warning "Get-Disk-Partitions-v3: disk $($disk.Number) is still Offline=$($diskState.IsOffline) ReadOnly=$($diskState.IsReadOnly) after Set-Disk, so it cannot be repaired. Skipping."
+            continue
+        }
+
         $partitions = Get-Partition -DiskNumber $disk.Number -ErrorAction SilentlyContinue
         if (-not $partitions) {
             Log-Info "Get-Disk-Partitions-v3: disk $($disk.Number) exposes no partitions, skipping."
@@ -97,17 +114,20 @@ function Get-Disk-Partitions-v3 {
         }
 
         # The Azure resource disk is attached like any other data disk; excluding it stops scripts
-        # treating ephemeral scratch space as a repair target.
-        $isResourceDisk = $false
-        ForEach ($partition in $partitions) {
-            $volume = Get-Volume -Partition $partition -ErrorAction SilentlyContinue
-            if ($volume -and $volume.FileSystemLabel -eq $script:AzureTempDiskLabel) {
-                $isResourceDisk = $true
+        # treating ephemeral scratch space as a repair target. The label alone is not enough: a broken
+        # OS disk may carry a data partition with the same label, so the disk must also look like the
+        # resource disk - always SCSI-attached, and a single volume.
+        $labelledTemp = @($partitions | ForEach-Object {
+                Get-Volume -Partition $_ -ErrorAction SilentlyContinue
+            } | Where-Object { $_ -and $_.FileSystemLabel -eq $global:AzureTempDiskLabel })
+
+        if ($labelledTemp.Count -gt 0) {
+            if ($diskState.BusType -eq 'SCSI' -and $partitions.Count -eq 1) {
+                Log-Info "Get-Disk-Partitions-v3: disk $($disk.Number) is the Azure resource disk, skipping."
+                continue
             }
-        }
-        if ($isResourceDisk) {
-            Log-Info "Get-Disk-Partitions-v3: disk $($disk.Number) is the Azure resource disk, skipping."
-            continue
+
+            Log-Warning "Get-Disk-Partitions-v3: disk $($disk.Number) has a volume labelled '$($global:AzureTempDiskLabel)' but is BusType=$($diskState.BusType) with $($partitions.Count) partition(s), so it is not the resource disk and is being treated as a repair target."
         }
 
         $partitionList += $partitions
@@ -138,7 +158,10 @@ function Get-Windows-OsDrives-v3 {
         if ($partition.DriveLetter -eq "`0") { continue }
 
         $driveLetter = $partition.DriveLetter.ToString()
-        $systemHive = Join-Path "$($driveLetter):" 'Windows\System32\config\SYSTEM'
+
+        # Composed as a string rather than with Join-Path: a temporary letter can be unmounted between
+        # enumeration and use, and Join-Path throws DriveNotFoundException when the drive is gone.
+        $systemHive = "${driveLetter}:\Windows\System32\config\SYSTEM"
 
         if (Test-Path -LiteralPath $systemHive) {
             Log-Info "Get-Windows-OsDrives-v3: found Windows installation on ${driveLetter}:"

--- a/src/windows/common/helpers/README.md
+++ b/src/windows/common/helpers/README.md
@@ -1,3 +1,13 @@
 # Windows Shared Helper Scripts
 
 Each helper script and description should be listed here.
+
+| Helper | Description |
+|---|---|
+| `Logger.ps1` | `Log-Output` / `Log-Info` / `Log-Warning` / `Log-Error` / `Log-Debug`. Imported automatically by `common/setup/init.ps1`. |
+| `Get-Disk-Partitions.ps1` | Returns partitions of attached disks whose `Win32_diskdrive` model is `Microsoft Virtual Disk`, bringing them online with `diskpart`. **SCSI-attached disks only.** |
+| `Get-Disk-Partitions-v2.ps1` | As v1, with `$partitionlist` initialised to an array so a single result is not unrolled. **SCSI-attached disks only.** |
+| `Get-Disk-Partitions-v3.ps1` | `Get-Disk-Partitions-v3` selects attached disks by **BusType** (SCSI/SAS/RAID/NVMe) instead of the SCSI-only model string, so it also works when the repair VM uses the NVMe disk controller. Excludes the Azure resource disk. `Get-Windows-OsDrives-v3` narrows the result to drive letters that contain a Windows installation. |
+
+**Which one to use:** new scripts should use **v3**. v1 and v2 are retained because existing scripts depend
+on them; they return nothing on a repair VM created with the NVMe disk controller.

--- a/src/windows/win-detect-nvme-readiness.ps1
+++ b/src/windows/win-detect-nvme-readiness.ps1
@@ -1,0 +1,237 @@
+#########################################################################################################
+#
+# .SYNOPSIS
+#   Read-only detection for SCSI-to-NVMe disk controller migration boot failures. v1.0.0
+#
+# .DESCRIPTION
+#   Runs on the repair VM against the source VM's OS disk attached as a data disk. Reports whether the
+#   guest is ready to boot from an NVMe disk controller, and collects an evidence bundle. Makes NO
+#   changes to the attached OS disk: the SYSTEM hive is mounted, read, and unmounted.
+#
+#   Emits one machine-readable JSON line prefixed with [NVME-EVIDENCE-JSON] so a caller (diagnostics,
+#   SelfHelp, or a test harness) can extract structured evidence from the free-text run-command output.
+#
+# .RESOLVES
+#   Nothing. Detection only. Use the results to decide whether an NVMe boot-driver repair is warranted.
+#
+# .NOTES
+#   Requires the --run-on-repair option: the source VM's OS disk must be attached to a repair VM as a
+#   data disk. Uses Get-Disk-Partitions-v3, which locates attached disks by BusType and therefore works
+#   on both SCSI and NVMe repair VMs.
+#
+# .PARAMETER OsDriveLetter
+#   [Optional] Restrict inspection to one drive letter (e.g. F). Default: inspect every Windows
+#   installation found on attached data disks.
+#
+# .EXAMPLE
+#   az vm repair run -g sourceRG -n problemVM --run-id win-detect-nvme-readiness --run-on-repair --verbose
+#
+# .EXAMPLE
+#   az vm repair run -g sourceRG -n problemVM --run-id win-detect-nvme-readiness --run-on-repair --parameters OsDriveLetter=F
+#
+#########################################################################################################
+
+Param(
+    [Parameter(Mandatory = $false)][string]$OsDriveLetter = ''
+)
+
+# Initialize script
+. .\src\windows\common\setup\init.ps1
+. .\src\windows\common\helpers\Get-Disk-Partitions-v3.ps1
+
+$scriptStartTime = Get-Date -f yyyyMMddHHmmss
+$scriptName = 'win-detect-nvme-readiness'
+$logFile = "$env:PUBLIC\Desktop\$scriptName.log"
+$evidenceRoot = "$env:PUBLIC\Desktop\nvme-evidence-$scriptStartTime"
+$hiveMountName = 'NVMEDETECT'
+
+# NVMe controllers present themselves as PCI class 01 / subclass 08 (NVM) / prog-if 02 (NVMe I/O).
+$CddbKeys = @('pci#cc_010802', 'pci#cc_0108')
+
+Log-Output "START: Running script $scriptName (read-only)" | Tee-Object -FilePath $logFile -Append
+
+function Dismount-RegistryHive {
+    # A reg unload issued straight after a registry read fails with "Access is denied": the PowerShell
+    # provider still holds keys open. The hive then stays mounted and locks the attached disk for every
+    # later run, which is worse than the fault being diagnosed. Collect, retry, and report on failure.
+    Param(
+        [string]$MountName,
+        [int]$MaxAttempts = 5
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        if (-not (Test-Path -LiteralPath "HKLM:\$MountName")) { return }
+        [gc]::Collect()
+        [gc]::WaitForPendingFinalizers()
+        Start-Sleep -Milliseconds 500
+        & reg.exe unload "HKLM\$MountName" *>$null
+    }
+
+    if (Test-Path -LiteralPath "HKLM:\$MountName") {
+        Log-Error "Failed to unload registry hive HKLM\$MountName after $MaxAttempts attempts. The attached disk may stay locked for subsequent runs. Unload it manually with: reg unload HKLM\$MountName" | Tee-Object -FilePath $logFile -Append
+    }
+}
+
+$findings = @()
+$overallStatus = $STATUS_SUCCESS
+
+try {
+    New-Item -Path $evidenceRoot -ItemType Directory -Force | Out-Null
+    Log-Output "Evidence directory: $evidenceRoot" | Tee-Object -FilePath $logFile -Append
+
+    # Bus type of the attached disks is itself evidence: it tells us how this repair VM was created.
+    $attachedDisks = Get-Disk -ErrorAction SilentlyContinue | Where-Object { -not $_.IsBoot -and -not $_.IsSystem }
+    $attachedBusTypes = @($attachedDisks | Select-Object -ExpandProperty BusType -Unique | ForEach-Object { $_.ToString() })
+    Log-Output "Attached data disk bus types: $($attachedBusTypes -join ', ')" | Tee-Object -FilePath $logFile -Append
+
+    Get-Disk | Format-List * | Out-File -FilePath (Join-Path $evidenceRoot 'get-disk.txt') -Encoding Ascii
+    Get-Partition | Format-List * | Out-File -FilePath (Join-Path $evidenceRoot 'get-partition.txt') -Encoding Ascii
+
+    if ($OsDriveLetter) {
+        $osDrives = @($OsDriveLetter.TrimEnd(':'))
+    }
+    else {
+        $osDrives = Get-Windows-OsDrives-v3
+    }
+
+    if (-not $osDrives -or $osDrives.Count -eq 0) {
+        Log-Error "No Windows installation found on any attached data disk. Confirm the source OS disk is attached with 'Get-Disk | Select Number,BusType,IsBoot,IsSystem'." | Tee-Object -FilePath $logFile -Append
+        throw "No attached Windows OS disk found."
+    }
+
+    ForEach ($drive in $osDrives) {
+        Log-Output "--- Inspecting ${drive}: ---" | Tee-Object -FilePath $logFile -Append
+
+        $systemHivePath = "${drive}:\Windows\System32\config\SYSTEM"
+        $driverPath = "${drive}:\Windows\System32\drivers\stornvme.sys"
+
+        $finding = [ordered]@{
+            osDrive               = $drive
+            systemHiveFound       = (Test-Path -LiteralPath $systemHivePath)
+            stornvmeDriverPresent = (Test-Path -LiteralPath $driverPath)
+            controlSet            = $null
+            stornvmeStart         = $null
+            stornvmeType          = $null
+            stornvmeErrorControl  = $null
+            stornvmeGroup         = $null
+            stornvmeImagePath     = $null
+            storahciStart         = $null
+            cddbNvmeEntries       = @()
+            bootReadyForNvme      = $false
+            problems              = @()
+        }
+
+        if (-not $finding.systemHiveFound) {
+            $finding.problems += 'SYSTEM hive not found'
+            $findings += $finding
+            continue
+        }
+        if (-not $finding.stornvmeDriverPresent) {
+            # Without the driver binary, enabling the service would produce an unbootable configuration.
+            $finding.problems += 'stornvme.sys missing from System32\drivers'
+        }
+
+        Dismount-RegistryHive -MountName $hiveMountName
+        & reg.exe load "HKLM\$hiveMountName" "$systemHivePath" *>$null
+        if ($LASTEXITCODE -ne 0) {
+            $finding.problems += "Failed to load SYSTEM hive (reg load exit $LASTEXITCODE)"
+            $findings += $finding
+            continue
+        }
+
+        try {
+            $current = (Get-ItemProperty -Path "HKLM:\$hiveMountName\Select" -Name Current -ErrorAction Stop).Current
+            $controlSet = 'ControlSet{0:D3}' -f $current
+            $finding.controlSet = $controlSet
+            Log-Output "Active control set: $controlSet" | Tee-Object -FilePath $logFile -Append
+
+            $stornvmeKey = "HKLM:\$hiveMountName\$controlSet\Services\stornvme"
+            if (Test-Path -LiteralPath $stornvmeKey) {
+                $svc = Get-ItemProperty -Path $stornvmeKey -ErrorAction SilentlyContinue
+                $finding.stornvmeStart = $svc.Start
+                $finding.stornvmeType = $svc.Type
+                $finding.stornvmeErrorControl = $svc.ErrorControl
+                $finding.stornvmeGroup = $svc.Group
+                $finding.stornvmeImagePath = $svc.ImagePath
+
+                # 0 = SERVICE_BOOT_START. Anything else means the driver is not on the boot path.
+                if ($svc.Start -ne 0) {
+                    $finding.problems += "stornvme Start=$($svc.Start) (expected 0 = boot-start)"
+                }
+            }
+            else {
+                $finding.problems += 'stornvme service key missing'
+            }
+
+            $storahciKey = "HKLM:\$hiveMountName\$controlSet\Services\storahci"
+            if (Test-Path -LiteralPath $storahciKey) {
+                $finding.storahciStart = (Get-ItemProperty -Path $storahciKey -ErrorAction SilentlyContinue).Start
+            }
+
+            ForEach ($cddb in $CddbKeys) {
+                $cddbPath = "HKLM:\$hiveMountName\$controlSet\Control\CriticalDeviceDatabase\$cddb"
+                if (Test-Path -LiteralPath $cddbPath) {
+                    $entry = Get-ItemProperty -Path $cddbPath -ErrorAction SilentlyContinue
+                    $finding.cddbNvmeEntries += [ordered]@{ key = $cddb; service = $entry.Service; classGuid = $entry.ClassGUID }
+                }
+            }
+            if ($finding.cddbNvmeEntries.Count -eq 0) {
+                $finding.problems += 'No NVMe CriticalDeviceDatabase entries'
+            }
+
+            $finding.bootReadyForNvme = ($finding.stornvmeStart -eq 0) -and $finding.stornvmeDriverPresent
+
+            # Preserve the exact pre-change state so any later repair can be audited against it.
+            & reg.exe export "HKLM\$hiveMountName\$controlSet\Services\stornvme" (Join-Path $evidenceRoot "$drive-stornvme.reg") /y *>$null
+            & reg.exe export "HKLM\$hiveMountName\$controlSet\Control\CriticalDeviceDatabase" (Join-Path $evidenceRoot "$drive-cddb.reg") /y *>$null
+            & reg.exe export "HKLM\$hiveMountName\Select" (Join-Path $evidenceRoot "$drive-select.reg") /y *>$null
+        }
+        finally {
+            Dismount-RegistryHive -MountName $hiveMountName
+        }
+
+        if ($finding.bootReadyForNvme) {
+            Log-Output "${drive}: appears READY to boot on NVMe (stornvme Start=0, driver present)." | Tee-Object -FilePath $logFile -Append
+        }
+        else {
+            Log-Warning "${drive}: NOT ready to boot on NVMe. Problems: $($finding.problems -join '; ')" | Tee-Object -FilePath $logFile -Append
+        }
+
+        $findings += $finding
+    }
+
+    $anyNotReady = @($findings | Where-Object { -not $_.bootReadyForNvme }).Count -gt 0
+
+    # Guest evidence alone is not enough to declare the scenario: the caller must combine it with the
+    # control-plane fact that the VM is actually on (or moving to) the NVMe controller.
+    $confidence = 'low'
+    if ($anyNotReady -and ($attachedBusTypes -contains 'NVMe')) { $confidence = 'high' }
+    elseif ($anyNotReady) { $confidence = 'medium' }
+
+    $evidence = [ordered]@{
+        schemaVersion    = '1.0'
+        scenario         = 'scsi-to-nvme-migration'
+        producedBy       = $scriptName
+        producedAtUtc    = (Get-Date).ToUniversalTime().ToString('o')
+        confidence       = $confidence
+        os               = [ordered]@{ family = 'windows' }
+        repairVm         = [ordered]@{ attachedDiskBusTypes = $attachedBusTypes }
+        controlPlane     = $null   # filled in by the caller; not visible from inside the guest
+        guest            = $findings
+        evidencePath     = $evidenceRoot
+    }
+
+    $json = $evidence | ConvertTo-Json -Depth 8 -Compress
+    $json | Out-File -FilePath (Join-Path $evidenceRoot 'evidence.json') -Encoding Ascii
+    Log-Output "[NVME-EVIDENCE-JSON]$json" | Tee-Object -FilePath $logFile -Append
+
+    Log-Output "END: Detection complete. Evidence at $evidenceRoot" | Tee-Object -FilePath $logFile -Append
+}
+catch {
+    $overallStatus = $STATUS_ERROR
+    Log-Error "$($_.Exception.Message)" | Tee-Object -FilePath $logFile -Append
+    Log-Error "$($_.ScriptStackTrace)" | Tee-Object -FilePath $logFile -Append
+    Dismount-RegistryHive -MountName $hiveMountName
+}
+
+return $overallStatus


### PR DESCRIPTION
### Summary

Adds an NVMe-aware disk-discovery helper for Windows repair VMs, and the first script that uses it.

The existing helpers identify attached disks using the SCSI-specific model name `Microsoft Virtual Disk`.
On repair VMs using an NVMe controller this can return no disks, and dependent repair scripts may then
complete without modifying the attached OS disk while still reporting success. The new helper selects
eligible disks by `BusType`, supporting SCSI, SAS, RAID and NVMe controllers.

`win-detect-nvme-readiness` is a read-only detection script built on that helper. It reports whether a
Windows OS disk can boot from an NVMe disk controller: the `stornvme` `Start` value, `stornvme.sys`
presence, NVMe `CriticalDeviceDatabase` entries, the active ControlSet, and the bus types of attached
disks. It writes an evidence bundle and emits one machine-readable line prefixed
`[NVME-EVIDENCE-JSON]`. It makes no changes: the SYSTEM hive is mounted, read and unmounted.

### Changes

- Added `src/windows/common/helpers/Get-Disk-Partitions-v3.ps1` (`Get-Disk-Partitions-v3`, `Get-Windows-OsDrives-v3`).
- Added `src/windows/win-detect-nvme-readiness.ps1`.
- Added `map.json` run-id `win-detect-nvme-readiness`.
- Updated the helpers README with the v3 entry.

### Deliberately unchanged

- Existing v1 and v2 helpers are untouched.
- Existing repair-script callers are untouched; caller migration will be handled separately with per-script validation.

### Reliable hive unload

A `reg unload` issued straight after a registry read fails with "Access is denied" because the PowerShell
registry provider still holds keys open, leaving the hive mounted and locking the attached disk for later
runs. The detection script retries, verifies with `Test-Path HKLM:\<mount>`, and logs the manual unload
command rather than suppressing the error.

Live-validated on SCSI and NVMe repair VMs. Two defects were found and fixed during that validation:
the helper returned its own log lines as data, and it returned before Windows had assigned drive
letters to a newly-onlined disk — which would have made the first run against every fresh repair VM
report "no Windows installation found".