### PR TITLE
Add the offline registry and protected-resource helpers (2 of 3)

### DIFF
--- a/src/windows/common/helpers/Get-OfflineWindowsDisk.ps1
+++ b/src/windows/common/helpers/Get-OfflineWindowsDisk.ps1
@@ -22,8 +22,8 @@
       Clear-OfflineDriveLetter      Release every drive letter this run assigned (finally).
       Stop-NestedRepairVm           Stop a nested Hyper-V repair VM holding the disk.
 
-    Get-OfflineWindowsDisk sets $script:OfflineWindowsDrive, which the offline registry
-    hive helper (Use-OfflineRegistryHive.ps1) uses as its default Windows path.
+    Get-OfflineWindowsDisk publishes the selected Windows drive through the shared repair
+    state, which the offline registry hive helper uses as its default Windows path.
 
 .NOTES
     Name:   Get-OfflineWindowsDisk.ps1
@@ -61,9 +61,14 @@
     v1.4: Verify disk state after diskpart, skip writes to already-ready disks, and recognise
           the resource disk by its language-independent warning file as well as its label.
           Probe hive metadata in memory through offreg, without registry mounts.
+    v1.5: Refuse discovery while a helper-managed guest owns its disks. Limit automatic
+          shutdown to ProblemVM or an explicit Id, and serialize guest/disk hand-offs.
 #>
 
-if (-not (Get-Command Open-OfflineRegistryReader -ErrorAction SilentlyContinue)) {
+if (-not (Get-Command Open-OfflineRegistryReader -ErrorAction SilentlyContinue) -or
+    -not (Get-Command Set-OfflineWindowsDrive -ErrorAction SilentlyContinue) -or
+    -not (Get-Command Enter-OfflineNestedVmLifecycle -ErrorAction SilentlyContinue) -or
+    -not (Get-Command Test-OfflineNestedVmManaged -ErrorAction SilentlyContinue)) {
     try {
         . (Join-Path $PSScriptRoot 'OfflineRepairCommon.ps1')
     }
@@ -269,42 +274,91 @@ function Get-PartitionExistingRoot {
 function Stop-NestedRepairVm {
     <#
     .SYNOPSIS
-        Stops a running nested Hyper-V VM so its VHD can be mounted offline.
+        Releases the Azure-created nested guest before an offline repair.
 
     .DESCRIPTION
         Only relevant when the repair VM was created with 'az vm repair create --enable-nested'.
-        Returns the names of the VMs that were stopped. Silently does nothing when the
-        Hyper-V role is not installed.
+        The default target is exactly one guest named ProblemVM; a custom guest requires its
+        explicit Id. Other active guests block discovery rather than being turned off.
 
-        SupportsShouldProcess is declared so -WhatIf reports each VM it would turn off.
-        ConfirmImpact is left at the default (Medium), below the default $ConfirmPreference
-        (High), so the non-interactive SYSTEM run under az vm repair proceeds without a prompt.
+        A guest claimed by Start-NestedRepairVm is never stopped here. The owning flow must
+        call Stop-NestedRepairVmGraceful and confirm Stopped before rediscovering the disk.
+        Refusing, rather than merely skipping that guest, prevents disk preparation from
+        proceeding while the guest still owns it. The Notes marker persists across processes.
+
+        Returns the name only after the selected guest is confirmed Off. Does nothing when
+        Hyper-V is absent. Enumeration or shutdown failures abort the hand-off.
+
+    .PARAMETER VmId
+        Exact Id of a custom, unmanaged repair guest. Omit for the Azure-created ProblemVM.
     #>
     [CmdletBinding(SupportsShouldProcess)]
     [OutputType([System.Object[]])]
-    param()
+    param([guid]$VmId = [guid]::Empty)
 
     $stopped = @()
-
     if (-not (Get-Command Get-VM -ErrorAction SilentlyContinue)) { return $stopped }
 
+    $lease = Enter-OfflineNestedVmLifecycle
     try {
-        $running = @(Get-VM -ErrorAction SilentlyContinue | Where-Object { $_.State -eq 'Running' })
-    }
-    catch {
-        Add-OfflineRepairLog -Level Info -Message "Hyper-V is present but VMs could not be enumerated: $($_.Exception.Message)"
+        $guests = @(Get-VM -ErrorAction Stop)
+        $active = @($guests | Where-Object { $_.State -ne 'Off' })
+        $managed = @($active | Where-Object { Test-OfflineNestedVmManaged -Vm $_ })
+        if ($managed.Count -gt 0) {
+            $names = ($managed | ForEach-Object { "'$($_.Name)' ($($_.Id))" }) -join ', '
+            throw "Offline discovery refused: helper-managed guest(s) $names are still active. The owning flow must use Stop-NestedRepairVmGraceful and confirm Stopped before taking the disk back."
+        }
+
+        $target = @(if ($VmId -ne [guid]::Empty) {
+                $guests | Where-Object { $_.Id -eq $VmId }
+            }
+            else {
+                $guests | Where-Object { $_.Name -eq 'ProblemVM' }
+            })
+
+        if ($VmId -ne [guid]::Empty -and $target.Count -ne 1) {
+            throw "The explicitly selected nested repair guest '$VmId' could not be resolved uniquely."
+        }
+        if ($active.Count -eq 0) { return $stopped }
+        if ($target.Count -ne 1) {
+            throw 'Active Hyper-V guests exist but there is not exactly one ProblemVM. Nothing was stopped. Select the intended unmanaged repair guest explicitly with -NestedVmId on Get-OfflineWindowsDisk.'
+        }
+
+        $other = @($active | Where-Object { $_.Id -ne $target[0].Id })
+        if ($other.Count -gt 0) {
+            $names = ($other | ForEach-Object { "'$($_.Name)' ($($_.Id))" }) -join ', '
+            throw "Offline discovery refused: other Hyper-V guest(s) $names are active. Nothing was stopped; complete their disk hand-off explicitly first."
+        }
+
+        $vm = Get-VM -Id $target[0].Id -ErrorAction Stop
+        if (-not $vm) { throw 'The selected nested repair guest disappeared before shutdown.' }
+        if ($vm.State -eq 'Off') { return $stopped }
+        if (Test-OfflineNestedVmManaged -Vm $vm) {
+            throw "Nested guest '$($vm.Name)' was claimed by a repair flow; automatic shutdown was refused."
+        }
+        if ($vm.State -ne 'Running') {
+            throw "Nested guest '$($vm.Name)' is '$($vm.State)', not Running or Off. Resolve that state explicitly before offline discovery."
+        }
+        if (-not $PSCmdlet.ShouldProcess($vm.Name, 'Turn off the selected unmanaged repair VM so its disk can be mounted offline')) {
+            return $stopped
+        }
+
+        Add-OfflineRepairLog -Level Info -Message "Stopping unmanaged nested repair guest '$($vm.Name)' ($($vm.Id)) so its disk can be mounted offline."
+        Stop-VM -VM $vm -TurnOff -Force -ErrorAction Stop
+        $after = Get-VM -Id $vm.Id -ErrorAction Stop
+        if (-not $after -or $after.State -ne 'Off') {
+            throw "Nested guest '$($vm.Name)' could not be confirmed Off after shutdown; disk preparation was refused."
+        }
+        $stopped += $vm.Name
         return $stopped
     }
-
-    foreach ($vm in $running) {
-        if (-not $PSCmdlet.ShouldProcess($vm.Name, 'Turn off nested Hyper-V VM so its disk can be mounted offline')) { continue }
-        Add-OfflineRepairLog -Level Info -Message "Stopping nested Hyper-V VM '$($vm.Name)' so its disk can be mounted offline."
-        Stop-VM -Name $vm.Name -TurnOff -Force -ErrorAction SilentlyContinue
-        $stopped += $vm.Name
+    catch {
+        Add-OfflineRepairLog -Level Error -Message $_.Exception.Message
+        throw
     }
-
-    if ($stopped.Count -gt 0) { Start-Sleep -Seconds 3 }
-    return $stopped
+    finally {
+        Exit-OfflineNestedVmLifecycle -Lease $lease
+    }
 }
 
 function Test-TemporaryStorageDisk {
@@ -825,17 +879,21 @@ function Get-OfflineWindowsDisk {
         Locates the offline Windows installation on the attached broken OS disk.
 
     .DESCRIPTION
-        Stops a nested repair VM if one is running, brings the attached virtual disks
+        Releases an unmanaged Azure-created nested repair VM, brings the attached virtual disks
         online, assigns drive letters to partitions that have none, then selects the
-        best Windows installation and its matching boot partition.
+        best Windows installation and its matching boot partition. Active helper-managed
+        or unrelated guests block discovery before disks or drive letters are changed.
 
-        Sets $script:OfflineWindowsDrive for the offline registry hive helper.
+        Publishes the selected Windows drive through the shared repair state.
 
     .PARAMETER DiskNumber
         Restrict the search to a specific disk number.
 
     .PARAMETER WindowsDrive
         Skip discovery and use this drive letter as the offline Windows volume.
+
+    .PARAMETER NestedVmId
+        Exact Id of a custom unmanaged repair guest. Omit for the Azure-created ProblemVM.
 
     .OUTPUTS
         PSCustomObject with DiskNumber, PartitionStyle, Generation, WindowsDrive,
@@ -850,7 +908,8 @@ function Get-OfflineWindowsDisk {
     #>
     param(
         [Parameter(Mandatory = $false)][int]$DiskNumber = -1,
-        [Parameter(Mandatory = $false)][string]$WindowsDrive
+        [Parameter(Mandatory = $false)][string]$WindowsDrive,
+        [Parameter(Mandatory = $false)][guid]$NestedVmId = [guid]::Empty
     )
 
     # The rescue VM's own OS disk must be known before anything is brought online, because
@@ -864,8 +923,14 @@ function Get-OfflineWindowsDisk {
         throw "Could not determine the rescue VM's own system disk number, so the broken disk cannot be told apart from it: $($_.Exception.Message)"
     }
 
-    $null = Stop-NestedRepairVm
-    $onlineDiskNumbers = @(Set-OfflineDisksOnline -ExcludeDiskNumber @($systemDiskNumber | Where-Object { $_ -ge 0 }))
+    $lease = Enter-OfflineNestedVmLifecycle
+    try {
+        $null = Stop-NestedRepairVm -VmId $NestedVmId
+        $onlineDiskNumbers = @(Set-OfflineDisksOnline -ExcludeDiskNumber @($systemDiskNumber | Where-Object { $_ -ge 0 }))
+    }
+    finally {
+        Exit-OfflineNestedVmLifecycle -Lease $lease
+    }
 
     # Select by bus type, not model name: Azure NVMe disks report 'Microsoft NVMe Direct
     # Disk', which the old '*Virtual Disk*' match missed. The rescue VM's own system disk,
@@ -1007,15 +1072,13 @@ function Get-OfflineWindowsDisk {
     # VM's own system drive, which is the fail-closed behaviour we want. The boot/EFI
     # partition is a separate volume on the same disk that BCD repairs write to, so it is
     # bound too or the gate would refuse them.
-    $null = Set-OfflineRepairRoot -Path $selected.Drive
+    $null = Set-OfflineWindowsDrive -WindowsDrive $selected.Drive
     if ($bootDrive) {
         $bootRoot = "$bootDrive".TrimEnd('\')
         if ($bootRoot -match '^[A-Za-z]:$' -and $bootRoot -ne $selected.Drive) {
             $null = Set-OfflineRepairRoot -Path $bootRoot
         }
     }
-
-    $script:OfflineWindowsDrive = $selected.Drive
 
     $result = [PSCustomObject]@{
         DiskNumber           = $selected.DiskNumber

--- a/src/windows/common/helpers/OfflineRepairCommon.ps1
+++ b/src/windows/common/helpers/OfflineRepairCommon.ps1
@@ -58,6 +58,8 @@
           resource.
     v1.2: Added a read-only offreg reader for discovery and hive validation, without
           mounting hives in the rescue VM's registry or replaying logs onto the source.
+    v1.3: Shared writable-hive lifecycle and default-drive state across dot-source scopes.
+          Added numeric, read-only native queries for mounted keys and DWORD metadata.
 #>
 
 function Get-OfflineRepairState {
@@ -66,8 +68,8 @@ function Get-OfflineRepairState {
         Returns the shared helper state, creating it on first use.
 
     .DESCRIPTION
-        One hashtable in $global: holds the log buffer, the bound offline roots and the
-        registered hive mount keys. See the file header for why this is not $script:.
+        One hashtable in $global: holds the log buffer, target bindings, default Windows
+        drive and hive lifecycle. See the file header for why this is not $script:.
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '',
         Justification = 'Deliberate, and confined to this one function. These helpers are dot-sourced, and a $script: variable binds to the scope that did the dot-sourcing: a helper sourced from inside a function would get its own private copy of the root list, so Assert-OfflineTarget would check a set the caller never populated and the gate would fail open. Each az vm repair run is a fresh process, so there is nothing to leak into; Clear-OfflineRepairRoot resets it for tests.')]
@@ -76,12 +78,67 @@ function Get-OfflineRepairState {
 
     if (-not $global:OfflineRepairState) {
         $global:OfflineRepairState = @{
-            LogBuffer = [System.Collections.Generic.List[object]]::new()
-            Roots     = [System.Collections.Generic.List[string]]::new()
-            HiveKeys  = [System.Collections.Generic.List[string]]::new()
+            LogBuffer     = [System.Collections.Generic.List[object]]::new()
+            Roots         = [System.Collections.Generic.List[string]]::new()
+            HiveKeys      = [System.Collections.Generic.List[string]]::new()
+            WindowsDrive  = $null
+            HiveLoadDepth = @{}
+            HiveFilePaths = @{}
         }
     }
+    # Upgrade an existing state without resetting another dot-source scope's acquisitions.
+    foreach ($name in @('HiveLoadDepth', 'HiveFilePaths')) {
+        if (-not $global:OfflineRepairState.ContainsKey($name)) {
+            $global:OfflineRepairState[$name] = @{}
+        }
+    }
+    if (-not $global:OfflineRepairState.ContainsKey('WindowsDrive')) {
+        $global:OfflineRepairState.WindowsDrive = $null
+    }
     return $global:OfflineRepairState
+}
+
+function Set-OfflineWindowsDrive {
+    <#
+    .SYNOPSIS
+        Binds the default offline Windows drive for every dot-source scope.
+
+    .DESCRIPTION
+        Call after discovery selects the Windows volume. Returns the bound root, like
+        Set-OfflineRepairRoot. An active hive caller must not have its default retargeted.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Only updates the in-process offline target binding; skipping it for WhatIf would leave subsequent helpers bound to the wrong default.')]
+    param([Parameter(Mandatory = $true)][string]$WindowsDrive)
+
+    $state = Get-OfflineRepairState
+    $normalised = ConvertTo-OfflineComparablePath $WindowsDrive
+    if ($state.WindowsDrive -and $normalised -ne $state.WindowsDrive -and $state.HiveLoadDepth.Count -gt 0) {
+        throw "Cannot change the offline Windows drive from '$($state.WindowsDrive)' to '$WindowsDrive' while hives are in use."
+    }
+    $state.WindowsDrive = Set-OfflineRepairRoot -Path $WindowsDrive
+    return $state.WindowsDrive
+}
+
+function Get-OfflineWindowsDrive {
+    <#
+    .SYNOPSIS
+        Returns the shared default offline Windows drive.
+
+    .DESCRIPTION
+        Imports a legacy $script:OfflineWindowsDrive only when no shared default is set.
+        Once imported, shared state is authoritative; callers changing disks must use
+        Set-OfflineWindowsDrive rather than updating a scope-private variable.
+    #>
+    $state = Get-OfflineRepairState
+    if ([string]::IsNullOrWhiteSpace($state.WindowsDrive)) {
+        $legacy = Get-Variable -Name OfflineWindowsDrive -Scope Script -ErrorAction SilentlyContinue
+        if ($legacy -and -not [string]::IsNullOrWhiteSpace($legacy.Value)) {
+            $null = Set-OfflineWindowsDrive -WindowsDrive $legacy.Value
+            Add-OfflineRepairLog -Level Warning -Message 'Imported the legacy OfflineWindowsDrive default. Use Set-OfflineWindowsDrive when selecting another disk.'
+        }
+    }
+    return $state.WindowsDrive
 }
 
 function Add-OfflineRepairLog {
@@ -302,6 +359,122 @@ function Open-OfflineRegistryReader {
     return [RslOffline.RegistryHiveReader]::Open($Path)
 }
 
+function Initialize-OfflineMountedRegistry {
+    <#
+    .SYNOPSIS
+        Initialises read-only native queries of already mounted HKLM keys.
+
+    .DESCRIPTION
+        RegOpenKeyEx returns numeric errors for the key itself, independently of its
+        default value or the OS language. Every handle is disposed before returning.
+        No privileges, registry provider handles, mounts or writes are involved.
+        Offline file discovery and validation continue to use the separate offreg reader.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ('RslOffline.MountedRegistry' -as [type]) { return }
+
+    Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace RslOffline
+{
+    public static class MountedRegistry
+    {
+        private static readonly IntPtr HKLM = new IntPtr(unchecked((int)0x80000002));
+        private const int KeyQueryValue = 1;
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        private static extern int RegOpenKeyExW(IntPtr key, string subKey, int options,
+            int access, out SafeRegistryHandle result);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        private static extern int RegQueryValueExW(SafeRegistryHandle key, string name,
+            IntPtr reserved, out uint type, byte[] data, ref uint size);
+
+        private static void Check(int result, string operation)
+        {
+            if (result != 0)
+                throw new Win32Exception(result, operation + " failed (Win32 error " +
+                    result + "): " + new Win32Exception(result).Message);
+        }
+
+        public static int OpenKeyResult(string subKey)
+        {
+            SafeRegistryHandle key;
+            int result = RegOpenKeyExW(HKLM, subKey, 0, KeyQueryValue, out key);
+            using (key) { return result; }
+        }
+
+        public static uint? ReadDword(string subKey, string name)
+        {
+            SafeRegistryHandle key;
+            int result = RegOpenKeyExW(HKLM, subKey, 0, KeyQueryValue, out key);
+            using (key)
+            {
+                if (result == 2 || result == 3) return null;
+                Check(result, "Opening HKLM\\" + subKey);
+                uint type;
+                uint size = 4;
+                byte[] data = new byte[size];
+                result = RegQueryValueExW(key, name, IntPtr.Zero, out type, data, ref size);
+                if (result == 2) return null;
+                if (result != 234) Check(result, "Reading HKLM\\" + subKey + "\\" + name);
+                if (result == 234 || type != 4 || size != 4)
+                    throw new InvalidDataException("HKLM\\" + subKey + "\\" + name +
+                        " is not a four-byte registry DWORD.");
+                return BitConverter.ToUInt32(data, 0);
+            }
+        }
+    }
+}
+'@ -ErrorAction Stop
+}
+
+function Get-OfflineRegistryKeyOpenResult {
+    <#
+    .SYNOPSIS
+        Returns the native result of opening an existing HKLM key for query access.
+    #>
+    param([Parameter(Mandatory = $true)][string]$Key)
+
+    $normalised = ConvertTo-OfflineComparableRegistryPath $Key
+    if (-not $normalised -or $normalised -eq 'HKLM') {
+        throw "'$Key' is not an HKLM subkey."
+    }
+    Initialize-OfflineMountedRegistry
+    return [RslOffline.MountedRegistry]::OpenKeyResult($normalised.Substring(5))
+}
+
+function Get-OfflineRegistryDword {
+    <#
+    .SYNOPSIS
+        Reads a mounted HKLM DWORD without retaining a registry handle.
+
+    .DESCRIPTION
+        Returns null only for an absent key/value. A wrong type, access denial or any
+        other native read failure throws instead of converting it into a missing value.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Key,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Name
+    )
+
+    $normalised = ConvertTo-OfflineComparableRegistryPath $Key
+    if (-not $normalised -or $normalised -eq 'HKLM') {
+        throw "'$Key' is not an HKLM subkey."
+    }
+    Initialize-OfflineMountedRegistry
+    return [RslOffline.MountedRegistry]::ReadDword($normalised.Substring(5), $Name)
+}
+
 #region Offline target binding
 
 $script:OfflineRootPattern = '^([A-Za-z]:|\\\\[^\\]+\\[^\\]+)$'
@@ -477,6 +650,7 @@ function Clear-OfflineRepairRoot {
     $state = Get-OfflineRepairState
     $state.Roots.Clear()
     $state.HiveKeys.Clear()
+    $state.WindowsDrive = $null
 }
 
 function Register-OfflineHiveKey {
@@ -876,4 +1050,85 @@ function Get-OfflineSecureBootState {
 
     $result.Source = 'the SecureBoot variable was not present in the most recent Measured Boot logs'
     return $result
+}
+
+function Get-OfflineNestedVmOwnershipTag {
+    <#
+    .SYNOPSIS
+        Returns the persistent Notes marker shared by discovery and nested-guest helpers.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+    return 'repair-script-library:nested-repair:v1'
+}
+
+function Test-OfflineNestedVmManaged {
+    <#
+    .SYNOPSIS
+        Reports whether a guest has the exact ownership marker on a separate Notes line.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param([Parameter(Mandatory = $true)][AllowNull()]$Vm)
+
+    if ($null -eq $Vm) { return $false }
+    $notes = $Vm.PSObject.Properties['Notes']
+    if (-not $notes) { return $false }
+    $tag = Get-OfflineNestedVmOwnershipTag
+    foreach ($line in ([string]$notes.Value -split '\r\n|\n|\r')) {
+        if ([string]::Equals($line, $tag, [StringComparison]::Ordinal)) { return $true }
+    }
+    return $false
+}
+
+function Enter-OfflineNestedVmLifecycle {
+    <#
+    .SYNOPSIS
+        Serializes nested-guest ownership and disk hand-offs across host processes.
+
+    .DESCRIPTION
+        The lease is reentrant on the current thread, so discovery can call the guarded
+        stopper while holding its own disk-preparation lease. Another thread or process
+        is refused immediately. Release each acquired lease in finally; this is not a
+        lease for an entire repair session or the lifetime of a running guest.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Threading.Mutex])]
+    param()
+
+    $lease = $null
+    $acquired = $false
+    try {
+        $lease = [System.Threading.Mutex]::new($false, 'Global\RslOfflineNestedVmLifecycleV1')
+        try { $acquired = $lease.WaitOne(0) }
+        catch [System.Threading.AbandonedMutexException] {
+            $acquired = $true
+            Add-OfflineRepairLog -Level Warning -Message 'The previous nested-VM lifecycle owner exited unexpectedly. Guest ownership and disk state will be checked again before proceeding.'
+        }
+        if (-not $acquired) {
+            throw 'Another nested-VM lifecycle operation is in progress on this host; the disk hand-off was refused.'
+        }
+        return $lease
+    }
+    catch {
+        if ($lease) {
+            try { if ($acquired) { $lease.ReleaseMutex() } }
+            finally { $lease.Dispose() }
+        }
+        Add-OfflineRepairLog -Level Error -Message "Could not acquire the nested-VM lifecycle lease: $($_.Exception.Message)"
+        throw
+    }
+}
+
+function Exit-OfflineNestedVmLifecycle {
+    <#
+    .SYNOPSIS
+        Releases and disposes a lifecycle lease acquired by the current thread.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][System.Threading.Mutex]$Lease)
+
+    try { $Lease.ReleaseMutex() }
+    finally { $Lease.Dispose() }
 }

--- a/src/windows/common/helpers/README.md
+++ b/src/windows/common/helpers/README.md
@@ -8,14 +8,14 @@ Each helper script and description should be listed here.
 | `Get-Disk-Partitions.ps1` | Returns partitions of attached disks whose `Win32_diskdrive` model is `Microsoft Virtual Disk`, bringing them online with `diskpart`. **SCSI-attached disks only.** |
 | `Get-Disk-Partitions-v2.ps1` | As v1, with `$partitionlist` initialised to an array so a single result is not unrolled. **SCSI-attached disks only.** |
 | `Get-Disk-Partitions-v3.ps1` | `Get-Disk-Partitions-v3` selects attached disks by **BusType** (SCSI/SAS/RAID/NVMe) instead of the SCSI-only model string, so it also works when the repair VM uses the NVMe disk controller. Excludes the Azure resource disk. `Get-Windows-OsDrives-v3` narrows the result to drive letters that contain a Windows installation. |
-| `OfflineRepairCommon.ps1` | Shared primitives for offline repair: buffered logging, path joining and validation, Authenticode/catalog signature inspection, a read-only `offreg.dll` hive reader, and the offline-target gate (`Set-OfflineRepairRoot` / `Assert-OfflineTarget`) that binds every other offline helper to the attached disk. |
-| `Get-OfflineWindowsDisk.ps1` | Finds the offline Windows installation on the attached disk, verifies its disks are online and writable, and manages temporary drive letters for hidden EFI System and Recovery partitions. Selects by **BusType**, excludes resource disks by label or warning-file marker, and refuses the rescue VM's own boot/system disk. Reads hive metadata without registry mounts and binds the offline root for `Assert-OfflineTarget`. |
-| `Use-OfflineRegistryHive.ps1` | Mounts writable hives from the attached disk, runs a scriptblock, and verifies their unload even after a partial mount failure. Its separate `Test-OfflineHiveFile` validation uses the shared in-memory reader without mounting or copying hives. |
+| `OfflineRepairCommon.ps1` | Shared primitives for offline repair: buffered logging, drive-safe paths, signature inspection, a read-only `offreg.dll` reader, shared hive/default-drive state, the offline-target gate, and cross-process nested-VM lifecycle coordination. |
+| `Get-OfflineWindowsDisk.ps1` | Finds the offline Windows installation, verifies its disks are online and writable, and manages temporary drive letters. Selects by **BusType**, excludes resource disks and the rescue VM's own disks, reads hive metadata without mounts, and publishes the shared offline target. Active helper-managed or unrelated guests block discovery before disk preparation. |
+| `Use-OfflineRegistryHive.ps1` | Mounts writable hives, runs reentrant callbacks, and verifies unload with language-independent key-state checks. Provides strict control-set selection for writers. Its separate `Test-OfflineHiveFile` uses the shared in-memory reader without mounting or copying hives. |
 | `Use-OfflineProtectedResource.ps1` | Takes ownership of, reads and restores files and registry keys on the attached disk that `SYSTEM` cannot otherwise open, restoring every security descriptor it changed and verifying the restore rather than counting it. |
 | `Use-OfflinePrivilegedRegistry.ps1` | The privileged registry operations from `Use-OfflineProtectedResource.ps1`: enabling `SeTakeOwnershipPrivilege`/`SeRestorePrivilege` and removing or rewriting keys that deny access to `SYSTEM`. |
 | `Get-OfflineBcdStore.ps1` | Locates the BCD store on the attached disk and runs `bcdedit.exe` against it directly, without a shell. Distinguishes an empty boot inventory from a failed enumeration, and refuses to operate on the rescue VM's own store. |
-| `Use-OfflineFileRemoval.ps1` | Removes files from the attached disk with a backup, a verified rollback, and post-removal checks. Refuses to remove a registry hive or any of its side files, refuses to follow reparse points, and refuses any path outside the bound offline root. |
-| `Use-NestedRepairVm.ps1` | Boots the offline Windows installation as a nested Hyper-V guest on the rescue VM for repairs that only the running OS can perform. Restores the offline state of every disk it took, on every exit path. |
+| `Use-OfflineFileRemoval.ps1` | Removes approved files with hash-verified backups and rollback. Unknown or insufficient native volume capacity refuses removal. Retains original hashes and recorded metadata for later restores, refuses hive side files and reparse points, and enforces the bound offline target. |
+| `Use-NestedRepairVm.ps1` | Hands named disks to an existing nested guest and records ownership in Notes so discovery cannot interrupt it. A failed start restores only disks that call took offline. Reports whether an explicit shutdown actually completed before the caller takes the disk back. |
 
 **Which one to use:** new scripts that need the *Windows installation* — to mount its hives, edit its
 BCD, or repair files on it — should use `Get-OfflineWindowsDisk.ps1`, which also binds the offline root
@@ -78,3 +78,51 @@ not that the guest will boot or that a separate structural check is unnecessary.
 `Invoke-WithHive` and the protected-registry helpers still expose writable HKLM paths. The in-memory
 reader does not replace that contract; callers requiring those paths must keep using the guarded
 mount/unmount helpers.
+
+## Writable hives and control-set selection
+
+Mounted-key state is `Present`, `Absent`, or `Unknown`, determined through registry APIs rather
+than localized `reg.exe` messages. Access denial is not absence, and a file-sharing check is not
+used as proof of which registry key owns a hive.
+
+Writers must use `Get-OfflineSystemRootPath -Strict`, `Get-OfflineControlSetName -Strict`, or
+`Get-OfflineReferencedControlSetName -Strict`. Strict selection rejects an unreadable, wrongly typed,
+out-of-range or missing current control set instead of guessing `ControlSet001`. The non-strict
+fallback remains for tolerant reads, not for deriving a write target.
+
+`Invoke-WithHive` shares its depth and file bindings across dot-source scopes. An inner callback
+cannot unload an outer caller's hive or switch that active hive to another file. Discovery sets
+the default through `Set-OfflineWindowsDrive`; manual selection must use that setter too, rather
+than assigning a scope-private `$script:OfflineWindowsDrive`.
+
+## Removal and later rollback
+
+Persist `Invoke-OfflineRemovalPlan`'s `BackupRecord` with the backup location. Pass those records as
+`Restore-OfflineFileSet -FileRecord` on a later revert; reconstructing just names and attributes
+discards the verified original hashes and security descriptors.
+
+A restore checks the backup and restored contents against the recorded hash, reapplies the recorded
+security, then restores and verifies exact attributes. Attributes come last because an NTFS security
+change can set Archive. Treat `Succeeded = $false` as a failed or incomplete restore and retain the
+undo manifest, even when some files were restored.
+
+Legacy records without a Hash field remain supported with an explicit warning: the check proves the
+copy against the current backup, not against a recorded historical original. An explicitly empty
+Hash field is an unavailable verification result and is refused.
+
+## Nested-guest hand-offs
+
+Automatic discovery shutdown is limited to the unmanaged Azure-created `ProblemVM`, or an exact
+custom guest selected with `Get-OfflineWindowsDisk -NestedVmId`. Other active guests are never
+implicitly turned off.
+
+`Start-NestedRepairVm` marks a started or adopted guest with a separate
+`repair-script-library:nested-repair:v1` Notes line, preserving existing notes. A fresh discovery
+process recognizes it and refuses to proceed while it is active. Skipping the guest and onlining
+its disk would not be safe.
+
+Sequence offline editing, `Start-NestedRepairVm`, boot/result observation,
+`Stop-NestedRepairVmGraceful`, and rediscovery. **Confirm `Stopped` before taking the disk back.**
+A timeout power-off is reported as non-graceful and requires rechecking the disk. The shared host
+mutex serializes lifecycle transitions, not an entire repair session; it does not replace this
+caller sequencing.

--- a/src/windows/common/helpers/Use-OfflinePrivilegedRegistry.ps1
+++ b/src/windows/common/helpers/Use-OfflinePrivilegedRegistry.ps1
@@ -1,0 +1,670 @@
+<#
+.SYNOPSIS
+    Reading and repairing a single offline registry key or value that denies access to every
+    account, SYSTEM included, by opening it with SeBackupPrivilege / SeRestorePrivilege rather
+    than by its DACL.
+
+.DESCRIPTION
+    Split out of Use-OfflineProtectedResource.ps1 during the PR #143 review because it solves a
+    different problem by a different mechanism, and keeping the two apart keeps each one readable.
+
+    Use-OfflineProtectedResource.ps1 handles objects that are merely OWNED by TrustedInstaller: it
+    takes ownership, rewrites the DACL, does the repair, and puts the original security descriptor
+    back afterwards. The functions here never change a key's owner or DACL at all. They open it
+    with REG_OPTION_BACKUP_RESTORE while SeBackupPrivilege and SeRestorePrivilege are held, which
+    makes the kernel grant access on the strength of the privilege and skip the DACL check
+    entirely. Nothing about the key changes, so a read leaves even a healthy machine untouched and
+    a write goes through the same privileged handle instead of loosening the key first.
+
+    "Privileged" here means "opened by privilege rather than by permission". It has nothing to do
+    with Backup-OfflineHiveFile, which copies a hive file.
+
+    Use these when a key denies read to everyone including SYSTEM - mpssvc's AppCs key is the known
+    example. Use the *-OfflineProtected* functions in Use-OfflineProtectedResource.ps1 when the key
+    is merely owned by TrustedInstaller.
+
+    The three functions that change the hive - New-OfflinePrivilegedRegistryKey,
+    Set-OfflinePrivilegedRegistryValue and Remove-OfflinePrivilegedRegistryValue - each call
+    Assert-OfflineTarget BEFORE enabling any privilege, so a privileged create, write or delete
+    cannot land on the rescue VM's own registry if an upstream precondition degrades. They take an
+    optional -OfflineRoot to state the binding explicitly. The read functions inspect only and are
+    not gated.
+
+    Exposed functions:
+      Initialize-OfflinePrivilegedRegistryType    Compile the backup-restore P/Invoke (idempotent).
+      Get-OfflinePrivilegedRegistryValueName      List value names under a guarded key.
+      Get-OfflinePrivilegedRegistrySubKeyName     List subkey names under a guarded key.
+      Get-OfflinePrivilegedRegistryValue          Read one value from a guarded key.
+      New-OfflinePrivilegedRegistryKey            Create a guarded key.                 [gated]
+      Set-OfflinePrivilegedRegistryValue          Write one value to a guarded key.     [gated]
+      Remove-OfflinePrivilegedRegistryValue       Remove one value from a guarded key.  [gated]
+
+.NOTES
+    Name:   Use-OfflinePrivilegedRegistry.ps1
+    Requires: OfflineRepairCommon.ps1 (Assert-OfflineTarget, Add-OfflineRepairLog) and
+              Use-OfflineProtectedResource.ps1 (ConvertTo-OfflineNativeSubKey,
+              Enable-OfflineBackupPrivilege). Both are dot-sourced below from this file's own
+              folder via $PSScriptRoot, not the caller's working directory.
+    These functions return values, so they buffer their messages with Add-OfflineRepairLog
+    instead of calling Log-* directly. Call Write-OfflineRepairLog at script level to flush.
+
+.VERSION
+    v1.0: Split unchanged out of Use-OfflineProtectedResource.ps1 so the backup-restore path lives
+          on its own.
+    v1.1: The three writing functions now call Assert-OfflineTarget before enabling
+          SeBackupPrivilege / SeRestorePrivilege and accept an optional -OfflineRoot, so a
+          privileged create, write or remove is proven to land on the mounted offline hive and
+          never on the rescue VM's own registry (PR #143 review).
+#>
+
+# These functions call the offline-target gate (Assert-OfflineTarget, from OfflineRepairCommon) and
+# the subkey and privilege helpers that stay in Use-OfflineProtectedResource.ps1
+# (ConvertTo-OfflineNativeSubKey, Enable-OfflineBackupPrivilege). Resolve both siblings against this
+# file's own folder so a scenario loads the same helpers wherever it dot-sources this from, and fail
+# loudly if either cannot be loaded rather than at the first privileged call.
+$script:OfflinePrivilegedRegistryDependencies = @(
+    @{ File = 'OfflineRepairCommon.ps1';          Sentinel = 'Assert-OfflineTarget' },
+    @{ File = 'Use-OfflineProtectedResource.ps1'; Sentinel = 'ConvertTo-OfflineNativeSubKey' }
+)
+foreach ($dependency in $script:OfflinePrivilegedRegistryDependencies) {
+    if (Get-Command -Name $dependency.Sentinel -ErrorAction SilentlyContinue) { continue }
+    $dependencyPath = Join-Path -Path $PSScriptRoot -ChildPath $dependency.File
+    try {
+        . $dependencyPath
+    }
+    catch {
+        throw "Use-OfflinePrivilegedRegistry.ps1 could not load its dependency '$($dependency.File)' from '$dependencyPath': $($_.Exception.Message)"
+    }
+}
+
+# A sentinel still missing after the load means the dependency did not define what these functions
+# need, so running on would only defer the failure to a privileged registry call.
+foreach ($required in @('Assert-OfflineTarget', 'ConvertTo-OfflineNativeSubKey', 'Enable-OfflineBackupPrivilege')) {
+    if (-not (Get-Command -Name $required -ErrorAction SilentlyContinue)) {
+        throw "Use-OfflinePrivilegedRegistry.ps1 loaded its dependencies but '$required' is still unavailable, so it cannot run safely."
+    }
+}
+
+function Initialize-OfflinePrivilegedRegistryType {
+    <#
+    .SYNOPSIS
+        Compiling the registry P/Invoke used by the backup-restore path.
+
+    .DESCRIPTION
+        The .NET registry classes give no way to pass REG_OPTION_BACKUP_RESTORE, and the PowerShell
+        provider gives no way either, so the Win32 API is called directly.
+
+        RegCreateKeyEx is used rather than RegOpenKeyEx because the backup-restore option is only
+        honoured by RegCreateKeyEx. That function creates the key when it is absent, which would be
+        a write to a machine that may be healthy, so every open checks the disposition it returns
+        and removes anything it created before handing the handle back.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ('OfflinePrivilegedRegistry' -as [type]) { return }
+
+    Add-Type -TypeDefinition @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class OfflinePrivilegedRegistry
+{
+    const int REG_OPTION_BACKUP_RESTORE = 0x00000004;
+    const int REG_CREATED_NEW_KEY = 1;
+    const int KEY_READ = 0x20019;
+    const int KEY_WRITE = 0x20006;
+    const int ERROR_SUCCESS = 0;
+    const int ERROR_NO_MORE_ITEMS = 259;
+    const int ERROR_MORE_DATA = 234;
+    const int ERROR_ALREADY_EXISTS = 183;
+    static readonly IntPtr HKLM = new IntPtr(unchecked((int)0x80000002));
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern int RegCreateKeyExW(IntPtr hKey, string lpSubKey, int Reserved, string lpClass,
+        int dwOptions, int samDesired, IntPtr lpSecurityAttributes, out IntPtr phkResult,
+        out int lpdwDisposition);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern int RegDeleteKeyW(IntPtr hKey, string lpSubKey);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern int RegCloseKey(IntPtr hKey);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern int RegEnumValueW(IntPtr hKey, int dwIndex, StringBuilder lpValueName,
+        ref int lpcchValueName, IntPtr lpReserved, IntPtr lpType, IntPtr lpData, IntPtr lpcbData);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern int RegEnumKeyExW(IntPtr hKey, int dwIndex, StringBuilder lpName, ref int lpcchName,
+        IntPtr lpReserved, IntPtr lpClass, IntPtr lpcchClass, IntPtr lpftLastWriteTime);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern int RegQueryValueExW(IntPtr hKey, string lpValueName, IntPtr lpReserved,
+        out int lpType, byte[] lpData, ref int lpcbData);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern int RegDeleteValueW(IntPtr hKey, string lpValueName);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern int RegSetValueExW(IntPtr hKey, string lpValueName, int Reserved, int dwType,
+        byte[] lpData, int cbData);
+
+    // Opens an existing key through the backup path. Never leaves a key behind that it created:
+    // if the disposition says the key was new, it is deleted again and the call reports failure,
+    // so a caller can treat a non-zero result as "not there" without having changed anything.
+    static int Open(string subKey, bool forWrite, out IntPtr handle)
+    {
+        handle = IntPtr.Zero;
+        int disposition;
+        int access = forWrite ? (KEY_READ | KEY_WRITE) : KEY_READ;
+        int rc = RegCreateKeyExW(HKLM, subKey, 0, null, REG_OPTION_BACKUP_RESTORE, access,
+                                 IntPtr.Zero, out handle, out disposition);
+        if (rc != ERROR_SUCCESS) { handle = IntPtr.Zero; return rc; }
+        if (disposition == REG_CREATED_NEW_KEY)
+        {
+            RegCloseKey(handle);
+            RegDeleteKeyW(HKLM, subKey);
+            handle = IntPtr.Zero;
+            return ERROR_ALREADY_EXISTS;
+        }
+        return ERROR_SUCCESS;
+    }
+
+    public static int KeyExists(string subKey, out bool exists)
+    {
+        exists = false;
+        IntPtr h;
+        int rc = Open(subKey, false, out h);
+        if (rc == ERROR_ALREADY_EXISTS) { return ERROR_SUCCESS; }
+        if (rc != ERROR_SUCCESS) { return rc; }
+        RegCloseKey(h);
+        exists = true;
+        return ERROR_SUCCESS;
+    }
+
+    // Deliberately creates the key when it is absent, and says which happened. Kept separate from
+    // Open on purpose: Open guarantees that reading or correcting a value never adds anything to a
+    // machine that may be healthy, so the one operation allowed to add has to be asked for by name.
+    public static int CreateKey(string subKey, out bool created)
+    {
+        created = false;
+        IntPtr h;
+        int disposition;
+        int rc = RegCreateKeyExW(HKLM, subKey, 0, null, REG_OPTION_BACKUP_RESTORE,
+                                 KEY_READ | KEY_WRITE, IntPtr.Zero, out h, out disposition);
+        if (rc != ERROR_SUCCESS) { return rc; }
+        created = (disposition == REG_CREATED_NEW_KEY);
+        RegCloseKey(h);
+        return ERROR_SUCCESS;
+    }
+
+    public static int SubKeyNames(string subKey, out string[] names)
+    {
+        names = new string[0];
+        IntPtr h;
+        int rc = Open(subKey, false, out h);
+        if (rc != ERROR_SUCCESS) { return rc; }
+        try
+        {
+            List<string> found = new List<string>();
+            for (int i = 0; ; i++)
+            {
+                StringBuilder sb = new StringBuilder(256);
+                int len = sb.Capacity;
+                int r = RegEnumKeyExW(h, i, sb, ref len, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+                if (r == ERROR_NO_MORE_ITEMS) { break; }
+                if (r != ERROR_SUCCESS) { return r; }
+                found.Add(sb.ToString());
+            }
+            names = found.ToArray();
+            return ERROR_SUCCESS;
+        }
+        finally { RegCloseKey(h); }
+    }
+
+    public static int ValueNames(string subKey, out string[] names)
+    {
+        names = new string[0];
+        IntPtr h;
+        int rc = Open(subKey, false, out h);
+        if (rc != ERROR_SUCCESS) { return rc; }
+        try
+        {
+            List<string> found = new List<string>();
+            for (int i = 0; ; i++)
+            {
+                // 16383 characters is the documented maximum length of a value name.
+                StringBuilder sb = new StringBuilder(16384);
+                int len = sb.Capacity;
+                int r = RegEnumValueW(h, i, sb, ref len, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+                if (r == ERROR_NO_MORE_ITEMS) { break; }
+                if (r != ERROR_SUCCESS) { return r; }
+                found.Add(sb.ToString());
+            }
+            names = found.ToArray();
+            return ERROR_SUCCESS;
+        }
+        finally { RegCloseKey(h); }
+    }
+
+    public static int GetValue(string subKey, string name, out int type, out byte[] data)
+    {
+        type = 0;
+        data = null;
+        IntPtr h;
+        int rc = Open(subKey, false, out h);
+        if (rc != ERROR_SUCCESS) { return rc; }
+        try
+        {
+            int size = 0;
+            int r = RegQueryValueExW(h, name, IntPtr.Zero, out type, null, ref size);
+            if (r != ERROR_SUCCESS && r != ERROR_MORE_DATA) { return r; }
+            byte[] buffer = new byte[size];
+            r = RegQueryValueExW(h, name, IntPtr.Zero, out type, buffer, ref size);
+            if (r != ERROR_SUCCESS) { return r; }
+            data = buffer;
+            return ERROR_SUCCESS;
+        }
+        finally { RegCloseKey(h); }
+    }
+
+    public static int DeleteValue(string subKey, string name)
+    {
+        IntPtr h;
+        int rc = Open(subKey, true, out h);
+        if (rc != ERROR_SUCCESS) { return rc; }
+        try { return RegDeleteValueW(h, name); }
+        finally { RegCloseKey(h); }
+    }
+
+    // The caller supplies the type as well as the bytes. The LSA policy database stores the
+    // logon-right mask as REG_NONE, and rewriting it as REG_BINARY or REG_DWORD changes the shape
+    // of the value even when the four bytes are identical, so the type is never inferred here.
+    public static int SetValue(string subKey, string name, int type, byte[] data)
+    {
+        IntPtr h;
+        int rc = Open(subKey, true, out h);
+        if (rc != ERROR_SUCCESS) { return rc; }
+        try { return RegSetValueExW(h, name, 0, type, data, data.Length); }
+        finally { RegCloseKey(h); }
+    }
+}
+"@
+}
+
+function Get-OfflinePrivilegedRegistryValueName {
+    <#
+    .SYNOPSIS
+        Listing the value names under a key that may deny read to every account, SYSTEM included.
+
+    .DESCRIPTION
+        Returns an object rather than a bare list, because "the key holds no values" and "the key
+        could not be opened" are different answers and must not be confused. Ok is $false only when
+        something went wrong; a key that is genuinely absent comes back Ok with Exists $false.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $result = [PSCustomObject]@{ Ok = $false; Exists = $false; Names = @(); Error = '' }
+
+    $subKey = ConvertTo-OfflineNativeSubKey -Path $Path
+    if (-not $subKey) {
+        $result.Error = "$Path is not a path under HKLM."
+        return $result
+    }
+
+    [void](Enable-OfflineBackupPrivilege)
+    Initialize-OfflinePrivilegedRegistryType
+
+    $exists = $false
+    $rc = [OfflinePrivilegedRegistry]::KeyExists($subKey, [ref]$exists)
+    if ($rc -ne 0) {
+        $result.Error = "The key could not be opened (error $rc)."
+        return $result
+    }
+    if (-not $exists) {
+        $result.Ok = $true
+        return $result
+    }
+
+    $names = $null
+    $rc = [OfflinePrivilegedRegistry]::ValueNames($subKey, [ref]$names)
+    if ($rc -ne 0) {
+        $result.Exists = $true
+        $result.Error = "The key opened but its values could not be listed (error $rc)."
+        return $result
+    }
+
+    $result.Ok = $true
+    $result.Exists = $true
+    $result.Names = @($names)
+    return $result
+}
+
+function Get-OfflinePrivilegedRegistrySubKeyName {
+    <#
+    .SYNOPSIS
+        Listing the subkeys of a key that may deny read to every account, SYSTEM included.
+
+    .DESCRIPTION
+        The counterpart of Get-OfflinePrivilegedRegistryValueName, for callers that have to walk a
+        protected tree rather than read one key. The offline SECURITY hive is the case that needs
+        it: Policy\Accounts holds one subkey per account that has been granted a logon right or a
+        privilege, and neither the provider nor the .NET registry classes can enumerate it.
+
+        As with the value-name listing, "the key has no subkeys" and "the key could not be opened"
+        are different answers. Ok is $false only when something went wrong; a key that is genuinely
+        absent comes back Ok with Exists $false.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $result = [PSCustomObject]@{ Ok = $false; Exists = $false; Names = @(); Error = '' }
+
+    $subKey = ConvertTo-OfflineNativeSubKey -Path $Path
+    if (-not $subKey) {
+        $result.Error = "$Path is not a path under HKLM."
+        return $result
+    }
+
+    [void](Enable-OfflineBackupPrivilege)
+    Initialize-OfflinePrivilegedRegistryType
+
+    $exists = $false
+    $rc = [OfflinePrivilegedRegistry]::KeyExists($subKey, [ref]$exists)
+    if ($rc -ne 0) {
+        $result.Error = "The key could not be opened (error $rc)."
+        return $result
+    }
+    if (-not $exists) {
+        $result.Ok = $true
+        return $result
+    }
+
+    $names = $null
+    $rc = [OfflinePrivilegedRegistry]::SubKeyNames($subKey, [ref]$names)
+    if ($rc -ne 0) {
+        $result.Exists = $true
+        $result.Error = "The key opened but its subkeys could not be listed (error $rc)."
+        return $result
+    }
+
+    $result.Ok = $true
+    $result.Exists = $true
+    $result.Names = @($names)
+    return $result
+}
+
+function Get-OfflinePrivilegedRegistryValue {
+    <#
+    .SYNOPSIS
+        Reading one value from a key that may deny read to every account, SYSTEM included.
+
+    .DESCRIPTION
+        Returns the raw bytes and the registry type alongside a decoded value. The type matters as
+        much as the content for a caller deciding whether the value is well formed, and a decoded
+        string array cannot report either the type or the true byte length.
+
+        Strings decodes REG_SZ, REG_EXPAND_SZ and REG_MULTI_SZ. Anything else is left to Bytes.
+
+        Name accepts an empty string, which is how the Win32 registry API names a key's default
+        (unnamed) value. Without AllowEmptyString the binder rejects the call before the function
+        runs, which is not a theoretical concern: the offline SECURITY hive keeps the logon-right
+        mask in the default value of Policy\Accounts\<SID>\ActSysAc, so that is the only way to
+        read it.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Name
+    )
+
+    $result = [PSCustomObject]@{
+        Ok = $false; Found = $false; Type = 0; ByteLength = 0
+        Bytes = $null; Strings = @(); Error = ''
+    }
+
+    $subKey = ConvertTo-OfflineNativeSubKey -Path $Path
+    if (-not $subKey) {
+        $result.Error = "$Path is not a path under HKLM."
+        return $result
+    }
+
+    [void](Enable-OfflineBackupPrivilege)
+    Initialize-OfflinePrivilegedRegistryType
+
+    $type = 0
+    $bytes = $null
+    $rc = [OfflinePrivilegedRegistry]::GetValue($subKey, $Name, [ref]$type, [ref]$bytes)
+
+    # 2 is ERROR_FILE_NOT_FOUND, which the API returns both for a missing key and a missing value.
+    if ($rc -eq 2) {
+        $result.Ok = $true
+        return $result
+    }
+    if ($rc -ne 0) {
+        $result.Error = "$Name could not be read (error $rc)."
+        return $result
+    }
+
+    $result.Ok = $true
+    $result.Found = $true
+    $result.Type = $type
+    $result.Bytes = $bytes
+    $result.ByteLength = @($bytes).Count
+
+    # 1 REG_SZ, 2 REG_EXPAND_SZ, 7 REG_MULTI_SZ.
+    if ($type -in 1, 2, 7 -and $result.ByteLength -gt 1) {
+        $text = [System.Text.Encoding]::Unicode.GetString($bytes)
+        $result.Strings = @($text.Split([char]0) | Where-Object { $_.Length -gt 0 })
+    }
+
+    return $result
+}
+
+function Remove-OfflinePrivilegedRegistryValue {
+    <#
+    .SYNOPSIS
+        Removing one value from a key that may deny write to every account, SYSTEM included.
+
+    .DESCRIPTION
+        The key's owner and DACL are left exactly as they were found. Only the named value is
+        removed; the key itself and every other value under it survive.
+
+    .PARAMETER OfflineRoot
+        Optional explicit mounted-hive key to validate $Path against, forwarded to
+        Assert-OfflineTarget.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = ''
+    )
+
+    $result = [PSCustomObject]@{ Removed = $false; Error = '' }
+
+    $subKey = ConvertTo-OfflineNativeSubKey -Path $Path
+    if (-not $subKey) {
+        $result.Error = "$Path is not a path under HKLM."
+        return $result
+    }
+
+    # The gate before the backup-restore privilege is enabled: a well-formed HKLM path that is not
+    # under a mounted offline hive - the rescue VM's own live registry, say - is refused here rather
+    # than opened for write by privilege. Throws by design, because a privileged write that lands on
+    # the wrong hive is exactly the outcome this guards against.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'remove the offline registry value from')
+
+    if (-not $PSCmdlet.ShouldProcess("$Path\$Name", 'Remove registry value')) { return $result }
+
+    if (-not (Enable-OfflineBackupPrivilege)) {
+        $result.Error = 'SeBackupPrivilege or SeRestorePrivilege could not be enabled, so the guarded key cannot be opened for write.'
+        return $result
+    }
+    Initialize-OfflinePrivilegedRegistryType
+
+    $rc = [OfflinePrivilegedRegistry]::DeleteValue($subKey, $Name)
+    if ($rc -ne 0) {
+        $result.Error = "$Name could not be removed (error $rc)."
+        return $result
+    }
+
+    $result.Removed = $true
+    return $result
+}
+
+function New-OfflinePrivilegedRegistryKey {
+    <#
+    .SYNOPSIS
+        Creating a key under a hive that may deny write to every account, SYSTEM included.
+
+    .DESCRIPTION
+        Separate from Set-OfflinePrivilegedRegistryValue because creating a key is a different
+        promise from correcting a value. Everything else in this helper is built so that reading or
+        repairing cannot add anything to a machine that may be healthy; this is the one entry point
+        that adds, so a caller has to ask for it by name.
+
+        Reports whether the key was created or was already there, so a caller can tell a repair from
+        a no-op, and confirms the key is readable afterwards rather than trusting the return code.
+
+    .PARAMETER OfflineRoot
+        Optional explicit mounted-hive key to validate $Path against, forwarded to
+        Assert-OfflineTarget.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = ''
+    )
+
+    $result = [PSCustomObject]@{ Ok = $false; Created = $false; Error = '' }
+
+    $subKey = ConvertTo-OfflineNativeSubKey -Path $Path
+    if (-not $subKey) {
+        $result.Error = "$Path is not a path under HKLM."
+        return $result
+    }
+
+    # The gate before the backup-restore privilege is enabled: this is the one entry point that
+    # ADDS a key, so it must be certain the key lands in the mounted offline hive and never in the
+    # rescue VM's own registry. Throws by design when the target is not bound.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'create the offline registry key')
+
+    if (-not $PSCmdlet.ShouldProcess($Path, 'Create registry key')) { return $result }
+
+    if (-not (Enable-OfflineBackupPrivilege)) {
+        $result.Error = 'SeBackupPrivilege or SeRestorePrivilege could not be enabled, so the guarded key cannot be created.'
+        return $result
+    }
+    Initialize-OfflinePrivilegedRegistryType
+
+    $created = $false
+    $rc = [OfflinePrivilegedRegistry]::CreateKey($subKey, [ref]$created)
+    if ($rc -ne 0) {
+        $result.Error = "$Path could not be created (error $rc)."
+        return $result
+    }
+
+    $exists = $false
+    $check = [OfflinePrivilegedRegistry]::KeyExists($subKey, [ref]$exists)
+    if ($check -ne 0 -or -not $exists) {
+        $result.Error = "$Path does not read back as an existing key after being created."
+        return $result
+    }
+
+    $result.Created = $created
+    $result.Ok = $true
+    return $result
+}
+
+function Set-OfflinePrivilegedRegistryValue {
+    <#
+    .SYNOPSIS
+        Writing one value to a key that may deny write to every account, SYSTEM included.
+
+    .DESCRIPTION
+        The key's owner and DACL are left exactly as they were found: the write goes through the
+        backup-restore path rather than by granting anyone access, so nothing has to be put back
+        afterwards and a failure part way cannot leave the hive more permissive than it was.
+
+        Type is passed in rather than inferred. The offline SECURITY hive stores the logon-right
+        mask as REG_NONE (type 0), and writing the same four bytes back as REG_BINARY changes the
+        shape of the value even though the content matches.
+
+        Name accepts an empty string, which is how the Win32 registry API names a key's default
+        (unnamed) value - the only place the ActSysAc mask exists.
+
+        Bytes accepts an empty array for the same reason: a zero-length value is a real thing in
+        this hive. LSA leaves exactly one on each Policy\Accounts\<SID> key, so recreating an
+        account entry that matches what LSA itself writes has to be able to write nothing. A
+        mandatory [byte[]] rejects an empty array outright, which is why it is allowed explicitly.
+
+        The value is read back and compared byte for byte before success is reported. A silent
+        write failure on a protected hive would otherwise be indistinguishable from a repair.
+
+    .PARAMETER OfflineRoot
+        Optional explicit mounted-hive key to validate $Path against, forwarded to
+        Assert-OfflineTarget.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Name,
+        [Parameter(Mandatory = $true)][int]$Type,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][byte[]]$Bytes,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = ''
+    )
+
+    $result = [PSCustomObject]@{ Written = $false; Error = '' }
+
+    $subKey = ConvertTo-OfflineNativeSubKey -Path $Path
+    if (-not $subKey) {
+        $result.Error = "$Path is not a path under HKLM."
+        return $result
+    }
+
+    # The gate before the backup-restore privilege is enabled: a well-formed HKLM path that is not
+    # under a mounted offline hive is refused here rather than opened for write. Throws by design.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'write to the offline registry value at')
+
+    if (-not $PSCmdlet.ShouldProcess("$Path\$Name", 'Set registry value')) { return $result }
+
+    if (-not (Enable-OfflineBackupPrivilege)) {
+        $result.Error = 'SeBackupPrivilege or SeRestorePrivilege could not be enabled, so the guarded key cannot be opened for write.'
+        return $result
+    }
+    Initialize-OfflinePrivilegedRegistryType
+
+    $rc = [OfflinePrivilegedRegistry]::SetValue($subKey, $Name, $Type, $Bytes)
+    if ($rc -ne 0) {
+        $result.Error = "$(if ([string]::IsNullOrEmpty($Name)) { 'the default value' } else { $Name }) could not be written (error $rc)."
+        return $result
+    }
+
+    $readBack = Get-OfflinePrivilegedRegistryValue -Path $Path -Name $Name
+    if (-not $readBack.Ok -or -not $readBack.Found) {
+        $result.Error = "$Name was written but could not be read back."
+        return $result
+    }
+    if ($readBack.Type -ne $Type) {
+        $result.Error = "$Name reads back as type $($readBack.Type) instead of $Type."
+        return $result
+    }
+    if (@($readBack.Bytes).Count -ne $Bytes.Count) {
+        $result.Error = "$Name reads back as $($readBack.ByteLength) byte(s) instead of $($Bytes.Count)."
+        return $result
+    }
+    for ($i = 0; $i -lt $Bytes.Count; $i++) {
+        if ($readBack.Bytes[$i] -ne $Bytes[$i]) {
+            $result.Error = "$Name reads back with different content at byte $i."
+            return $result
+        }
+    }
+
+    $result.Written = $true
+    return $result
+}

--- a/src/windows/common/helpers/Use-OfflineProtectedResource.ps1
+++ b/src/windows/common/helpers/Use-OfflineProtectedResource.ps1
@@ -1,0 +1,1600 @@
+<#
+.SYNOPSIS
+    Taking ownership of a TrustedInstaller-owned file, folder or offline registry key just long
+    enough to repair it, and putting the original security descriptor back afterwards.
+
+.DESCRIPTION
+    The servicing state a repair has to reach is deliberately protected. WinSxS is owned by
+    NT SERVICE\TrustedInstaller and denies write even to Administrators, and the CBS pending keys
+    carry their own ACL that denies delete. Running as SYSTEM is not enough: SYSTEM is not the
+    owner, and only the owner can rewrite a DACL.
+
+    Measured on a real Server 2022 disk with servicing markers planted, an offline repair running
+    as SYSTEM could not rename WinSxS\pending.xml and could not delete CBS\PackagesPending or
+    CBS\RebootPending. Every attempt failed, and the run still reported success.
+
+    This helper closes that gap without leaving the disk less protected than it found it:
+
+      1. The original descriptor is captured first, including owner and group. Registry keys, and
+         this file's own copy, rename and delete paths, capture it in BINARY form, which round-trips
+         losslessly where an SDDL string re-resolves machine-relative aliases (LA, DA, DU, DC)
+         against the rescue VM's own SIDs. Measured: LA came back as the rescue VM's own local
+         administrator rather than the offline image's, and DA, DU and DC could not be parsed at all
+         on a workgroup machine - the alias needs a domain to resolve against, which a rescue VM
+         does not have. An SDDL capture is still offered for the scenarios that consume it as a
+         string.
+
+      2. Ownership is taken, and only then is an access rule added - a DACL cannot be written by
+         an account that does not own the object.
+
+      3. The captured descriptor is replayed WHOLE afterwards. It is never rebuilt rule by rule,
+         and the granted ACE is never removed individually. Both of those approaches also drop
+         the ACEs Windows shipped, which silently damages WinSxS and the component store. Replay
+         restores the owner as well, so TrustedInstaller gets its object back.
+
+      4. Ownership is only taken when it is actually needed. Every operation is attempted plainly
+         first and the result is verified; the elevated path runs only if the plain one was
+         refused. On a disk where the ACLs are already permissive, nothing is touched at all.
+
+    Restoring an owner that is not the current account requires SeRestorePrivilege, and taking an
+    owner requires SeTakeOwnershipPrivilege, so both are enabled up front. Without SeRestore the
+    object could be taken but never handed back, which is the worst of the three outcomes.
+
+.NOTES
+    Registry handles are closed explicitly and the finalizer queue is drained before returning.
+    A single leaked RegistryKey handle makes the later 'reg unload' fail, which strands the
+    offline hive mounted under HKLM on the rescue VM.
+
+.VERSION
+    1.0  Capture the descriptor, take ownership, repair, and replay the descriptor whole.
+
+    1.1  Hardened after the PR #143 review:
+         - Every function that writes, deletes, takes ownership or changes a security descriptor
+           now calls Assert-OfflineTarget BEFORE any privilege is enabled, so a privileged operation
+           cannot land on the rescue VM's own disk or hive if an upstream precondition degrades. The
+           public entry points take an optional -OfflineRoot to state the binding explicitly.
+         - Registry descriptors are captured and replayed in BINARY rather than SDDL, so the P/AI
+           control flags and machine-relative SIDs survive the round-trip; the file paths do the
+           same through an optional binary capture while still returning SDDL for external callers.
+         - Every restore is verified by reading the descriptor back and comparing owner, DACL and
+           protection; a key that cannot be reopened to restore is reported, not silently skipped.
+         - A value removal reports success only once the value is verified gone, and the key's
+           descriptor is put back even when taking ownership throws part way through.
+#>
+
+$script:OfflinePrivilegeReady = $false
+$script:OfflineBackupPrivilegeReady = $false
+
+# Owner, Group and Access. SACL is deliberately not captured or replayed: reading it needs
+# SeSecurityPrivilege and writing it back can fail on its own, and nothing here changes auditing.
+$script:OfflineSecuritySection = 'Owner,Group,Access'
+
+# The same three sections as the enum the binary security APIs take. Binary capture and replay is
+# used wherever this file restores its own descriptors, because it is lossless where the SDDL string
+# above is not: SDDL re-resolves machine-relative aliases against whatever machine parses it.
+$script:OfflineSecuritySections = [System.Security.AccessControl.AccessControlSections]::Owner -bor
+    [System.Security.AccessControl.AccessControlSections]::Group -bor
+    [System.Security.AccessControl.AccessControlSections]::Access
+
+# Resolve the offline-repair core against this file's own folder, so a scenario loads the same
+# helper wherever it dot-sources this from, and fail loudly here rather than at the first
+# privileged call. Assert-OfflineTarget is the gate every ownership path in this file depends on:
+# discovering it is missing halfway through taking ownership of a key is far worse than refusing
+# to load.
+if (-not (Get-Command -Name Assert-OfflineTarget -ErrorAction SilentlyContinue)) {
+    $dependencyPath = Join-Path -Path $PSScriptRoot -ChildPath 'OfflineRepairCommon.ps1'
+    try {
+        . $dependencyPath
+    }
+    catch {
+        throw "Use-OfflineProtectedResource.ps1 could not load its dependency OfflineRepairCommon.ps1 from '$dependencyPath': $($_.Exception.Message)"
+    }
+}
+foreach ($required in @('Assert-OfflineTarget', 'Add-OfflineRepairLog')) {
+    if (-not (Get-Command -Name $required -ErrorAction SilentlyContinue)) {
+        throw "Use-OfflineProtectedResource.ps1 requires '$required', which OfflineRepairCommon.ps1 did not define."
+    }
+}
+
+function Initialize-OfflinePrivilegeType {
+    <#
+    .SYNOPSIS
+        Compiling the token-privilege helper both privilege paths use.
+
+    .DESCRIPTION
+        Separate from the functions that enable privileges so that the ownership path and the
+        backup path share one type rather than each carrying a copy of the same P/Invoke.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if (-not ('OfflineRepairPrivilege' -as [type])) {
+        Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class OfflineRepairPrivilege
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct LUID { public uint LowPart; public int HighPart; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct LUID_AND_ATTRIBUTES { public LUID Luid; public uint Attributes; }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct TOKEN_PRIVILEGES { public uint PrivilegeCount; public LUID_AND_ATTRIBUTES Privilege; }
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool OpenProcessToken(IntPtr process, uint access, out IntPtr token);
+
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    static extern bool LookupPrivilegeValue(string system, string name, out LUID luid);
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    static extern bool AdjustTokenPrivileges(IntPtr token, bool disableAll, ref TOKEN_PRIVILEGES state, uint length, IntPtr previous, IntPtr returnLength);
+
+    [DllImport("kernel32.dll")]
+    static extern IntPtr GetCurrentProcess();
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern bool CloseHandle(IntPtr handle);
+
+    public static bool Enable(string privilegeName)
+    {
+        IntPtr token;
+        if (!OpenProcessToken(GetCurrentProcess(), 0x0020u | 0x0008u, out token)) { return false; }
+        try
+        {
+            LUID luid;
+            if (!LookupPrivilegeValue(null, privilegeName, out luid)) { return false; }
+            TOKEN_PRIVILEGES tp = new TOKEN_PRIVILEGES();
+            tp.PrivilegeCount = 1;
+            tp.Privilege.Luid = luid;
+            tp.Privilege.Attributes = 0x00000002u;
+            if (!AdjustTokenPrivileges(token, false, ref tp, 0, IntPtr.Zero, IntPtr.Zero)) { return false; }
+            return Marshal.GetLastWin32Error() == 0;
+        }
+        finally { CloseHandle(token); }
+    }
+}
+'@
+    }
+}
+
+function Enable-OfflineOwnershipPrivilege {
+    <#
+    .SYNOPSIS
+        Enabling the token privileges that taking and returning ownership need.
+
+    .DESCRIPTION
+        SeTakeOwnershipPrivilege allows taking an object whose DACL denies WRITE_OWNER.
+        SeRestorePrivilege allows setting the owner to somebody other than the caller, which is
+        what putting TrustedInstaller back requires.
+        SeBackupPrivilege and SeSecurityPrivilege allow reading a descriptor the DACL would
+        otherwise hide, so the capture is complete before anything is changed.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ($script:OfflinePrivilegeReady) { return }
+
+    Initialize-OfflinePrivilegeType
+
+    foreach ($privilege in @('SeTakeOwnershipPrivilege', 'SeRestorePrivilege', 'SeBackupPrivilege', 'SeSecurityPrivilege')) {
+        if (-not [OfflineRepairPrivilege]::Enable($privilege)) {
+            Add-OfflineRepairLog -Level Info -Message "$privilege could not be enabled. It is not held by this token, so a protected object may stay protected."
+        }
+    }
+
+    $script:OfflinePrivilegeReady = $true
+}
+
+function Enable-OfflineBackupPrivilege {
+    <#
+    .SYNOPSIS
+        Enabling only the two privileges that reading and writing a key through the backup path needs.
+
+    .DESCRIPTION
+        Deliberately narrower than Enable-OfflineOwnershipPrivilege: it does not enable
+        SeTakeOwnershipPrivilege, so a detection pass that only ever reads cannot accidentally
+        acquire the right to take an object it was only meant to look at.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    if ($script:OfflineBackupPrivilegeReady) { return $true }
+
+    Initialize-OfflinePrivilegeType
+
+    $ok = $true
+    foreach ($privilege in @('SeBackupPrivilege', 'SeRestorePrivilege')) {
+        if (-not [OfflineRepairPrivilege]::Enable($privilege)) {
+            $ok = $false
+            Add-OfflineRepairLog -Level Info -Message "$privilege could not be enabled. A key whose DACL denies this account will stay unreadable."
+        }
+    }
+
+    $script:OfflineBackupPrivilegeReady = $ok
+    return $ok
+}
+
+function Get-OfflineCurrentUserSid {
+    <#
+    .SYNOPSIS
+        The SID this process runs as, which is the account ownership is taken by.
+    #>
+    [CmdletBinding()]
+    param()
+
+    return ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User
+}
+
+function ConvertTo-OfflineNativeSubKey {
+    <#
+    .SYNOPSIS
+        Turning a PowerShell registry path into the subkey string the Win32 registry APIs want.
+
+    .DESCRIPTION
+        The provider hands back three shapes depending on how a key was reached, and the .NET
+        RegistryKey APIs accept none of them: they want the path below the hive with no root.
+        Returns $null for anything that is not under HKLM, because every offline hive this
+        library mounts is mounted there.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if ($Path -match 'HKEY_LOCAL_MACHINE\\(.+)$') { return $Matches[1] }
+    if ($Path -match '^HKLM:\\(.+)$') { return $Matches[1] }
+    if ($Path -match '^HKLM\\(.+)$') { return $Matches[1] }
+    return $null
+}
+
+function Get-OfflineRawOwner {
+    <#
+    .SYNOPSIS
+        Reading just the owner SID out of a binary security descriptor.
+
+    .DESCRIPTION
+        Used to decide whether the owner still needs replaying. Comparing the captured owner with
+        the current one avoids a privileged owner-write when the owner never changed. Returns an
+        empty string when there is no owner or the descriptor cannot be parsed.
+
+    .OUTPUTS
+        [string] the owner SID in S-1-... form, or an empty string.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([byte[]]$BinaryDescriptor)
+
+    if (-not $BinaryDescriptor -or $BinaryDescriptor.Length -eq 0) { return '' }
+    try {
+        $raw = [System.Security.AccessControl.RawSecurityDescriptor]::new($BinaryDescriptor, 0)
+        if ($raw.Owner) { return $raw.Owner.Value }
+        return ''
+    }
+    catch { return '' }
+}
+
+function Test-OfflineDescriptorMatch {
+    <#
+    .SYNOPSIS
+        Confirming a descriptor read back after a restore matches the one that was captured.
+
+    .DESCRIPTION
+        A restore is not trusted until it is verified, the same way a privileged value write is read
+        back and byte-compared before it is called done. Raw self-relative bytes are not compared
+        whole, because two equivalent descriptors can be laid out differently; instead the owner, the
+        protected (P) and auto-inherited (AI) control flags, and every DACL ACE (compared by its own
+        binary form, in canonical order) are checked. Those are exactly the parts an SDDL round-trip
+        used to corrupt, so a mismatch here is a real restore failure, not a layout artefact.
+
+        Returns $true only when both descriptors parse and every compared part is identical.
+
+    .OUTPUTS
+        [bool]
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [byte[]]$Captured,
+        [byte[]]$ReadBack
+    )
+
+    if (-not $Captured -or -not $ReadBack) { return $false }
+    try {
+        $a = [System.Security.AccessControl.RawSecurityDescriptor]::new($Captured, 0)
+        $b = [System.Security.AccessControl.RawSecurityDescriptor]::new($ReadBack, 0)
+
+        if ("$($a.Owner)" -ne "$($b.Owner)") { return $false }
+
+        $mask = [System.Security.AccessControl.ControlFlags]'DiscretionaryAclProtected, DiscretionaryAclAutoInherited'
+        if (($a.ControlFlags -band $mask) -ne ($b.ControlFlags -band $mask)) { return $false }
+
+        $da = $a.DiscretionaryAcl
+        $db = $b.DiscretionaryAcl
+        if (($null -eq $da) -ne ($null -eq $db)) { return $false }
+        if ($da) {
+            if ($da.Count -ne $db.Count) { return $false }
+            for ($i = 0; $i -lt $da.Count; $i++) {
+                if ($da[$i].BinaryLength -ne $db[$i].BinaryLength) { return $false }
+                $xb = [byte[]]::new($da[$i].BinaryLength)
+                $yb = [byte[]]::new($db[$i].BinaryLength)
+                $da[$i].GetBinaryForm($xb, 0)
+                $db[$i].GetBinaryForm($yb, 0)
+                for ($j = 0; $j -lt $xb.Length; $j++) {
+                    if ($xb[$j] -ne $yb[$j]) { return $false }
+                }
+            }
+        }
+        return $true
+    }
+    catch { return $false }
+}
+
+function Get-OfflineRegistryKeySecurity {
+    <#
+    .SYNOPSIS
+        Capturing a registry key's owner, group and DACL in binary form, before anything is changed.
+
+    .DESCRIPTION
+        Returns the descriptor as a byte array, or $null when it cannot be read. Binary is used
+        rather than SDDL because a descriptor captured on the rescue VM and replayed against an
+        offline hive has to survive the round-trip exactly: an SDDL string re-resolves the
+        machine-relative aliases (LA, DA, DU, DC) against the machine that parses it. Measured on a
+        workgroup host, LA silently became that host's own administrator SID, and DA, DU and DC
+        threw outright because there is no domain to resolve them against. The binary form carries
+        the raw SIDs and the exact control bits, so none of that happens.
+
+        A caller that gets $null must not take ownership: without a capture there is nothing to put
+        back, and an object left owned by SYSTEM with an extra FullControl ACE is a permanent change
+        to a system it was only meant to borrow.
+
+    .OUTPUTS
+        [byte[]] the descriptor's Owner, Group and DACL in self-relative binary form, or $null.
+    #>
+    [CmdletBinding()]
+    [OutputType([byte[]])]
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $subKey = ConvertTo-OfflineNativeSubKey -Path $Path
+    if (-not $subKey) { return $null }
+
+    $key = $null
+    try {
+        $rights = [System.Security.AccessControl.RegistryRights]::ReadPermissions
+        $key = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey(
+            $subKey, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadSubTree, $rights)
+        if (-not $key) { return $null }
+
+        return $key.GetAccessControl($script:OfflineSecuritySections).GetSecurityDescriptorBinaryForm()
+    }
+    catch { return $null }
+    finally { if ($key) { $key.Close() } }
+}
+
+function Grant-OfflineRegistryKeyAccess {
+    <#
+    .SYNOPSIS
+        Taking ownership of an offline hive key and everything below it, capturing what was there.
+
+    .DESCRIPTION
+        Deleting a key requires delete rights on that key AND on every subkey beneath it, so the
+        whole subtree is covered rather than just the top. The parent is taken first, because its
+        children cannot be enumerated reliably until it is readable.
+
+        -NoRecurse covers the key alone. Use it when the target is a value rather than the key,
+        because removing a value needs rights on its own key only - and because recursing a key
+        like COMPONENTS would walk the entire component store to no purpose.
+
+        Assert-OfflineTarget runs before any privilege is enabled, so a key outside the mounted
+        offline hive is refused before ownership is ever taken. That gate is the whole point of the
+        helper: a privileged take-and-modify can only ever reach the offline image, never the rescue
+        VM's own registry, even if an upstream precondition silently degrades.
+
+        Each captured descriptor is appended to -CapturedInto, if the caller supplies a list, as it
+        is taken. That way a throw part way through a subtree still leaves the caller holding
+        everything captured so far to restore, instead of the whole capture being lost with a return
+        value that never arrived. The same list is returned for callers that do not pass one.
+
+        Descriptors are captured in binary (see Get-OfflineRegistryKeySecurity) so the replay is
+        lossless. A key whose descriptor could not be captured is skipped rather than taken.
+
+    .PARAMETER Path
+        The offline hive key to take. Must resolve under a registered mounted hive.
+
+    .PARAMETER NoRecurse
+        Take only this key, not the subtree below it.
+
+    .PARAMETER OfflineRoot
+        Optional explicit mounted-hive key to validate $Path against instead of the registered
+        mount(s). Forwarded to Assert-OfflineTarget.
+
+    .PARAMETER CapturedInto
+        Optional caller-owned list that each captured descriptor is appended to as it is taken, so a
+        partial capture survives a mid-subtree throw.
+
+    .OUTPUTS
+        [System.Collections.Generic.List[object]] the captured descriptors, oldest first.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Collections.Generic.List[object]])]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [switch]$NoRecurse,
+        [string]$OfflineRoot = '',
+        [System.Collections.Generic.List[object]]$CapturedInto
+    )
+
+    # The gate first, before a single privilege is enabled: if the path is not under a mounted
+    # offline hive this throws, and nothing is taken.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'take ownership of')
+
+    Enable-OfflineOwnershipPrivilege
+    $me = Get-OfflineCurrentUserSid
+    $captured = if ($CapturedInto) { $CapturedInto } else { [System.Collections.Generic.List[object]]::new() }
+
+    # Enumerate before changing anything: the recursion below opens provider handles, and doing
+    # that after ownership changes has been written makes a partial failure harder to unwind.
+    $targets = [System.Collections.Generic.List[string]]::new()
+    [void]$targets.Add($Path)
+    if (-not $NoRecurse) {
+        foreach ($child in @(Get-ChildItem -LiteralPath $Path -Recurse -ErrorAction SilentlyContinue)) {
+            [void]$targets.Add($child.PSPath)
+        }
+    }
+
+    foreach ($target in $targets) {
+        $subKey = ConvertTo-OfflineNativeSubKey -Path $target
+        if (-not $subKey) { continue }
+
+        $descriptor = Get-OfflineRegistryKeySecurity -Path $target
+        if (-not $descriptor) {
+            Add-OfflineRepairLog -Level Info -Message "Could not read the security descriptor of $subKey, so its ownership was left alone."
+            continue
+        }
+
+        $ownerKey = $null
+        try {
+            $ownerKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey(
+                $subKey,
+                [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree,
+                [System.Security.AccessControl.RegistryRights]::TakeOwnership)
+            if ($ownerKey) {
+                # Only the owner is set on this descriptor, so only the owner section is written
+                # and the existing DACL survives until it is deliberately changed below.
+                $ownerOnly = [System.Security.AccessControl.RegistrySecurity]::new()
+                $ownerOnly.SetOwner($me)
+                $ownerKey.SetAccessControl($ownerOnly)
+            }
+        }
+        catch {
+            Add-OfflineRepairLog -Level Info -Message "Could not take ownership of $subKey : $($_.Exception.Message)"
+        }
+        finally { if ($ownerKey) { $ownerKey.Close() } }
+
+        $accessKey = $null
+        try {
+            $rights = [System.Security.AccessControl.RegistryRights]::ReadPermissions -bor
+                      [System.Security.AccessControl.RegistryRights]::ChangePermissions
+            $accessKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey(
+                $subKey, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree, $rights)
+            if ($accessKey) {
+                $access = $accessKey.GetAccessControl([System.Security.AccessControl.AccessControlSections]::Access)
+                $access.AddAccessRule([System.Security.AccessControl.RegistryAccessRule]::new(
+                        $me, 'FullControl', 'None', 'None', 'Allow'))
+                $accessKey.SetAccessControl($access)
+            }
+        }
+        catch {
+            Add-OfflineRepairLog -Level Info -Message "Could not grant access on $subKey : $($_.Exception.Message)"
+        }
+        finally { if ($accessKey) { $accessKey.Close() } }
+
+        [void]$captured.Add([PSCustomObject]@{ Path = $target; SubKey = $subKey; Descriptor = $descriptor })
+    }
+
+    # The provider opens keys of its own while enumerating. Releasing them here is what keeps the
+    # later 'reg unload' from failing and stranding the hive mounted on the rescue VM.
+    [System.GC]::Collect()
+    [System.GC]::WaitForPendingFinalizers()
+
+    return $captured
+}
+
+function Restore-OfflineRegistrySecurity {
+    <#
+    .SYNOPSIS
+        Replaying captured registry descriptors, so every key that survives is as it was found.
+
+    .DESCRIPTION
+        Keys that no longer exist are skipped, because a key that was successfully deleted has
+        nothing to restore - that is the normal outcome, not an error. The descriptor is replayed
+        whole from its binary capture rather than by removing the ACE that was added, which also
+        puts the owner back and cannot be corrupted by SDDL alias re-resolution.
+
+        Each restore is verified by reading the descriptor back and comparing owner, DACL and
+        protection (see Test-OfflineDescriptorMatch). A key that cannot be reopened, rewritten or
+        verified is reported with a Warning and a subinacl hint, because leaving it owned by this
+        account with an added ACE is a lasting change to the offline image, not a clean outcome.
+
+        Returns the number of keys whose descriptor was replayed AND verified.
+    #>
+    [CmdletBinding()]
+    [OutputType([int])]
+    param([Parameter(Mandatory = $true)][AllowEmptyCollection()][object[]]$Captured)
+
+    Enable-OfflineOwnershipPrivilege
+    $restored = 0
+
+    # Deepest first: a parent's DACL may deny what a child still needs to be written.
+    $ordered = @($Captured | Sort-Object -Property { ($_.SubKey -split '\\').Count } -Descending)
+
+    foreach ($entry in $ordered) {
+        if (-not $entry.SubKey -or -not $entry.Descriptor) { continue }
+
+        $key = $null
+        try {
+            $rights = [System.Security.AccessControl.RegistryRights]::ReadPermissions -bor
+                      [System.Security.AccessControl.RegistryRights]::ChangePermissions -bor
+                      [System.Security.AccessControl.RegistryRights]::TakeOwnership
+            $key = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey(
+                $entry.SubKey, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree, $rights)
+            if (-not $key) {
+                # OpenSubKey returns null only for a key that does not exist; an existing key we may
+                # not open throws instead and is handled by the catch below. A key captured and then
+                # deleted on purpose - the whole subtree beneath a removed key - is the normal
+                # outcome and has nothing to restore, so it is skipped silently. But a key that is
+                # still present yet came back null is one we failed to reopen: leaving it owned by
+                # this account with the added ACE is a lasting change to the offline image, so it is
+                # reported rather than passed over.
+                if (Test-Path -LiteralPath $entry.Path) {
+                    Add-OfflineRepairLog -Level Warning -Message "Could not reopen $($entry.SubKey) to restore its original ACL, so it is left owned by this account. Restore it by hand with: subinacl /keyreg `"$($entry.SubKey)`" /setowner=`"NT SERVICE\TrustedInstaller`""
+                }
+                continue
+            }
+
+            $sd = [System.Security.AccessControl.RegistrySecurity]::new()
+            $sd.SetSecurityDescriptorBinaryForm($entry.Descriptor, $script:OfflineSecuritySections)
+            $key.SetAccessControl($sd)
+
+            # Trust nothing: read the descriptor back and compare it to the capture, the same way a
+            # privileged value write is read back and byte-compared before it is called done.
+            $readBack = Get-OfflineRegistryKeySecurity -Path $entry.Path
+            if ($readBack -and (Test-OfflineDescriptorMatch -Captured $entry.Descriptor -ReadBack $readBack)) {
+                $restored++
+            }
+            else {
+                Add-OfflineRepairLog -Level Warning -Message "The original ACL was written back to $($entry.SubKey) but did not read back identically, so it cannot be counted as restored. Check it by hand with: subinacl /keyreg `"$($entry.SubKey)`" /display"
+            }
+        }
+        catch {
+            Add-OfflineRepairLog -Level Warning -Message "Could not restore the original ACL on $($entry.SubKey): $($_.Exception.Message). Restore it by hand with: subinacl /keyreg `"$($entry.SubKey)`" /setowner=`"NT SERVICE\TrustedInstaller`""
+        }
+        finally { if ($key) { $key.Close() } }
+    }
+
+    [System.GC]::Collect()
+    [System.GC]::WaitForPendingFinalizers()
+
+    return $restored
+}
+
+function Invoke-OfflineKeyDeleteAttempt {
+    <#
+    .SYNOPSIS
+        Deleting a key and reporting why if it is refused.
+
+    .DESCRIPTION
+        Remove-Item with -ErrorAction SilentlyContinue throws the reason away and leaves the caller
+        unable to tell an access-denied delete from a key that was never there. The attempt is made
+        with -ErrorAction Stop instead and the result is still confirmed by re-reading the path,
+        because a provider that reports no error is not proof that the key has gone.
+
+        Returns an object with Removed and Reason.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    try {
+        Remove-Item -LiteralPath $Path -Recurse -Force -ErrorAction Stop
+    }
+    catch {
+        if (-not (Test-Path -LiteralPath $Path)) {
+            return [PSCustomObject]@{ Removed = $true; Reason = '' }
+        }
+        return [PSCustomObject]@{ Removed = $false; Reason = $_.Exception.Message }
+    }
+
+    if (Test-Path -LiteralPath $Path) {
+        return [PSCustomObject]@{ Removed = $false; Reason = 'the delete reported no error but the key is still present' }
+    }
+    return [PSCustomObject]@{ Removed = $true; Reason = '' }
+}
+
+function Invoke-OfflineProtectedKeyRemoval {
+    <#
+    .SYNOPSIS
+        Deleting an offline hive key, taking ownership only if the plain delete is refused.
+
+    .DESCRIPTION
+        The plain attempt runs first and its result is verified by re-reading the path, because a
+        delete that is refused must not be mistaken for one that succeeded. Ownership is taken only
+        when that verification says the key is still there.
+
+        Both the key and its parent are taken. Deleting a key is a write against the key that
+        contains it, so rights on the key alone are not enough - measured on Server 2022, a
+        PackagesPending key owned by SYSTEM with FullControl on itself is still refused while its
+        parent grants SYSTEM only KEY_READ. The parent is taken without recursing, so no sibling
+        of the target is touched.
+
+        A key that is successfully deleted has nothing to put back, but the parent always survives
+        and so is always restored. Restore-OfflineRegistrySecurity works deepest first, which puts
+        the parent back last - while its rights are still in place for the children beneath it.
+
+        Returns an object with Removed, TookOwnership, Restored and Reason.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [string]$Label = '',
+        [string]$OfflineRoot = ''
+    )
+
+    if (-not $Label) { $Label = $Path }
+
+    # The gate before the plain delete below, which is itself a mutation: refuse a key that is not
+    # under the mounted offline hive before anything is attempted against it.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'delete the offline registry key')
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return [PSCustomObject]@{ Removed = $true; TookOwnership = $false; Restored = 0; Reason = 'The key was not present.' }
+    }
+
+    $plain = Invoke-OfflineKeyDeleteAttempt -Path $Path
+    if ($plain.Removed) {
+        return [PSCustomObject]@{ Removed = $true; TookOwnership = $false; Restored = 0; Reason = 'Removed without changing any permission.' }
+    }
+
+    Add-OfflineRepairLog -Level Info -Message "$Label could not be removed as it stands ($($plain.Reason)). Taking ownership of it and of the key that contains it, deleting, and putting both back."
+
+    $captured = [System.Collections.Generic.List[object]]::new()
+    try {
+        # The parent first: until it is writable the delete is refused no matter what the target
+        # itself grants. -NoRecurse keeps the grant off every sibling of the target.
+        $parent = Split-Path -Path $Path -Parent
+        if ($parent -and (ConvertTo-OfflineNativeSubKey -Path $parent)) {
+            [void](Grant-OfflineRegistryKeyAccess -Path $parent -NoRecurse -OfflineRoot $OfflineRoot -CapturedInto $captured)
+        }
+        [void](Grant-OfflineRegistryKeyAccess -Path $Path -OfflineRoot $OfflineRoot -CapturedInto $captured)
+    }
+    catch {
+        $undone = Restore-OfflineRegistrySecurity -Captured $captured.ToArray()
+        return [PSCustomObject]@{ Removed = $false; TookOwnership = $true; Restored = $undone; Reason = "Ownership could not be taken: $($_.Exception.Message)" }
+    }
+
+    $owned = Invoke-OfflineKeyDeleteAttempt -Path $Path
+
+    # Always restore. On success only the parent is left to put back, because the keys below it no
+    # longer exist and Restore-OfflineRegistrySecurity skips what has gone.
+    $restored = Restore-OfflineRegistrySecurity -Captured $captured.ToArray()
+
+    if ($owned.Removed) {
+        return [PSCustomObject]@{
+            Removed       = $true
+            TookOwnership = $true
+            Restored      = $restored
+            Reason        = "Removed after taking ownership. $restored surviving descriptor(s) were put back."
+        }
+    }
+
+    return [PSCustomObject]@{
+        Removed       = $false
+        TookOwnership = $true
+        Restored      = $restored
+        Reason        = "The key survived even after ownership was taken ($($owned.Reason)). $restored descriptor(s) were put back."
+    }
+}
+
+function Invoke-OfflineProtectedValueRemoval {
+    <#
+    .SYNOPSIS
+        Removing a value from an offline hive key, taking the key only if the plain remove fails.
+
+    .DESCRIPTION
+        The difference from a key removal is that the key survives, so the descriptor MUST be put
+        back - there is no "it is gone, so there is nothing to restore" shortcut here. The restore
+        runs in a finally, on every path.
+
+        Only the key itself is taken, never its subkeys: removing a value needs rights on its own
+        key. COMPONENTS is the caller this matters for, and recursing it would walk the whole
+        component store for no benefit.
+
+        The caller supplies a test rather than a comparison value, because "still set" for these
+        markers means non-zero rather than merely present.
+
+        Both the plain remove and the owned remove run with -ErrorAction Stop. A refused remove is
+        caught and escalated rather than swallowed, so a value that only reads back as gone because
+        its key denies read is never mistaken for one that was removed, and success is reported only
+        once the value is verified gone. If taking ownership throws part way, the key's descriptor is
+        still put back, mirroring the write counterpart.
+
+        Assert-OfflineTarget runs before any remove, so a value whose key is not under the mounted
+        offline hive is refused before anything is attempted.
+
+    .PARAMETER OfflineRoot
+        Optional explicit mounted-hive key to validate $Path against, forwarded to the gate and the
+        ownership grant.
+
+    .OUTPUTS
+        [PSCustomObject] with Removed, TookOwnership, Restored and Reason.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][scriptblock]$StillSet,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = ''
+    )
+
+    # The gate before the plain remove below, which mutates: refuse a value whose key is not under
+    # the mounted offline hive before anything is attempted.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'remove the offline registry value from')
+
+    $read = { (Get-ItemProperty -Path $Path -ErrorAction SilentlyContinue).$Name }
+
+    if (-not (& $StillSet (& $read))) {
+        return [PSCustomObject]@{ Removed = $true; TookOwnership = $false; Restored = 0; Reason = 'The value was not set.' }
+    }
+
+    # -ErrorAction Stop, not SilentlyContinue: a refused remove has to be told apart from a real
+    # one. An access-denied failure falls through to the ownership path; any other failure is the
+    # honest answer and is rethrown, exactly as the write counterpart does.
+    $deniedPlain = $false
+    try {
+        Remove-ItemProperty -Path $Path -Name $Name -Force -ErrorAction Stop
+    }
+    catch {
+        if (Test-OfflineRegistryAccessDenied -ErrorRecord $_) { $deniedPlain = $true }
+        else { throw }
+    }
+    if (-not $deniedPlain -and -not (& $StillSet (& $read))) {
+        return [PSCustomObject]@{ Removed = $true; TookOwnership = $false; Restored = 0; Reason = 'Removed without changing any permission.' }
+    }
+
+    Add-OfflineRepairLog -Level Info -Message "$Name is protected by its key's ACL. Taking the key, removing the value, and putting the ACL back."
+
+    $captured = [System.Collections.Generic.List[object]]::new()
+    try { [void](Grant-OfflineRegistryKeyAccess -Path $Path -NoRecurse -OfflineRoot $OfflineRoot -CapturedInto $captured) }
+    catch {
+        # Ownership may have been taken on the key before the failure, so its descriptor is put back
+        # rather than left changed - the asymmetry the write counterpart already avoids.
+        $undone = Restore-OfflineRegistrySecurity -Captured $captured.ToArray()
+        return [PSCustomObject]@{ Removed = $false; TookOwnership = $true; Restored = $undone; Reason = "Ownership could not be taken: $($_.Exception.Message)" }
+    }
+
+    $removed = $false
+    $failure = $null
+    try {
+        Remove-ItemProperty -Path $Path -Name $Name -Force -ErrorAction Stop
+        $removed = -not (& $StillSet (& $read))
+    }
+    catch { $failure = $_ }
+    finally {
+        # Always. The key is still here, so an unrestored descriptor is a permanent change.
+        $restored = Restore-OfflineRegistrySecurity -Captured $captured.ToArray()
+    }
+
+    return [PSCustomObject]@{
+        Removed       = $removed
+        TookOwnership = $true
+        Restored      = $restored
+        Reason        = $(if ($removed) { "Removed after taking the key. $restored descriptor(s) were put back." }
+                          else { "The value survived even after the key was taken$(if ($failure) { " ($($failure.Exception.Message))" }). $restored descriptor(s) were put back." })
+    }
+}
+
+function Test-OfflineRegistryAccessDenied {
+    <#
+    .SYNOPSIS
+        Deciding whether a failed registry operation failed because of an ACL.
+
+    .DESCRIPTION
+        An offline hive refuses an operation in two different ways depending on which layer rejects
+        it: the provider surfaces UnauthorizedAccessException, while the RegistryKey APIs raise
+        SecurityException. Either one means "the ACL said no", and only those two are worth retrying
+        behind an ownership change.
+
+        Everything else - a missing key, a wrong value type - must keep failing loudly. Retrying
+        those behind an ownership change would rewrite a security descriptor to work around a bug in
+        the caller, and then still fail.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param([Parameter(Mandatory = $true)]$ErrorRecord)
+
+    $ex = $ErrorRecord.Exception
+    while ($ex) {
+        if ($ex -is [System.UnauthorizedAccessException] -or $ex -is [System.Security.SecurityException]) { return $true }
+        $ex = $ex.InnerException
+    }
+    return $false
+}
+
+function Get-OfflineNearestExistingKey {
+    <#
+    .SYNOPSIS
+        Finding the key whose ACL actually governs an operation on a path that may not exist yet.
+
+    .DESCRIPTION
+        Setting a value needs rights on its own key, but creating a key needs rights on the nearest
+        ancestor that already exists, because that is the descriptor consulted when the first
+        missing level is created. Taking the leaf would be taking something that is not there.
+
+        Returns $null when nothing on the path exists, which for a mounted hive means the caller was
+        given a path outside it.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $current = $Path
+    while ($current) {
+        if (Test-Path -LiteralPath $current) { return $current }
+        $parent = Split-Path -Parent $current
+        if (-not $parent -or $parent -eq $current) { break }
+        $current = $parent
+    }
+    return $null
+}
+
+function Invoke-OfflineProtectedRegistryWrite {
+    <#
+    .SYNOPSIS
+        Writing to an offline hive key, taking the key only if the plain write is refused.
+
+    .DESCRIPTION
+        The write counterpart of Invoke-OfflineProtectedValueRemoval, and it exists for the same
+        reason: a key in an offline hive can be owned by TrustedInstaller and deny write to
+        Administrators, so a repair reports success having changed nothing.
+
+        The plain write is attempted first and the descriptor is only touched when the write is
+        actually refused. That matters more here than it does for a removal, because this sits
+        behind every value a repair sets: unconditionally rewriting a descriptor per value would be
+        slow and would be a change the guest never asked for. The overwhelming majority of writes
+        take the fast path and cost nothing.
+
+        Only the guarded key itself is taken, never its subtree. Setting a value needs KEY_SET_VALUE
+        on one key, and recursing a key like Services would rewrite the descriptor of every key
+        beneath it for no benefit.
+
+        The restore runs in a finally, so a write that fails after ownership was taken still leaves
+        the descriptor as it was found. Returns an object with Written, TookOwnership, Restored and
+        Reason.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][scriptblock]$Action,
+        [Parameter(Mandatory = $false)][string]$Description = 'the value',
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = ''
+    )
+
+    # The gate before the fast-path write below: even the plain attempt mutates the hive, so a key
+    # outside the mounted offline image must be refused before $Action runs at all.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'write to the offline registry key')
+
+    try {
+        # [void] so the caller scriptblock's own pipeline output cannot merge with and contaminate
+        # this function's returned result object.
+        [void](& $Action)
+        return [PSCustomObject]@{ Written = $true; TookOwnership = $false; Restored = 0; Reason = 'Written without changing any permission.' }
+    }
+    catch {
+        $firstError = $_
+        if (-not (Test-OfflineRegistryAccessDenied -ErrorRecord $firstError)) { throw }
+    }
+
+    # Captured before anything changes so the descriptor can be replayed verbatim. A path that
+    # cannot be addressed by these APIs leaves the original access-denied error as the honest answer.
+    $guardPath = Get-OfflineNearestExistingKey -Path $Path
+    if (-not $guardPath) { throw $firstError }
+
+    Add-OfflineRepairLog -Level Info -Message "$guardPath is protected by its own ACL. Taking the key to write $Description, then putting the ACL back."
+
+    $captured = [System.Collections.Generic.List[object]]::new()
+    try { [void](Grant-OfflineRegistryKeyAccess -Path $guardPath -NoRecurse -OfflineRoot $OfflineRoot -CapturedInto $captured) }
+    catch {
+        [void](Restore-OfflineRegistrySecurity -Captured $captured.ToArray())
+        return [PSCustomObject]@{ Written = $false; TookOwnership = $false; Restored = 0; Reason = "Ownership could not be taken: $($_.Exception.Message)" }
+    }
+
+    $written = $false
+    $failure = $null
+    try {
+        # [void] so the caller scriptblock's own pipeline output cannot contaminate the result.
+        [void](& $Action)
+        $written = $true
+    }
+    catch { $failure = $_ }
+    finally {
+        # Always. The key is still here, so an unrestored descriptor is a permanent change to a
+        # system this script was only meant to borrow.
+        $restored = Restore-OfflineRegistrySecurity -Captured $captured.ToArray()
+    }
+
+    return [PSCustomObject]@{
+        Written       = $written
+        TookOwnership = $true
+        Restored      = $restored
+        Reason        = $(if ($written) { "Written after taking the key. $restored descriptor(s) were put back." }
+                          else { "The write still failed after the key was taken ($($failure.Exception.Message)). $restored descriptor(s) were put back." })
+    }
+}
+
+function Get-OfflineProtectedRegistryValue {
+    <#
+    .SYNOPSIS
+        Reading a value from an offline hive key that may deny read to Administrators.
+
+    .DESCRIPTION
+        The read counterpart of Invoke-OfflineProtectedRegistryWrite. A key locked to SYSTEM:Read
+        denies Administrators even READ_CONTROL, so reporting the current value of a guarded key
+        needs the same ownership dance the write does.
+
+        -Found distinguishes "the value is genuinely not set" from "the value could not be read",
+        which are different outcomes and must not be confused: mislabelling a locked value as absent
+        is how a repair ends up logging 'was: (not set)' about a value it never managed to see, and
+        then writing a default over something it never looked at.
+    #>
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'Name',
+        Justification = 'Name is used, inside the $read scriptblock below. PSScriptAnalyzer does not look into a scriptblock assigned to a variable, so it cannot see the three uses there. Removing the parameter would break every caller.')]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $false)]$DefaultValue = $null,
+        [Parameter(Mandatory = $false)][ref]$Found,
+        [Parameter(Mandatory = $false)][ref]$Denied,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = ''
+    )
+
+    if ($Found) { $Found.Value = $false }
+    if ($Denied) { $Denied.Value = $false }
+
+    $read = {
+        $props = Get-ItemProperty -Path $Path -Name $Name -ErrorAction Stop
+        if ($props -and ($props.PSObject.Properties.Name -contains $Name)) {
+            if ($Found) { $Found.Value = $true }
+            return $props.$Name
+        }
+        return $DefaultValue
+    }
+
+    try { return & $read }
+    catch {
+        if (-not (Test-OfflineRegistryAccessDenied -ErrorRecord $_)) { return $DefaultValue }
+    }
+
+    if ($Denied) { $Denied.Value = $true }
+
+    $guardPath = Get-OfflineNearestExistingKey -Path $Path
+    if (-not $guardPath) { return $DefaultValue }
+
+    $captured = [System.Collections.Generic.List[object]]::new()
+    try { [void](Grant-OfflineRegistryKeyAccess -Path $guardPath -NoRecurse -OfflineRoot $OfflineRoot -CapturedInto $captured) }
+    catch {
+        [void](Restore-OfflineRegistrySecurity -Captured $captured.ToArray())
+        return $DefaultValue
+    }
+
+    try { return & $read }
+    catch { return $DefaultValue }
+    finally { [void](Restore-OfflineRegistrySecurity -Captured $captured.ToArray()) }
+}
+
+function Get-OfflinePathSecurity {
+    <#
+    .SYNOPSIS
+        Capturing a file or folder's owner, group and DACL as SDDL, and optionally in binary form.
+
+    .DESCRIPTION
+        Returns the descriptor as an SDDL string, which is the form the scenarios that consume this
+        capture expect. When -BinaryForm is supplied it is also set to the same descriptor's binary
+        form, which round-trips losslessly where an SDDL string re-resolves machine-relative aliases
+        against the machine parsing it; the copy, rename and delete paths in this file restore from
+        that binary rather than from the SDDL.
+
+    .PARAMETER BinaryForm
+        Optional [ref] set to the descriptor's Owner+Group+DACL binary form ([byte[]]), or $null on
+        failure.
+
+    .OUTPUTS
+        [string] the descriptor in SDDL form, or $null.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $false)][ref]$BinaryForm
+    )
+
+    if ($BinaryForm) { $BinaryForm.Value = $null }
+    try {
+        $acl = Get-Acl -LiteralPath $Path -ErrorAction Stop
+        if ($BinaryForm) { $BinaryForm.Value = $acl.GetSecurityDescriptorBinaryForm() }
+        return $acl.GetSecurityDescriptorSddlForm($script:OfflineSecuritySection)
+    }
+    catch { return $null }
+}
+
+function Get-OfflineSddlOwner {
+    <#
+    .SYNOPSIS
+        Reading just the owner SID out of a captured SDDL string.
+
+    .DESCRIPTION
+        Used to decide whether the owner needs writing at all. Rewriting an owner to the value it
+        already holds still demands WRITE_OWNER, so skipping it is both less privileged and less
+        of a change to an object this script is only borrowing.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([AllowEmptyString()][AllowNull()][string]$Sddl)
+
+    if (-not $Sddl) { return '' }
+    try {
+        $raw = [System.Security.AccessControl.RawSecurityDescriptor]::new($Sddl)
+        if ($raw.Owner) { return $raw.Owner.Value }
+        return ''
+    }
+    catch { return '' }
+}
+
+function Save-OfflinePathSecurity {
+    <#
+    .SYNOPSIS
+        Writing a partial security descriptor back to a file or folder.
+
+    .DESCRIPTION
+        Set-Acl is deliberately not used. It refuses a protected DACL - the D:P shape that WinSxS
+        and every other hardened folder carries - unless the caller holds SeSecurityPrivilege, even
+        though nothing about the write touches auditing. The .NET call writes only the sections the
+        descriptor object records as modified and has no such requirement.
+
+        These statics exist in the Windows PowerShell that az vm run-command starts on the rescue
+        VM, which is the only place this library runs.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][System.Security.AccessControl.FileSystemSecurity]$Security,
+        [switch]$IsDirectory
+    )
+
+    if ($IsDirectory) {
+        if ([System.IO.Directory].GetMethod('SetAccessControl', [type[]]@([string], [System.Security.AccessControl.DirectorySecurity]))) {
+            [System.IO.Directory]::SetAccessControl($Path, $Security)
+            return
+        }
+        [System.IO.FileSystemAclExtensions]::SetAccessControl([System.IO.DirectoryInfo]::new($Path), $Security)
+        return
+    }
+
+    if ([System.IO.File].GetMethod('SetAccessControl', [type[]]@([string], [System.Security.AccessControl.FileSecurity]))) {
+        [System.IO.File]::SetAccessControl($Path, $Security)
+        return
+    }
+    [System.IO.FileSystemAclExtensions]::SetAccessControl([System.IO.FileInfo]::new($Path), $Security)
+}
+
+function Grant-OfflinePathAccess {
+    <#
+    .SYNOPSIS
+        Taking ownership of a file or folder and granting this account FullControl.
+
+    .DESCRIPTION
+        Returns the captured SDDL, or $null when it could not be captured - in which case nothing
+        is changed, because an object that cannot be handed back should not be taken.
+
+        Assert-OfflineTarget runs before any privilege is enabled, so a path outside the bound
+        offline root is refused before ownership is ever taken - a privileged take-and-modify can
+        only ever reach the offline image, never the rescue VM's own disk.
+
+        -CapturedBinary optionally receives the original descriptor in binary form, which the
+        internal copy, rename and delete paths replay in preference to the SDDL because it
+        round-trips losslessly where SDDL does not.
+
+    .PARAMETER OfflineRoot
+        Optional explicit offline root to validate $Path against instead of the bound root(s).
+
+    .PARAMETER CapturedBinary
+        Optional [ref] set to the original descriptor's binary form, for a lossless restore.
+
+    .OUTPUTS
+        [string] the captured descriptor in SDDL form, or $null.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = '',
+        [Parameter(Mandatory = $false)][ref]$CapturedBinary
+    )
+
+    # The gate before any privilege is enabled.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'take ownership of')
+
+    Enable-OfflineOwnershipPrivilege
+
+    $binary = $null
+    $original = Get-OfflinePathSecurity -Path $Path -BinaryForm ([ref]$binary)
+    if (-not $original) {
+        Add-OfflineRepairLog -Level Info -Message "Could not read the security descriptor of $Path, so its ownership was left alone."
+        return $null
+    }
+    if ($CapturedBinary) { $CapturedBinary.Value = $binary }
+
+    $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+    $isDirectory = $item.PSIsContainer
+    $me = Get-OfflineCurrentUserSid
+
+    # Owner first and on its own, but only when it is not already ours. A DACL cannot be written by
+    # an account that does not own the object, so ownership has to come first where it is needed -
+    # yet writing the owner back to the value it already holds is a privileged write that buys
+    # nothing, and an existing owner already carries the WRITE_DAC the grant below needs.
+    if ((Get-OfflineSddlOwner -Sddl $original) -ne $me.Value) {
+        $ownerOnly = if ($isDirectory) { [System.Security.AccessControl.DirectorySecurity]::new() } else { [System.Security.AccessControl.FileSecurity]::new() }
+        $ownerOnly.SetOwner($me)
+        Save-OfflinePathSecurity -Path $Path -Security $ownerOnly -IsDirectory:$isDirectory
+    }
+
+    # Built from the captured SDDL rather than from Get-Acl, so that only the DACL is ever written.
+    # A descriptor that carries the SACL along demands SeSecurityPrivilege for a change that has
+    # nothing to do with auditing, and fails for that reason alone.
+    # The granted ACE deliberately does not inherit: pushing it onto children would alter
+    # descriptors that were never captured and so could never be put back. Callers that need a
+    # child as well take that child in its own right.
+    $acl = if ($isDirectory) { [System.Security.AccessControl.DirectorySecurity]::new() } else { [System.Security.AccessControl.FileSecurity]::new() }
+    $acl.SetSecurityDescriptorSddlForm($original, 'Access')
+    $acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new(
+            $me, 'FullControl', 'None', 'None', 'Allow'))
+    Save-OfflinePathSecurity -Path $Path -Security $acl -IsDirectory:$isDirectory
+
+    return $original
+}
+
+function Restore-OfflinePathSecurity {
+    <#
+    .SYNOPSIS
+        Replaying a descriptor captured by Grant-OfflinePathAccess.
+
+    .DESCRIPTION
+        Replayed whole, never rebuilt. Removing the granted ACE individually - the icacls
+        /remove:g shape - also drops the inherited and shipped ACEs alongside it, which is how
+        WinSxS ends up quietly damaged by a repair that looked like it cleaned up after itself.
+
+        When -BinaryDescriptor is supplied it is replayed in preference to the SDDL, because a binary
+        descriptor round-trips losslessly where an SDDL string re-resolves machine-relative aliases
+        (LA, DA, DU, DC) against the machine that parses it - measured on a workgroup host, LA
+        resolved to that host's own administrator and DA, DU and DC failed to parse at all. The
+        internal copy, rename and delete paths capture and pass it; external callers that hold only
+        the SDDL still get the SDDL replay.
+
+        A binary restore is verified: the descriptor is read back and compared (owner, DACL and
+        protection), and a restore that does not read back identically is reported and returns
+        $false rather than being counted as done.
+
+        A missing path is not an error: the caller may legitimately offer both the original and
+        the renamed path without knowing which one survived.
+
+    .PARAMETER BinaryDescriptor
+        Optional [byte[]] captured by Grant-OfflinePathAccess -CapturedBinary. Replayed and verified
+        in preference to -Sddl when present.
+
+    .PARAMETER OfflineRoot
+        Optional explicit offline root. Defaults to the root bound during disk discovery.
+        Forwarded to Assert-OfflineTarget.
+
+    .OUTPUTS
+        [bool] $true when the descriptor was written (and, for a binary restore, verified).
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [AllowEmptyString()][string]$Sddl = '',
+        [byte[]]$BinaryDescriptor,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = ''
+    )
+
+    $haveBinary = ($BinaryDescriptor -and $BinaryDescriptor.Length -gt 0)
+    if (-not $Sddl -and -not $haveBinary) { return $false }
+    if (-not (Test-Path -LiteralPath $Path)) { return $false }
+
+    # Gated like every other privileged path, and for the same reason. Restoring is not inherently
+    # safe just because it puts something back: this enables SeTakeOwnershipPrivilege and then writes
+    # a descriptor that was captured from a DIFFERENT object, so a $Path that resolved to the rescue
+    # VM's own C: would have its owner and DACL replaced with the offline image's. The gate runs after
+    # the missing-path check, because a path that is not there is explicitly not an error here.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'restore the security descriptor of')
+
+    Enable-OfflineOwnershipPrivilege
+
+    try {
+        $isDirectory = (Get-Item -LiteralPath $Path -Force).PSIsContainer
+        $sd = if ($isDirectory) { [System.Security.AccessControl.DirectorySecurity]::new() } else { [System.Security.AccessControl.FileSecurity]::new() }
+
+        if ($haveBinary) {
+            # Only the sections that actually differ are written. If ownership was never taken -
+            # because it was already ours - replaying the owner would be a privileged write with no
+            # effect that fails on a restricted account and takes the DACL restore down with it.
+            $capturedOwner = Get-OfflineRawOwner -BinaryDescriptor $BinaryDescriptor
+            $currentBinary = $null
+            [void](Get-OfflinePathSecurity -Path $Path -BinaryForm ([ref]$currentBinary))
+            $sections = $script:OfflineSecuritySections
+            if ($capturedOwner -and $currentBinary -and ($capturedOwner -eq (Get-OfflineRawOwner -BinaryDescriptor $currentBinary))) {
+                $sections = [System.Security.AccessControl.AccessControlSections]::Access
+            }
+            $sd.SetSecurityDescriptorBinaryForm($BinaryDescriptor, $sections)
+            Save-OfflinePathSecurity -Path $Path -Security $sd -IsDirectory:$isDirectory
+
+            # Trust nothing: read the descriptor back and confirm it matches before calling it done.
+            $readBack = $null
+            [void](Get-OfflinePathSecurity -Path $Path -BinaryForm ([ref]$readBack))
+            if ($readBack -and (Test-OfflineDescriptorMatch -Captured $BinaryDescriptor -ReadBack $readBack)) {
+                return $true
+            }
+            Add-OfflineRepairLog -Level Warning -Message "The original ACL was written back to $Path but did not read back identically, so it cannot be counted as restored. Check it by hand with: icacls `"$Path`""
+            return $false
+        }
+
+        # SDDL fall-back for external callers that captured only the string form.
+        $sections = $script:OfflineSecuritySection
+        $capturedOwner = Get-OfflineSddlOwner -Sddl $Sddl
+        if ($capturedOwner -and $capturedOwner -eq (Get-OfflineSddlOwner -Sddl (Get-OfflinePathSecurity -Path $Path))) {
+            $sections = 'Access'
+        }
+        $sd.SetSecurityDescriptorSddlForm($Sddl, $sections)
+        Save-OfflinePathSecurity -Path $Path -Security $sd -IsDirectory:$isDirectory
+        return $true
+    }
+    catch {
+        Add-OfflineRepairLog -Level Warning -Message "Could not restore the original ACL on $Path : $($_.Exception.Message). Restore it by hand with: icacls `"$Path`" /setowner `"NT SERVICE\TrustedInstaller`""
+        return $false
+    }
+}
+
+function Rename-OfflineProtectedFile {
+    <#
+    .SYNOPSIS
+        Renaming a file in a protected folder, taking the folder only if the plain rename fails.
+
+    .DESCRIPTION
+        Both the parent folder and the file are taken, because a rename needs rights on both and
+        neither alone is enough. The parent supplies FILE_ADD_FILE for the new name; the file
+        supplies the DELETE that Rename-Item asks for when it opens the source. Granting on the
+        parent with inheritance would cover the file too, but it would also rewrite every other
+        child's descriptor - descriptors that were never captured and so could never be handed
+        back. Taking the one file explicitly changes exactly what has to change.
+
+        Both descriptors are put back in a finally, so they are restored whether the rename
+        succeeded, failed, or threw, and the file is restored first while the parent rights that
+        make it reachable are still in place. Leaving WinSxS owned by SYSTEM would be a lasting
+        weakening of a folder this script only needed to borrow for one rename.
+
+        Returns an object with Renamed, NewPath, TookOwnership, Restored and Reason.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$NewName,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = ''
+    )
+
+    # The gate before the plain rename below, which mutates: refuse a file that is not under the
+    # bound offline root before anything is attempted, even the plain first attempt.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'rename the offline file')
+
+    # The existence check itself can be refused on a protected folder, which is a symptom of the
+    # very problem this function exists to solve rather than a reason to give up. Only a clean
+    # "not there" answer counts as absent; a denied check falls through to the escalation below.
+    try {
+        if (-not (Test-Path -LiteralPath $Path -ErrorAction Stop)) {
+            return [PSCustomObject]@{ Renamed = $false; NewPath = ''; TookOwnership = $false; Restored = $false; Reason = 'The file was not present.' }
+        }
+    }
+    catch {
+        Add-OfflineRepairLog -Level Info -Message "Whether $Path exists could not even be checked ($($_.Exception.Message)). Treating that as protection rather than absence."
+    }
+
+    $parent = Split-Path -Path $Path -Parent
+    $target = Join-Path $parent $NewName
+
+    try {
+        Rename-Item -LiteralPath $Path -NewName $NewName -Force -ErrorAction Stop
+        return [PSCustomObject]@{ Renamed = $true; NewPath = $target; TookOwnership = $false; Restored = $false; Reason = 'Renamed without changing any permission.' }
+    }
+    catch {
+        $firstError = $_.Exception.Message
+    }
+
+    Add-OfflineRepairLog -Level Info -Message "$Path could not be renamed ($firstError). Taking ownership of $parent, retrying, and putting its ACL back either way."
+
+    $originalSddl = $null
+    $fileSddl = $null
+    $parentBin = $null
+    $fileBin = $null
+    $absent = $false
+    $renamed = $false
+    try {
+        $originalSddl = Grant-OfflinePathAccess -Path $parent -OfflineRoot $OfflineRoot -CapturedBinary ([ref]$parentBin)
+        if (-not $originalSddl) {
+            return [PSCustomObject]@{ Renamed = $false; NewPath = ''; TookOwnership = $false; Restored = $false; Reason = "The folder's security descriptor could not be read, so its ownership was left alone. Original error: $firstError" }
+        }
+
+        # Now that the folder can be read, the earlier check can be trusted. Saying "the rename was
+        # refused" about a file that was never there would send an operator hunting for a
+        # permissions problem that does not exist.
+        if (-not (Test-Path -LiteralPath $Path)) {
+            $absent = $true
+            $reason = 'The file was not present once the folder could be read.'
+        }
+        else {
+            $fileSddl = Grant-OfflinePathAccess -Path $Path -OfflineRoot $OfflineRoot -CapturedBinary ([ref]$fileBin)
+            Rename-Item -LiteralPath $Path -NewName $NewName -Force -ErrorAction Stop
+            $renamed = $true
+            $reason = 'Renamed after taking ownership of the file and its parent folder.'
+        }
+    }
+    catch {
+        $reason = "The rename was still refused after taking ownership of the file and its parent folder: $($_.Exception.Message)"
+    }
+    finally {
+        # Always, on every path. Both objects were borrowed, not acquired. The file goes back
+        # first, under whichever name it ended up with, while the parent still grants access to it.
+        # The binary capture is replayed and verified in preference to the SDDL.
+        $restoredFile = $true
+        if ($fileSddl) {
+            $restoredFile = Restore-OfflinePathSecurity -Path $(if ($renamed) { $target } else { $Path }) -Sddl $fileSddl -BinaryDescriptor $fileBin
+        }
+        $restored = (Restore-OfflinePathSecurity -Path $parent -Sddl $originalSddl -BinaryDescriptor $parentBin) -and $restoredFile
+    }
+
+    return [PSCustomObject]@{
+        Renamed       = $renamed
+        NewPath       = $(if ($renamed) { $target } else { '' })
+        TookOwnership = -not $absent
+        Restored      = [bool]$restored
+        Reason        = $reason
+    }
+}
+
+function Clear-OfflineBlockingAttribute {
+    <#
+    .SYNOPSIS
+        Clearing the attributes that stop a file being deleted or renamed.
+
+    .DESCRIPTION
+        ReadOnly, Hidden and System all refuse a delete, and the write that clears them is itself
+        refused on a protected file - which is why this is called again after ownership is taken
+        rather than only before. Failure is deliberately swallowed: the attribute clear is a step
+        towards the delete, not the point of it, and the delete reports its own error.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    try {
+        $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+        $blocking = ([System.IO.FileAttributes]::ReadOnly -bor [System.IO.FileAttributes]::Hidden -bor [System.IO.FileAttributes]::System)
+        if ($item.Attributes -band $blocking) {
+            $item.Attributes = ($item.Attributes -band (-bnot $blocking))
+        }
+    }
+    catch {
+        # Deliberately swallowed. Clearing the attributes is a step towards the delete, not the
+        # point of it, and on a protected file this write is refused for the same reason the delete
+        # was - which the caller is about to handle by taking ownership and calling this again.
+        Write-Verbose "Attributes on $Path could not be cleared: $($_.Exception.Message)"
+    }
+}
+
+function Invoke-OfflineProtectedFileRemoval {
+    <#
+    .SYNOPSIS
+        Deleting a file in a protected folder, taking the folder only if the plain delete fails.
+
+    .DESCRIPTION
+        The same shape as Rename-OfflineProtectedFile, and for the same reason: deleting a file is a
+        write to the folder that contains it, so rights on the file alone are not enough. The parent
+        supplies FILE_DELETE_CHILD and the file supplies the DELETE that Remove-Item asks for when it
+        opens the source. Both are taken, and both are handed straight back in a finally.
+
+        Ownership is only taken after an ordinary delete has actually been refused. A folder whose
+        permissions were never in the way is never touched, so the common case leaves no trace.
+
+        The blocking attributes are cleared twice on purpose. The first attempt is part of the plain
+        delete; the second happens after ownership is taken, because on a genuinely protected file
+        the attribute write is refused for exactly the same reason the delete was.
+
+        Only the parent's descriptor is restored when the file goes, because a deleted file has no
+        descriptor to hand back. That is not a failure, and it is not counted as one.
+
+        Returns an object with Removed, TookOwnership, Restored and Reason.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = ''
+    )
+
+    # The gate before the plain delete below, which mutates: refuse a file that is not under the
+    # bound offline root before anything is attempted, even the plain first attempt.
+    [void](Assert-OfflineTarget -Path $Path -OfflineRoot $OfflineRoot -Action 'delete the offline file')
+
+    # A denied existence check is a symptom of the problem this function exists to solve, not an
+    # answer. Only a clean "not there" counts as absent.
+    try {
+        if (-not (Test-Path -LiteralPath $Path -ErrorAction Stop)) {
+            return [PSCustomObject]@{ Removed = $false; TookOwnership = $false; Restored = $false; Absent = $true; Reason = 'The file was not present.' }
+        }
+    }
+    catch {
+        Add-OfflineRepairLog -Level Info -Message "Whether $Path exists could not even be checked ($($_.Exception.Message)). Treating that as protection rather than absence."
+    }
+
+    try {
+        Clear-OfflineBlockingAttribute -Path $Path
+        Remove-Item -LiteralPath $Path -Force -ErrorAction Stop
+        return [PSCustomObject]@{ Removed = $true; TookOwnership = $false; Restored = $false; Absent = $false; Reason = 'Removed without changing any permission.' }
+    }
+    catch {
+        $firstError = $_.Exception.Message
+    }
+
+    $parent = Split-Path -Path $Path -Parent
+    Add-OfflineRepairLog -Level Info -Message "$Path could not be removed ($firstError). Taking ownership of $parent, retrying, and putting its ACL back either way."
+
+    $parentSddl = $null
+    $fileSddl = $null
+    $parentBin = $null
+    $fileBin = $null
+    $removed = $false
+    $absent = $false
+    try {
+        $parentSddl = Grant-OfflinePathAccess -Path $parent -OfflineRoot $OfflineRoot -CapturedBinary ([ref]$parentBin)
+        if (-not $parentSddl) {
+            return [PSCustomObject]@{ Removed = $false; TookOwnership = $false; Restored = $false; Absent = $false; Reason = "The folder's security descriptor could not be read, so its ownership was left alone. Original error: $firstError" }
+        }
+
+        # Now that the folder can be read, the earlier check can be trusted.
+        if (-not (Test-Path -LiteralPath $Path)) {
+            $absent = $true
+            $reason = 'The file was not present once the folder could be read.'
+        }
+        else {
+            $fileSddl = Grant-OfflinePathAccess -Path $Path -OfflineRoot $OfflineRoot -CapturedBinary ([ref]$fileBin)
+            Clear-OfflineBlockingAttribute -Path $Path
+            Remove-Item -LiteralPath $Path -Force -ErrorAction Stop
+            $removed = $true
+            $reason = 'Removed after taking ownership of the file and its parent folder.'
+        }
+    }
+    catch {
+        $reason = "The delete was still refused after taking ownership of the file and its parent folder: $($_.Exception.Message)"
+    }
+    finally {
+        # The file's descriptor is only restorable when the file survived. Restoring a path that was
+        # successfully deleted would report false, which must not be read as a failure to hand back.
+        # The binary capture is replayed and verified in preference to the SDDL.
+        $restoredFile = $true
+        if ($fileSddl -and -not $removed) {
+            $restoredFile = Restore-OfflinePathSecurity -Path $Path -Sddl $fileSddl -BinaryDescriptor $fileBin
+        }
+        $restored = (Restore-OfflinePathSecurity -Path $parent -Sddl $parentSddl -BinaryDescriptor $parentBin) -and $restoredFile
+    }
+
+    return [PSCustomObject]@{
+        Removed       = $removed
+        TookOwnership = -not $absent
+        Restored      = [bool]$restored
+        Absent        = $absent
+        Reason        = $reason
+    }
+}
+
+function Copy-OfflineProtectedFile {
+    <#
+    .SYNOPSIS
+        Writing a file into a protected folder, taking ownership only if the plain copy fails.
+
+    .DESCRIPTION
+        The same shape as Invoke-OfflineProtectedFileRemoval, and it exists for the same measured
+        reason. On a Server 2022 disk attached to a rescue VM, opening
+        F:\Windows\System32\winload.efi for write as SYSTEM is refused outright: the file is owned
+        by NT SERVICE\TrustedInstaller, and SYSTEM is not the owner. A Copy-Item over the top fails
+        just as silently, which is how a repair reports success while having changed nothing.
+
+        Overwriting a file is a write to the file and, when it does not yet exist, a write to the
+        folder that will hold it. Both are taken when needed and both are handed straight back in a
+        finally, replaying the whole captured descriptor rather than removing the granted ACE.
+
+        The destination keeps its own original descriptor. A replacement file must not inherit the
+        rescue VM's idea of what the ACL should be, and it must not be left owned by whoever ran
+        the repair - the guest has to boot with TrustedInstaller owning its system files again.
+
+        Returns an object with Copied, TookOwnership, Restored and Reason.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot = ''
+    )
+
+    # The gate is on the destination, which is what gets written: refuse a write whose target is
+    # not under the bound offline root before the plain copy below runs. The source is only read,
+    # so it may legitimately sit on the rescue VM (a staged replacement file).
+    [void](Assert-OfflineTarget -Path $Destination -OfflineRoot $OfflineRoot -Action 'write the offline file')
+
+    if (-not (Test-Path -LiteralPath $Source)) {
+        return [PSCustomObject]@{ Copied = $false; TookOwnership = $false; Restored = $false; Reason = "The source file $Source was not present." }
+    }
+
+    $existed = $false
+    try { $existed = Test-Path -LiteralPath $Destination -ErrorAction Stop } catch {
+        Add-OfflineRepairLog -Level Info -Message "Whether $Destination exists could not even be checked ($($_.Exception.Message)). Treating that as protection rather than absence."
+    }
+
+    try {
+        if ($existed) { Clear-OfflineBlockingAttribute -Path $Destination }
+        Copy-Item -LiteralPath $Source -Destination $Destination -Force -ErrorAction Stop
+        return [PSCustomObject]@{ Copied = $true; TookOwnership = $false; Restored = $false; Reason = 'Copied without changing any permission.' }
+    }
+    catch {
+        $firstError = $_.Exception.Message
+    }
+
+    $parent = Split-Path -Path $Destination -Parent
+    Add-OfflineRepairLog -Level Info -Message "$Destination could not be written ($firstError). Taking ownership of $parent, retrying, and putting its ACL back either way."
+
+    $parentSddl = $null
+    $fileSddl = $null
+    $parentBin = $null
+    $fileBin = $null
+    $copied = $false
+    $reason = ''
+    try {
+        $parentSddl = Grant-OfflinePathAccess -Path $parent -OfflineRoot $OfflineRoot -CapturedBinary ([ref]$parentBin)
+        if (-not $parentSddl) {
+            return [PSCustomObject]@{ Copied = $false; TookOwnership = $false; Restored = $false; Reason = "The folder's security descriptor could not be read, so its ownership was left alone. Original error: $firstError" }
+        }
+
+        # Re-checked now that the folder can actually be read: the first check ran against a folder
+        # that may have been denying us, so its answer could not be trusted.
+        if (Test-Path -LiteralPath $Destination) {
+            $fileSddl = Grant-OfflinePathAccess -Path $Destination -OfflineRoot $OfflineRoot -CapturedBinary ([ref]$fileBin)
+            Clear-OfflineBlockingAttribute -Path $Destination
+        }
+
+        Copy-Item -LiteralPath $Source -Destination $Destination -Force -ErrorAction Stop
+        $copied = $true
+        $reason = 'Copied after taking ownership of the destination and its parent folder.'
+    }
+    catch {
+        $reason = "The copy was still refused after taking ownership of the destination and its parent folder: $($_.Exception.Message)"
+    }
+    finally {
+        # The destination's own descriptor is replayed onto whatever now sits at that path, so a
+        # freshly written file ends up owned by TrustedInstaller exactly as the one it replaced was.
+        # The binary capture is replayed and verified in preference to the SDDL.
+        $restoredFile = $true
+        if ($fileSddl) { $restoredFile = Restore-OfflinePathSecurity -Path $Destination -Sddl $fileSddl -BinaryDescriptor $fileBin }
+        $restored = (Restore-OfflinePathSecurity -Path $parent -Sddl $parentSddl -BinaryDescriptor $parentBin) -and $restoredFile
+    }
+
+    return [PSCustomObject]@{
+        Copied        = $copied
+        TookOwnership = $true
+        Restored      = [bool]$restored
+        Reason        = $reason
+    }
+}

--- a/src/windows/common/helpers/Use-OfflineRegistryHive.ps1
+++ b/src/windows/common/helpers/Use-OfflineRegistryHive.ps1
@@ -48,20 +48,17 @@
     v1.2: Test-OfflineHiveFile uses the shared read-only offreg reader, avoiding registry
           mounts and scratch hive copies. An unavailable reader aborts validation rather
           than misclassifying the hive as corrupt. Writable HKLM-based helpers are unchanged.
+    v1.3: Removed localised-output decisions, distinguished file sharing from other failures,
+          added strict control-set selection for writers and shared lifecycle/default state.
 #>
 
-if (-not (Get-Command Open-OfflineRegistryReader -ErrorAction SilentlyContinue)) {
+if (-not (Get-Command Get-OfflineRegistryKeyOpenResult -ErrorAction SilentlyContinue)) {
     try {
         . (Join-Path $PSScriptRoot 'OfflineRepairCommon.ps1')
     }
     catch {
         throw "Use-OfflineRegistryHive.ps1 could not load its dependency OfflineRepairCommon.ps1 from '$PSScriptRoot': $($_.Exception.Message)"
     }
-}
-
-# Drive letter of the offline Windows installation, normally set by Get-OfflineWindowsDisk.ps1.
-if (-not (Get-Variable -Name OfflineWindowsDrive -Scope Script -ErrorAction SilentlyContinue)) {
-    $script:OfflineWindowsDrive = $null
 }
 
 function Get-OfflineHiveFilePath {
@@ -82,24 +79,28 @@ function Get-OfflineHiveFilePath {
 function Get-OfflineHiveKeyState {
     <#
     .SYNOPSIS
-        Reports whether a mount key is loaded, using reg.exe so no in-process handle opens.
+        Reports whether a key exists using a numeric native open result.
 
     .DESCRIPTION
-        Returns 'Present' when the key is loaded, 'Absent' when reg.exe reports the key does
-        not exist, and 'Unknown' when the state could not be read (for example access is
-        denied). The distinction is the point: treating 'Unknown' as 'Absent' is exactly how
-        an access-denied result was previously mistaken for a clean unload.
+        Returns 'Present' for ERROR_SUCCESS, 'Absent' only for ERROR_FILE_NOT_FOUND or
+        ERROR_PATH_NOT_FOUND, and 'Unknown' for access denial or any indeterminate result.
+        The query tests the key, not its default value or its backing file's lock state.
+        The native handle is disposed before this function returns.
 
     .OUTPUTS
         [string] one of 'Present', 'Absent' or 'Unknown'.
     #>
     param([Parameter(Mandatory = $true)][string]$HiveKey)
 
-    $out = reg.exe query $HiveKey /ve 2>&1 | Out-String
-    if ($LASTEXITCODE -eq 0) { return 'Present' }
-    # reg.exe reports "The system was unable to find the specified registry key or value"
-    # only when the key genuinely is not loaded. Any other failure is an undetermined state.
-    if ($out -match 'unable to find|cannot find|specified registry key') { return 'Absent' }
+    try {
+        $result = Get-OfflineRegistryKeyOpenResult -Key $HiveKey
+        if ($result -eq 0) { return 'Present' }
+        if ($result -eq 2 -or $result -eq 3) { return 'Absent' }
+        Add-OfflineRepairLog -Level Warning -Message "Could not determine whether $HiveKey exists (Win32 error $result)."
+    }
+    catch {
+        Add-OfflineRepairLog -Level Warning -Message "Could not determine whether $HiveKey exists: $($_.Exception.Message)"
+    }
     return 'Unknown'
 }
 
@@ -113,20 +114,29 @@ function Test-OfflineFileInUse {
         so an exclusive open fails with a sharing violation, while a file nothing has mounted
         opens cleanly. The handle is closed at once and nothing is written, so the hive on
         the offline disk is never changed by the check. Any other failure (for example access
-        denied) is raised to the caller, which must treat it as 'cannot verify'.
+        denied, missing file or unrelated I/O failure) is raised to the caller, which must
+        treat it as 'cannot verify'. A sharing violation alone does not identify a mount.
 
     .OUTPUTS
         [bool] $true when the file is in use, $false when it can be opened exclusively.
     #>
     param([Parameter(Mandatory = $true)][string]$Path)
 
+    $stream = $null
     try {
         $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::None)
-        $stream.Dispose()
         return $false
     }
+    catch [System.UnauthorizedAccessException] {
+        throw [System.UnauthorizedAccessException]::new("File access to '$Path' could not be verified: access was denied.", $_.Exception)
+    }
     catch [System.IO.IOException] {
-        return $true
+        # HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION / ERROR_LOCK_VIOLATION).
+        if ($_.Exception.HResult -in @(-2147024864, -2147024863)) { return $true }
+        throw
+    }
+    finally {
+        if ($null -ne $stream) { $stream.Dispose() }
     }
 }
 
@@ -138,7 +148,7 @@ function Invoke-OfflineRegUnload {
     .DESCRIPTION
         Releases cached registry handles with a garbage collection pass, then retries
         'reg unload' while PowerShell's registry provider lets go. After the loop it
-        re-queries the key with reg.exe and reports success only when the key is actually
+        checks the key with a numeric native query and reports success only when it is actually
         gone - a zero exit code is not trusted on its own, so a hive left mounted is never
         mistaken for unloaded. Callers decide how loudly to report a failure.
 
@@ -157,9 +167,13 @@ function Invoke-OfflineRegUnload {
     Add-OfflineRepairLog -Level Info -Message "Unloading offline hive: reg unload $HiveKey"
     $maxAttempts = 6
     $out = ''
+    $keyState = 'Unknown'
     for ($i = 1; $i -le $maxAttempts; $i++) {
         $out = reg.exe unload $HiveKey 2>&1 | Out-String
-        if ($LASTEXITCODE -eq 0 -or $out -match 'unable to find|parameter is incorrect') { break }
+        $exitCode = $LASTEXITCODE
+        $keyState = Get-OfflineHiveKeyState -HiveKey $HiveKey
+        if ($keyState -eq 'Absent') { return $true }
+        if ($exitCode -eq 0) { break }
         if ($i -lt $maxAttempts) {
             [GC]::Collect()
             [GC]::WaitForPendingFinalizers()
@@ -168,11 +182,7 @@ function Invoke-OfflineRegUnload {
         }
     }
 
-    # A zero exit code is necessary but not sufficient. Confirm the key is really gone before
-    # reporting success, so a hive that is still mounted is never reported as unloaded.
-    if ((Get-OfflineHiveKeyState -HiveKey $HiveKey) -eq 'Absent') { return $true }
-
-    Add-OfflineRepairLog -Level Warning -Message "reg unload $HiveKey did not confirm removal (last message: $($out.Trim()))."
+    Add-OfflineRepairLog -Level Warning -Message "reg unload $HiveKey did not confirm removal (exit code $exitCode; key state $keyState; last message: $($out.Trim()))."
     return $false
 }
 
@@ -182,13 +192,11 @@ function Mount-OfflineHive {
         Loads an offline hive as HKLM\BROKEN<HIVE> and registers it with the offline gate.
 
     .DESCRIPTION
-        A pre-existing HKLM\BROKEN<HIVE> key is reused only when it is proven to be backed by
-        THIS disk's hive file: a loaded hive holds its primary file open, so the target file
-        being in use is the signal that the mount is ours. If that file is free - which is
-        what a stale key from a crashed run, or a concurrent run against a different disk,
-        looks like - the mount is refused rather than silently retargeting every read and
-        write to the wrong hive. On a successful load or a verified reuse the key is
-        registered with Register-OfflineHiveKey so Assert-OfflineTarget will allow writes.
+        A pre-existing key is reused only when shared lifecycle state records a successful
+        load of THIS file and the file remains in use. A file lock alone proves neither
+        mount existence nor ownership. An untracked mount is not adopted, even if the
+        target file is locked by some other process. Successful loads and verified reuse
+        are registered with Register-OfflineHiveKey so Assert-OfflineTarget allows writes.
     #>
     param(
         [Parameter(Mandatory = $true)][string]$WindowsPath,
@@ -198,55 +206,67 @@ function Mount-OfflineHive {
     )
 
     $offHive = Get-OfflineHiveFilePath -WindowsPath $WindowsPath -Hive $Hive
-    if (-not (Test-OfflinePath $offHive)) {
-        throw "$Hive hive not found: $offHive"
+    $hiveKey = "HKLM\BROKEN$Hive"
+    $state = Get-OfflineRepairState
+    $keyState = Get-OfflineHiveKeyState -HiveKey $hiveKey
+    if ($keyState -eq 'Unknown') {
+        throw "Cannot load $hiveKey because its existing key state could not be verified. Resolve the registry query failure before retrying."
+    }
+    if ($keyState -eq 'Absent') {
+        $null = Unregister-OfflineHiveKey -Key $hiveKey
+        [void]$state.HiveFilePaths.Remove($hiveKey)
     }
 
-    $hiveKey = "HKLM\BROKEN$Hive"
+    try { $targetInUse = Test-OfflineFileInUse -Path $offHive }
+    catch [System.IO.FileNotFoundException] { throw "$Hive hive not found: $offHive" }
+    catch [System.IO.DirectoryNotFoundException] { throw "$Hive hive not found: $offHive" }
+    catch [System.UnauthorizedAccessException] {
+        throw "File access to '$offHive' could not be verified: access was denied. Check file permissions before retrying; no mount ownership was inferred."
+    }
+    catch {
+        throw "File access to '$offHive' could not be verified: $($_.Exception.Message). No mount ownership was inferred."
+    }
 
-    # A previous failed unload, or another run, can leave the key mounted. Reuse it only after
-    # proving it is backed by our file; otherwise refuse, because reusing a foreign or stale
-    # mount would point every read and write at the wrong hive.
-    if ((Get-OfflineHiveKeyState -HiveKey $hiveKey) -eq 'Present') {
-        try { $targetInUse = Test-OfflineFileInUse -Path $offHive }
-        catch {
-            throw "Refusing to reuse the existing $hiveKey mount: the state of '$offHive' could not be verified ($($_.Exception.Message)). Unload the key with 'reg unload $hiveKey' and retry."
-        }
-
-        if ($targetInUse) {
+    if ($keyState -eq 'Present') {
+        $knownFile = $state.HiveFilePaths[$hiveKey]
+        if ($knownFile -and $knownFile -eq (ConvertTo-OfflineComparablePath $offHive) -and $targetInUse) {
             Add-OfflineRepairLog -Level Info -Message "$hiveKey is already loaded from '$offHive' - reusing the existing mount."
             $null = Register-OfflineHiveKey -Key $hiveKey
             return
         }
 
-        throw "Refusing to reuse the existing $hiveKey mount: it is not backed by '$offHive' (that file is not open), so it belongs to a different disk or a crashed run. Unload it first with 'reg unload $hiveKey'."
+        throw "Refusing to reuse ${hiveKey}: its backing file could not be verified as '$offHive' from this process's mount records. A file lock alone does not identify a hive mount. Identify the existing key's owner before taking action."
     }
 
     Add-OfflineRepairLog -Level Info -Message "Loading offline hive: reg load $hiveKey `"$offHive`""
     $out = reg.exe load $hiveKey "$offHive" 2>&1 | Out-String
 
     if ($LASTEXITCODE -ne 0) {
-        if ($out -match 'being used by another process|locked') {
-            # The hive file is loaded under a different key name. Help the caller find it.
-            $stdKeys = @('BCD00000000', 'HARDWARE', 'SAM', 'SECURITY', 'SOFTWARE', 'SYSTEM',
-                'BROKENSYSTEM', 'BROKENSOFTWARE', 'BROKENCOMPONENTS', 'BROKENSAM',
-                'BROKENSECURITY', 'BROKENDEFAULT')
-            $foreign = reg.exe query HKLM 2>&1 | ForEach-Object {
-                if ($_ -match '^HKEY_LOCAL_MACHINE\\(.+)$') { $Matches[1] }
-            } | Where-Object { $_ -notin $stdKeys }
-
-            $hint = if ($foreign) {
-                "Non-standard HKLM keys that may hold this hive: $($foreign -join ', '). Unload them first with: reg unload HKLM\<keyname>"
-            }
-            else {
-                'Check for a hive loaded under a different key name (reg query HKLM) and unload it first.'
-            }
-            throw "Cannot load the $Hive hive - the file is already in use by another process. $hint"
+        $exitCode = $LASTEXITCODE
+        try { $targetInUse = Test-OfflineFileInUse -Path $offHive }
+        catch {
+            throw "Failed to load the offline $Hive hive (exit code $exitCode): $($out.Trim()). File access to '$offHive' could not be verified: $($_.Exception.Message). No mount ownership was inferred."
         }
-        throw "Failed to load the offline $Hive hive: $($out.Trim())"
+        if ($targetInUse) {
+            throw "Cannot load the $Hive hive: '$offHive' has a sharing or lock violation. Identify the process or mount holding the file before taking action; a lock does not prove a foreign mount. reg load exit code ${exitCode}: $($out.Trim())"
+        }
+        throw "Failed to load the offline $Hive hive (exit code $exitCode): $($out.Trim())"
     }
 
-    $null = Register-OfflineHiveKey -Key $hiveKey
+    $state.HiveFilePaths[$hiveKey] = ConvertTo-OfflineComparablePath $offHive
+    try { $null = Register-OfflineHiveKey -Key $hiveKey }
+    catch {
+        $registrationError = $_
+        try {
+            if (-not (Dismount-OfflineHive -Hive $Hive)) {
+                Add-OfflineRepairLog -Level Error -Message "Registration failed and cleanup of $hiveKey could not be confirmed."
+            }
+        }
+        catch {
+            Add-OfflineRepairLog -Level Error -Message "Registration failed and cleanup of $hiveKey threw: $($_.Exception.Message)"
+        }
+        throw $registrationError
+    }
 }
 
 function Dismount-OfflineHive {
@@ -259,7 +279,7 @@ function Dismount-OfflineHive {
         loaded is a success; a state that cannot be read (for example access is denied) is
         NOT, so it is never mistaken for a clean unload. On a confirmed unload the mount key
         is unregistered from the offline-target gate; on failure it is left registered and
-        $false is returned, because the file is still locked.
+        $false is returned, because the mount may still exist.
 
     .OUTPUTS
         [bool] $true when the hive is confirmed unloaded, $false otherwise.
@@ -273,10 +293,17 @@ function Dismount-OfflineHive {
     $hiveKey = "HKLM\BROKEN$Hive"
     $Error.Clear()
 
+    $sharedState = Get-OfflineRepairState
+    if ([int]$sharedState.HiveLoadDepth[$Hive] -gt 0) {
+        Add-OfflineRepairLog -Level Error -Message "Refusing to unload $hiveKey while an Invoke-WithHive caller still owns a reference."
+        return $false
+    }
+
     $state = Get-OfflineHiveKeyState -HiveKey $hiveKey
     if ($state -eq 'Absent') {
         Add-OfflineRepairLog -Level Info -Message "$hiveKey is not currently loaded - nothing to unload."
         $null = Unregister-OfflineHiveKey -Key $hiveKey
+        [void]$sharedState.HiveFilePaths.Remove($hiveKey)
         return $true
     }
     if ($state -eq 'Unknown') {
@@ -287,6 +314,7 @@ function Dismount-OfflineHive {
 
     if (Invoke-OfflineRegUnload -HiveKey $hiveKey) {
         $null = Unregister-OfflineHiveKey -Key $hiveKey
+        [void]$sharedState.HiveFilePaths.Remove($hiveKey)
         return $true
     }
 
@@ -428,8 +456,9 @@ function Invoke-WithHive {
         Mounts one or more offline hives, runs a script block, and always unmounts them.
 
     .DESCRIPTION
-        Nested calls are reference counted, so an inner call can reuse an outer mount
-        without unloading it from under the caller. Hives are unmounted in reverse order.
+        Nested calls share reference counts across dot-source scopes, so an inner call
+        can reuse an outer mount without unloading it from under the caller. Reusing a
+        hive name for a different Windows path is refused. Hives unload in reverse order.
 
         The block's output is materialised before the hive is unloaded. PowerShell's registry
         provider keeps a key open behind every live object it returns - a
@@ -448,8 +477,10 @@ function Invoke-WithHive {
 
         The mount loop runs inside the try, so a hive that fails to load part-way through a
         multi-hive mount does not strand the ones already mounted. If a hive cannot be
-        confirmed unloaded, its depth entry is kept (the mount is still real) and the call
-        throws rather than reporting a success that left the file locked.
+        confirmed unloaded, its mount record is kept and the call throws. Reference counts
+        track active callers only and are always balanced, including on cleanup failure;
+        a later call can retry cleanup of the recorded mount instead of inheriting a
+        phantom active caller.
 
     .OUTPUTS
         The script block's output, with any live registry handle replaced by an inert
@@ -462,20 +493,22 @@ function Invoke-WithHive {
         Invoke-WithHive 'SYSTEM','SOFTWARE' { ... }
     #>
     param(
-        [Parameter(Mandatory = $true)][string[]]$Hive,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('SYSTEM', 'SOFTWARE', 'COMPONENTS', 'SAM', 'SECURITY', 'DEFAULT')]
+        [string[]]$Hive,
         [Parameter(Mandatory = $true)][scriptblock]$ScriptBlock,
         [Parameter(Mandatory = $false)][string]$WindowsPath
     )
 
-    if (-not (Get-Variable -Name OfflineHiveLoadDepth -Scope Script -ErrorAction SilentlyContinue)) {
-        $script:OfflineHiveLoadDepth = @{}
-    }
+    $offlineHiveLifecycle = Get-OfflineRepairState
+    $offlineHiveDepths = $offlineHiveLifecycle.HiveLoadDepth
 
     if ([string]::IsNullOrWhiteSpace($WindowsPath)) {
-        if ([string]::IsNullOrWhiteSpace($script:OfflineWindowsDrive)) {
+        $offlineDefaultWindowsDrive = Get-OfflineWindowsDrive
+        if ([string]::IsNullOrWhiteSpace($offlineDefaultWindowsDrive)) {
             throw 'The offline Windows drive is unknown. Run Get-OfflineWindowsDisk first, or pass -WindowsPath.'
         }
-        $WindowsPath = Join-OfflinePath -Root $script:OfflineWindowsDrive -ChildPath 'Windows'
+        $WindowsPath = Join-OfflinePath -Root $offlineDefaultWindowsDrive -ChildPath 'Windows'
     }
 
     $mountedHere = [System.Collections.Generic.List[string]]::new()
@@ -491,12 +524,18 @@ function Invoke-WithHive {
         # by the finally: without this, a first hive stays mounted when a second fails to load.
         foreach ($h in $Hive) {
             $hiveName = $h.ToUpperInvariant()
-            $depth = if ($script:OfflineHiveLoadDepth.ContainsKey($hiveName)) { [int]$script:OfflineHiveLoadDepth[$hiveName] } else { 0 }
+            $offlineHiveKey = "HKLM\BROKEN$hiveName"
+            $offlineHiveFile = ConvertTo-OfflineComparablePath (Get-OfflineHiveFilePath -WindowsPath $WindowsPath -Hive $hiveName)
+            $depth = if ($offlineHiveDepths.ContainsKey($hiveName)) { [int]$offlineHiveDepths[$hiveName] } else { 0 }
             if ($depth -eq 0) {
                 Mount-OfflineHive -WindowsPath $WindowsPath -Hive $hiveName
                 [void]$mountedHere.Add($hiveName)
+                $offlineHiveLifecycle.HiveFilePaths[$offlineHiveKey] = $offlineHiveFile
             }
-            $script:OfflineHiveLoadDepth[$hiveName] = $depth + 1
+            elseif ($offlineHiveLifecycle.HiveFilePaths[$offlineHiveKey] -ne $offlineHiveFile) {
+                throw "Cannot reuse $offlineHiveKey for '$offlineHiveFile': an outer caller owns '$($offlineHiveLifecycle.HiveFilePaths[$offlineHiveKey])'."
+            }
+            $offlineHiveDepths[$hiveName] = $depth + 1
             [void]$acquired.Add($hiveName)
         }
 
@@ -517,28 +556,23 @@ function Invoke-WithHive {
 
         for ($i = $acquired.Count - 1; $i -ge 0; $i--) {
             $hiveName = $acquired[$i]
-            $depth = if ($script:OfflineHiveLoadDepth.ContainsKey($hiveName)) { [int]$script:OfflineHiveLoadDepth[$hiveName] } else { 0 }
-            if ($depth -le 1) {
-                if ($mountedHere.Contains($hiveName)) {
-                    $unloaded = $false
-                    try { $unloaded = Dismount-OfflineHive -Hive $hiveName }
-                    catch { $unloaded = $false; Add-OfflineRepairLog -Level Error -Message "Unloading BROKEN$hiveName threw: $($_.Exception.Message)" }
-                    if ($unloaded) {
-                        # Only now is the hive really gone, so only now does the counter drop.
-                        [void]$script:OfflineHiveLoadDepth.Remove($hiveName)
-                    }
-                    else {
-                        # Keep the counter: the hive is still mounted and its file still locked.
-                        [void]$failedUnloads.Add($hiveName)
-                    }
-                }
-                else {
-                    # An outer scope owns this mount; just release our reference to it.
-                    [void]$script:OfflineHiveLoadDepth.Remove($hiveName)
-                }
+            $depth = [int]$offlineHiveDepths[$hiveName]
+            if ($depth -lt 1) {
+                Add-OfflineRepairLog -Level Error -Message "The shared reference count for BROKEN$hiveName was lost; refusing an unowned unload."
+                [void]$failedUnloads.Add($hiveName)
+                continue
             }
-            else {
-                $script:OfflineHiveLoadDepth[$hiveName] = $depth - 1
+            if ($depth -gt 1) {
+                $offlineHiveDepths[$hiveName] = $depth - 1
+                continue
+            }
+
+            [void]$offlineHiveDepths.Remove($hiveName)
+            if ($mountedHere.Contains($hiveName)) {
+                $unloaded = $false
+                try { $unloaded = Dismount-OfflineHive -Hive $hiveName }
+                catch { Add-OfflineRepairLog -Level Error -Message "Unloading BROKEN$hiveName threw: $($_.Exception.Message)" }
+                if (-not $unloaded) { [void]$failedUnloads.Add($hiveName) }
             }
         }
     }
@@ -547,10 +581,55 @@ function Invoke-WithHive {
     if ($scriptError) { throw $scriptError }
 
     if ($failedUnloads.Count -gt 0) {
-        throw "Failed to unload offline hive(s) $($failedUnloads -join ', '): the hive file(s) remain locked, so a later repair run against the same disk would fail. Unload them with 'reg unload HKLM\BROKEN<HIVE>' before retrying."
+        throw "Failed to confirm unload of offline hive(s) $($failedUnloads -join ', '). Mount records are retained for retry; inspect the logged errors before attempting manual cleanup."
     }
 
     return $snapshot
+}
+
+function Get-OfflineSelectedControlSetName {
+    <#
+    .SYNOPSIS
+        Resolves one Select reference to an existing control set without provider handles.
+
+    .DESCRIPTION
+        Current is required. Default and LastKnownGood may be absent, zero or point at a
+        missing optional set, which is skipped. A non-DWORD, out-of-range reference or
+        indeterminate target key is not a missing optional set. Strict callers throw for
+        those failures; tolerant readers log the reason and receive no selection.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet('Current', 'Default', 'LastKnownGood')][string]$Name,
+        [switch]$Strict
+    )
+
+    try {
+        $number = Get-OfflineRegistryDword -Key 'HKLM\BROKENSYSTEM\Select' -Name $Name
+        if ($null -eq $number -or ($Name -ne 'Current' -and $number -eq 0)) {
+            if ($Name -eq 'Current') { throw 'Select\Current is missing.' }
+            return $null
+        }
+        if ($number -isnot [uint32] -or $number -lt 1 -or $number -gt 999) {
+            throw "Select\$Name must be a DWORD in the range 1..999."
+        }
+
+        $controlSet = 'ControlSet{0:d3}' -f $number
+        $keyState = Get-OfflineHiveKeyState -HiveKey "HKLM\BROKENSYSTEM\$controlSet"
+        if ($keyState -eq 'Absent' -and $Name -ne 'Current') {
+            Add-OfflineRepairLog -Level Warning -Message "Select\$Name references missing optional $controlSet; skipping it."
+            return $null
+        }
+        if ($keyState -ne 'Present') {
+            throw "Select\$Name references $controlSet, whose key state is $keyState."
+        }
+        return $controlSet
+    }
+    catch {
+        $message = "Cannot resolve SYSTEM\Select\$Name to an existing control set: $($_.Exception.Message)"
+        if ($Strict) { throw $message }
+        Add-OfflineRepairLog -Level Warning -Message $message
+        return $null
+    }
 }
 
 function Get-OfflineSystemRootPath {
@@ -559,10 +638,16 @@ function Get-OfflineSystemRootPath {
         Returns the active ControlSet path inside the mounted BROKENSYSTEM hive.
 
     .DESCRIPTION
-        Falls back to ControlSet001 when the Select key is absent (e.g. offline WinPE disks).
+        Tolerant readers fall back to ControlSet001 with a warning when Current cannot
+        be resolved (for example offline WinPE disks). Writers must pass -Strict: it
+        requires a DWORD Current in 1..999 and a verifiably existing target control set.
+        Access denial and indeterminate reads never become a successful strict selection.
     #>
-    $current = (Get-ItemProperty 'HKLM:\BROKENSYSTEM\Select' -ErrorAction SilentlyContinue).Current
-    if ($current) { return 'HKLM:\BROKENSYSTEM\ControlSet{0:d3}' -f $current }
+    param([switch]$Strict)
+
+    $name = Get-OfflineSelectedControlSetName -Name Current -Strict:$Strict
+    if ($name) { return "HKLM:\BROKENSYSTEM\$name" }
+    Add-OfflineRepairLog -Level Warning -Message 'Using ControlSet001 only as a tolerant read fallback; this path is not a verified write target.'
     return 'HKLM:\BROKENSYSTEM\ControlSet001'
 }
 
@@ -570,27 +655,40 @@ function Get-OfflineControlSetName {
     <#
     .SYNOPSIS
         Returns the active ControlSet name, for example 'ControlSet001'.
+
+    .DESCRIPTION
+        Pass -Strict for a write target; it has the same contract as Get-OfflineSystemRootPath.
     #>
-    return (Split-Path -Path (Get-OfflineSystemRootPath) -Leaf)
+    param([switch]$Strict)
+
+    return (Split-Path -Path (Get-OfflineSystemRootPath -Strict:$Strict) -Leaf)
 }
 
 function Get-OfflineReferencedControlSetName {
     <#
     .SYNOPSIS
         Returns every ControlSet referenced by Select (Current, Default, LastKnownGood).
-    #>
-    $names = [System.Collections.Generic.List[string]]::new()
-    $select = Get-ItemProperty 'HKLM:\BROKENSYSTEM\Select' -ErrorAction SilentlyContinue
 
-    foreach ($value in @($select.Current, $select.Default, $select.LastKnownGood)) {
-        if ($null -eq $value) { continue }
-        $name = 'ControlSet{0:d3}' -f [int]$value
-        if (-not $names.Contains($name) -and (Test-Path "HKLM:\BROKENSYSTEM\$name")) {
+    .DESCRIPTION
+        Strict writers require a valid Current even when other references are usable.
+        Missing optional references/sets are skipped; malformed or unreadable references
+        throw in strict mode. Tolerant readers retain the ControlSet001 fallback when no
+        usable references exist and that fallback key is present.
+    #>
+    param([switch]$Strict)
+
+    $names = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($reference in @('Current', 'Default', 'LastKnownGood')) {
+        $name = Get-OfflineSelectedControlSetName -Name $reference -Strict:$Strict
+        if ($name -and -not $names.Contains($name)) {
             [void]$names.Add($name)
         }
     }
 
-    if ($names.Count -eq 0 -and (Test-Path 'HKLM:\BROKENSYSTEM\ControlSet001')) {
+    if (-not $Strict -and $names.Count -eq 0 -and
+        (Get-OfflineHiveKeyState -HiveKey 'HKLM\BROKENSYSTEM\ControlSet001') -eq 'Present') {
+        Add-OfflineRepairLog -Level Warning -Message 'Using ControlSet001 only as a tolerant read fallback; no usable Select references were found.'
         [void]$names.Add('ControlSet001')
     }
 
@@ -701,7 +799,7 @@ function Resolve-OfflineImagePath {
         [Parameter(Mandatory = $false)][string]$WindowsDrive
     )
 
-    if ([string]::IsNullOrWhiteSpace($WindowsDrive)) { $WindowsDrive = $script:OfflineWindowsDrive }
+    if ([string]::IsNullOrWhiteSpace($WindowsDrive)) { $WindowsDrive = Get-OfflineWindowsDrive }
     if ([string]::IsNullOrWhiteSpace($WindowsDrive)) {
         throw 'The offline Windows drive is unknown. Run Get-OfflineWindowsDisk first, or pass -WindowsDrive.'
     }

--- a/src/windows/common/helpers/Use-OfflineRegistryHive.ps1
+++ b/src/windows/common/helpers/Use-OfflineRegistryHive.ps1
@@ -45,9 +45,12 @@
           reused only when its backing file is verified. Test-OfflineHiveFile copies hives
           into a per-run directory locked to SYSTEM and Administrators and checks its own
           unload and cleanup.
+    v1.2: Test-OfflineHiveFile uses the shared read-only offreg reader, avoiding registry
+          mounts and scratch hive copies. An unavailable reader aborts validation rather
+          than misclassifying the hive as corrupt. Writable HKLM-based helpers are unchanged.
 #>
 
-if (-not (Get-Command Add-OfflineRepairLog -ErrorAction SilentlyContinue)) {
+if (-not (Get-Command Open-OfflineRegistryReader -ErrorAction SilentlyContinue)) {
     try {
         . (Join-Path $PSScriptRoot 'OfflineRepairCommon.ps1')
     }
@@ -622,33 +625,21 @@ function Backup-OfflineHiveFile {
 function Test-OfflineHiveFile {
     <#
     .SYNOPSIS
-        Reports whether a registry hive file is structurally loadable by Windows.
+        Reports whether the Windows Offline Registry Library can open a hive file.
 
     .DESCRIPTION
         A size and 'regf' signature check only proves the file looks like a hive. The
-        authoritative test is to have Windows parse it, which is done by loading a scratch
-        copy with reg.exe. The copy means the file on the offline disk is never modified by
-        the check, while log replay still happens exactly as it would at boot, so a dirty
-        hive whose logs are present and applicable is correctly reported as healthy.
+        parsing test uses the shared offreg reader. Hive recovery happens in memory using
+        matching logs beside the file; no HKLM key, scratch copy or source write is needed.
 
-        This is a test of whether Windows will load the file as it stands, not a verdict on
-        whether the data is recoverable. A hive left unreconciled with no usable logs, which
-        is the normal state of a RegBack copy, is reported invalid here even though chkreg
-        can recover it. Callers that have a recovery path must try it before giving up.
+        IsValid means offreg can open the file, not that Windows will boot or that every
+        hive structure is healthy. An unreconciled hive without usable logs may fail even
+        though chkreg can recover it. Callers must retain their separate structural and
+        recovery checks.
 
-        It is also not a corruption check. reg.exe loads a hive with wrecked bins without
-        complaining, so structural damage needs chkreg on top of this.
-
-        RegLoadAppKey is deliberately not used. It rejects primary OS hives with
-        ERROR_BADDB (1009): measured on a healthy Windows Server 2022 disk, SAM and
-        COMPONENTS load through it but SYSTEM and SOFTWARE always fail, while reg.exe
-        loads the same SYSTEM file without error.
-
-        The scratch copy is made inside a per-run directory that is locked to SYSTEM and
-        Administrators with inheritance disabled BEFORE any hive bytes are written, because
-        SAM and SECURITY carry credential material that must not be left readable under a
-        default TEMP ACL. The validation unload is confirmed and the directory is deleted
-        afterwards; a copy that survives cleanup is reported as an error, not ignored.
+        Missing offreg.dll, type initialisation failures and a failed close throw: they are
+        environment/cleanup failures, not a reason to restore or repair a customer's hive.
+        This does not change Invoke-WithHive's writable HKLM-based contract.
 
     .OUTPUTS
         PSCustomObject with Path, Exists, Size, IsValid and Reason.
@@ -656,6 +647,8 @@ function Test-OfflineHiveFile {
     param(
         [Parameter(Mandatory = $true)][string]$Path
     )
+
+    Initialize-OfflineRegistryReader
 
     $result = [PSCustomObject]@{
         Path    = $Path
@@ -665,9 +658,7 @@ function Test-OfflineHiveFile {
         Reason  = $null
     }
 
-    $scratchDir = $null
-    $mountKey = "RSLVALIDATE$([guid]::NewGuid().ToString('N').Substring(0, 8))"
-    $mounted = $false
+    $reader = $null
     try {
         if (-not (Test-OfflinePath $Path)) { throw 'File does not exist.' }
 
@@ -684,57 +675,14 @@ function Test-OfflineHiveFile {
         try { [void]$stream.Read($header, 0, 4) } finally { $stream.Dispose() }
         if ([System.Text.Encoding]::ASCII.GetString($header) -ne 'regf') { throw "Hive header signature 'regf' is missing." }
 
-        # Create the scratch directory and lock it down BEFORE copying any hive bytes into it,
-        # so SAM/SECURITY credential material is never written out under an inheritable TEMP ACL.
-        $scratchDir = Join-Path ([System.IO.Path]::GetTempPath()) ("rsl-hive-{0}-{1}" -f $PID, [guid]::NewGuid().ToString('N'))
-        [void][System.IO.Directory]::CreateDirectory($scratchDir)
-        $acl = Get-Acl -LiteralPath $scratchDir
-        $acl.SetAccessRuleProtection($true, $false)
-        foreach ($existingRule in @($acl.Access)) { [void]$acl.RemoveAccessRule($existingRule) }
-        $inheritBoth = [System.Security.AccessControl.InheritanceFlags]'ContainerInherit, ObjectInherit'
-        $noPropagation = [System.Security.AccessControl.PropagationFlags]::None
-        $allow = [System.Security.AccessControl.AccessControlType]::Allow
-        $fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
-        foreach ($wellKnownSid in @([System.Security.Principal.WellKnownSidType]::LocalSystemSid, [System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid)) {
-            $sid = [System.Security.Principal.SecurityIdentifier]::new($wellKnownSid, $null)
-            $acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($sid, $fullControl, $inheritBoth, $noPropagation, $allow))
-        }
-        Set-Acl -LiteralPath $scratchDir -AclObject $acl -ErrorAction Stop
-
-        $scratchHive = Join-Path $scratchDir ([System.IO.Path]::GetFileName($Path))
-        Copy-Item -LiteralPath $Path -Destination $scratchHive -Force -ErrorAction Stop
-
-        # The transaction logs travel with the hive so that a dirty hive is recovered the
-        # way Windows would recover it, instead of being reported as damaged.
-        foreach ($suffix in @('.LOG', '.LOG1', '.LOG2')) {
-            if (Test-OfflinePath "$Path$suffix") {
-                Copy-Item -LiteralPath "$Path$suffix" -Destination "$scratchHive$suffix" -Force -ErrorAction SilentlyContinue
-            }
-        }
-
-        $loadOutput = & reg.exe load "HKLM\$mountKey" $scratchHive 2>&1 | ForEach-Object { "$_" }
-        if ($LASTEXITCODE -ne 0) { throw "Windows could not load the hive: $((@($loadOutput) -join ' ').Trim())" }
-        $mounted = $true
-
+        $reader = [RslOffline.RegistryHiveReader]::Open($Path)
         $result.IsValid = $true
     }
     catch {
         $result.Reason = $_.Exception.Message
     }
     finally {
-        if ($mounted) {
-            # Confirm the validation mount is gone; a copy left loaded keeps the scratch file locked.
-            if (-not (Invoke-OfflineRegUnload -HiveKey "HKLM\$mountKey")) {
-                Add-OfflineRepairLog -Level Error -Message "Could not unload the validation hive HKLM\$mountKey; a scratch copy of '$Path' may remain loaded."
-            }
-        }
-        if ($scratchDir -and (Test-Path -LiteralPath $scratchDir)) {
-            Remove-Item -LiteralPath $scratchDir -Recurse -Force -ErrorAction SilentlyContinue
-            if (Test-Path -LiteralPath $scratchDir) {
-                # A surviving copy of SAM/SECURITY is a credential exposure, so it is surfaced, not swallowed.
-                Add-OfflineRepairLog -Level Error -Message "Could not remove the validation scratch directory '$scratchDir'; it may hold a copy of hive '$Path' (which can include SAM/SECURITY credential material). Remove it manually."
-            }
-        }
+        if ($reader) { $reader.Dispose() }
     }
 
     return $result

--- a/src/windows/common/helpers/Use-OfflineRegistryHive.ps1
+++ b/src/windows/common/helpers/Use-OfflineRegistryHive.ps1
@@ -1,0 +1,771 @@
+<#
+.SYNOPSIS
+    Helper functions for loading, using and unloading registry hives from an offline
+    Windows installation attached to a rescue VM as a data disk.
+
+.DESCRIPTION
+    Provides a safe, reference-counted wrapper around 'reg load' / 'reg unload' so that
+    repair scripts can read and modify an offline hive without leaking mounted keys.
+
+    Offline hives are mounted under HKLM:\BROKEN<HIVE> (for example HKLM:\BROKENSYSTEM).
+
+    Every mount is registered with the offline-target gate (Register-OfflineHiveKey) and
+    every confirmed unload unregisters it (Unregister-OfflineHiveKey), so Assert-OfflineTarget
+    in OfflineRepairCommon can prove that a write lands on the mounted offline image and not
+    on the rescue VM's own registry.
+
+    Invoke-WithHive materialises the script block's output into an inert snapshot before it
+    unloads the hive, because a live registry object returned by the block keeps a handle
+    open and makes 'reg unload' fail. See its help for the exact contract.
+
+    Exposed functions:
+      Invoke-WithHive                   Mount hive(s), run a script block, always unmount.
+      Get-OfflineSystemRootPath         Active ControlSet path inside the mounted SYSTEM hive.
+      Get-OfflineControlSetName         Active ControlSet name (e.g. ControlSet001).
+      Get-OfflineReferencedControlSetName        All referenced ControlSet names (Current/Default/LKG).
+      Backup-OfflineHiveFile            Copy a hive file before it is modified.
+      Resolve-OfflineImagePath          Translate a guest ImagePath into a rescue-VM path.
+
+    Mount/unmount primitives (Mount-OfflineHive / Dismount-OfflineHive) are exported too,
+    but Invoke-WithHive should be preferred because it guarantees cleanup.
+
+.NOTES
+    Name:   Use-OfflineRegistryHive.ps1
+    Requires: common/setup/init.ps1 to be dot-sourced first (for the Log-* functions).
+    These functions return values, so they buffer their messages with Add-OfflineRepairLog
+    instead of calling Log-* directly. Call Write-OfflineRepairLog at script level to flush.
+
+.VERSION
+    v1.0: Initial version.
+    v1.1: Made the unload deterministic and honest. Invoke-WithHive now snapshots the
+          block's output so no live registry handle blocks the unload, mounts inside the
+          try so a partial mount cannot strand a hive, and only drops its bookkeeping and
+          reports success once the unload is confirmed. Mount/Dismount register and
+          unregister the mount key with the offline-target gate. An existing mount is
+          reused only when its backing file is verified. Test-OfflineHiveFile copies hives
+          into a per-run directory locked to SYSTEM and Administrators and checks its own
+          unload and cleanup.
+#>
+
+if (-not (Get-Command Add-OfflineRepairLog -ErrorAction SilentlyContinue)) {
+    try {
+        . (Join-Path $PSScriptRoot 'OfflineRepairCommon.ps1')
+    }
+    catch {
+        throw "Use-OfflineRegistryHive.ps1 could not load its dependency OfflineRepairCommon.ps1 from '$PSScriptRoot': $($_.Exception.Message)"
+    }
+}
+
+# Drive letter of the offline Windows installation, normally set by Get-OfflineWindowsDisk.ps1.
+if (-not (Get-Variable -Name OfflineWindowsDrive -Scope Script -ErrorAction SilentlyContinue)) {
+    $script:OfflineWindowsDrive = $null
+}
+
+function Get-OfflineHiveFilePath {
+    <#
+    .SYNOPSIS
+        Returns the full path of an offline hive file for a given Windows directory.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$WindowsPath,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('SYSTEM', 'SOFTWARE', 'COMPONENTS', 'SAM', 'SECURITY', 'DEFAULT')]
+        [string]$Hive
+    )
+
+    return (Join-OfflinePath -Root $WindowsPath -ChildPath "System32\Config\$Hive")
+}
+
+function Get-OfflineHiveKeyState {
+    <#
+    .SYNOPSIS
+        Reports whether a mount key is loaded, using reg.exe so no in-process handle opens.
+
+    .DESCRIPTION
+        Returns 'Present' when the key is loaded, 'Absent' when reg.exe reports the key does
+        not exist, and 'Unknown' when the state could not be read (for example access is
+        denied). The distinction is the point: treating 'Unknown' as 'Absent' is exactly how
+        an access-denied result was previously mistaken for a clean unload.
+
+    .OUTPUTS
+        [string] one of 'Present', 'Absent' or 'Unknown'.
+    #>
+    param([Parameter(Mandatory = $true)][string]$HiveKey)
+
+    $out = reg.exe query $HiveKey /ve 2>&1 | Out-String
+    if ($LASTEXITCODE -eq 0) { return 'Present' }
+    # reg.exe reports "The system was unable to find the specified registry key or value"
+    # only when the key genuinely is not loaded. Any other failure is an undetermined state.
+    if ($out -match 'unable to find|cannot find|specified registry key') { return 'Absent' }
+    return 'Unknown'
+}
+
+function Test-OfflineFileInUse {
+    <#
+    .SYNOPSIS
+        Reports whether a file is held open by another handle, without modifying it.
+
+    .DESCRIPTION
+        Opens the file for read with no sharing. A loaded hive keeps its primary file open,
+        so an exclusive open fails with a sharing violation, while a file nothing has mounted
+        opens cleanly. The handle is closed at once and nothing is written, so the hive on
+        the offline disk is never changed by the check. Any other failure (for example access
+        denied) is raised to the caller, which must treat it as 'cannot verify'.
+
+    .OUTPUTS
+        [bool] $true when the file is in use, $false when it can be opened exclusively.
+    #>
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    try {
+        $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::None)
+        $stream.Dispose()
+        return $false
+    }
+    catch [System.IO.IOException] {
+        return $true
+    }
+}
+
+function Invoke-OfflineRegUnload {
+    <#
+    .SYNOPSIS
+        Unloads a mount key with reg.exe, retrying while handles release, then verifies.
+
+    .DESCRIPTION
+        Releases cached registry handles with a garbage collection pass, then retries
+        'reg unload' while PowerShell's registry provider lets go. After the loop it
+        re-queries the key with reg.exe and reports success only when the key is actually
+        gone - a zero exit code is not trusted on its own, so a hive left mounted is never
+        mistaken for unloaded. Callers decide how loudly to report a failure.
+
+    .OUTPUTS
+        [bool] $true when the key is confirmed unloaded, $false otherwise.
+    #>
+    param([Parameter(Mandatory = $true)][string]$HiveKey)
+
+    # Release cached RegistryKey handles held by PowerShell's registry provider.
+    # Do NOT call Test-Path/Get-Item on the hive path here - those open NEW handles.
+    [GC]::Collect()
+    [GC]::WaitForPendingFinalizers()
+    [GC]::Collect()
+    Start-Sleep -Milliseconds 500
+
+    Add-OfflineRepairLog -Level Info -Message "Unloading offline hive: reg unload $HiveKey"
+    $maxAttempts = 6
+    $out = ''
+    for ($i = 1; $i -le $maxAttempts; $i++) {
+        $out = reg.exe unload $HiveKey 2>&1 | Out-String
+        if ($LASTEXITCODE -eq 0 -or $out -match 'unable to find|parameter is incorrect') { break }
+        if ($i -lt $maxAttempts) {
+            [GC]::Collect()
+            [GC]::WaitForPendingFinalizers()
+            [GC]::Collect()
+            Start-Sleep -Milliseconds (500 + ($i * 500))
+        }
+    }
+
+    # A zero exit code is necessary but not sufficient. Confirm the key is really gone before
+    # reporting success, so a hive that is still mounted is never reported as unloaded.
+    if ((Get-OfflineHiveKeyState -HiveKey $HiveKey) -eq 'Absent') { return $true }
+
+    Add-OfflineRepairLog -Level Warning -Message "reg unload $HiveKey did not confirm removal (last message: $($out.Trim()))."
+    return $false
+}
+
+function Mount-OfflineHive {
+    <#
+    .SYNOPSIS
+        Loads an offline hive as HKLM\BROKEN<HIVE> and registers it with the offline gate.
+
+    .DESCRIPTION
+        A pre-existing HKLM\BROKEN<HIVE> key is reused only when it is proven to be backed by
+        THIS disk's hive file: a loaded hive holds its primary file open, so the target file
+        being in use is the signal that the mount is ours. If that file is free - which is
+        what a stale key from a crashed run, or a concurrent run against a different disk,
+        looks like - the mount is refused rather than silently retargeting every read and
+        write to the wrong hive. On a successful load or a verified reuse the key is
+        registered with Register-OfflineHiveKey so Assert-OfflineTarget will allow writes.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$WindowsPath,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('SYSTEM', 'SOFTWARE', 'COMPONENTS', 'SAM', 'SECURITY', 'DEFAULT')]
+        [string]$Hive
+    )
+
+    $offHive = Get-OfflineHiveFilePath -WindowsPath $WindowsPath -Hive $Hive
+    if (-not (Test-OfflinePath $offHive)) {
+        throw "$Hive hive not found: $offHive"
+    }
+
+    $hiveKey = "HKLM\BROKEN$Hive"
+
+    # A previous failed unload, or another run, can leave the key mounted. Reuse it only after
+    # proving it is backed by our file; otherwise refuse, because reusing a foreign or stale
+    # mount would point every read and write at the wrong hive.
+    if ((Get-OfflineHiveKeyState -HiveKey $hiveKey) -eq 'Present') {
+        try { $targetInUse = Test-OfflineFileInUse -Path $offHive }
+        catch {
+            throw "Refusing to reuse the existing $hiveKey mount: the state of '$offHive' could not be verified ($($_.Exception.Message)). Unload the key with 'reg unload $hiveKey' and retry."
+        }
+
+        if ($targetInUse) {
+            Add-OfflineRepairLog -Level Info -Message "$hiveKey is already loaded from '$offHive' - reusing the existing mount."
+            $null = Register-OfflineHiveKey -Key $hiveKey
+            return
+        }
+
+        throw "Refusing to reuse the existing $hiveKey mount: it is not backed by '$offHive' (that file is not open), so it belongs to a different disk or a crashed run. Unload it first with 'reg unload $hiveKey'."
+    }
+
+    Add-OfflineRepairLog -Level Info -Message "Loading offline hive: reg load $hiveKey `"$offHive`""
+    $out = reg.exe load $hiveKey "$offHive" 2>&1 | Out-String
+
+    if ($LASTEXITCODE -ne 0) {
+        if ($out -match 'being used by another process|locked') {
+            # The hive file is loaded under a different key name. Help the caller find it.
+            $stdKeys = @('BCD00000000', 'HARDWARE', 'SAM', 'SECURITY', 'SOFTWARE', 'SYSTEM',
+                'BROKENSYSTEM', 'BROKENSOFTWARE', 'BROKENCOMPONENTS', 'BROKENSAM',
+                'BROKENSECURITY', 'BROKENDEFAULT')
+            $foreign = reg.exe query HKLM 2>&1 | ForEach-Object {
+                if ($_ -match '^HKEY_LOCAL_MACHINE\\(.+)$') { $Matches[1] }
+            } | Where-Object { $_ -notin $stdKeys }
+
+            $hint = if ($foreign) {
+                "Non-standard HKLM keys that may hold this hive: $($foreign -join ', '). Unload them first with: reg unload HKLM\<keyname>"
+            }
+            else {
+                'Check for a hive loaded under a different key name (reg query HKLM) and unload it first.'
+            }
+            throw "Cannot load the $Hive hive - the file is already in use by another process. $hint"
+        }
+        throw "Failed to load the offline $Hive hive: $($out.Trim())"
+    }
+
+    $null = Register-OfflineHiveKey -Key $hiveKey
+}
+
+function Dismount-OfflineHive {
+    <#
+    .SYNOPSIS
+        Unloads HKLM\BROKEN<HIVE>, retrying while the registry provider releases handles.
+
+    .DESCRIPTION
+        Reports success only when the key is confirmed gone. A hive that is genuinely not
+        loaded is a success; a state that cannot be read (for example access is denied) is
+        NOT, so it is never mistaken for a clean unload. On a confirmed unload the mount key
+        is unregistered from the offline-target gate; on failure it is left registered and
+        $false is returned, because the file is still locked.
+
+    .OUTPUTS
+        [bool] $true when the hive is confirmed unloaded, $false otherwise.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('SYSTEM', 'SOFTWARE', 'COMPONENTS', 'SAM', 'SECURITY', 'DEFAULT')]
+        [string]$Hive
+    )
+
+    $hiveKey = "HKLM\BROKEN$Hive"
+    $Error.Clear()
+
+    $state = Get-OfflineHiveKeyState -HiveKey $hiveKey
+    if ($state -eq 'Absent') {
+        Add-OfflineRepairLog -Level Info -Message "$hiveKey is not currently loaded - nothing to unload."
+        $null = Unregister-OfflineHiveKey -Key $hiveKey
+        return $true
+    }
+    if ($state -eq 'Unknown') {
+        # The load state could not be read. Do not assume it is unloaded; attempt the unload
+        # and let the post-unload verification inside Invoke-OfflineRegUnload decide.
+        Add-OfflineRepairLog -Level Warning -Message "Could not read the load state of $hiveKey; attempting to unload it anyway."
+    }
+
+    if (Invoke-OfflineRegUnload -HiveKey $hiveKey) {
+        $null = Unregister-OfflineHiveKey -Key $hiveKey
+        return $true
+    }
+
+    Add-OfflineRepairLog -Level Error -Message "Failed to unload $hiveKey. The hive file may still be locked, which will block later runs against the same disk."
+    return $false
+}
+
+function ConvertTo-OfflineInertRegistryKey {
+    <#
+    .SYNOPSIS
+        Captures a live RegistryKey's data into a plain object and disposes the handle.
+
+    .DESCRIPTION
+        A returned Microsoft.Win32.RegistryKey holds an open handle that keeps the hive
+        rooted. This reads its name, values and immediate subkey names into a PSCustomObject
+        - so a caller can still read $key.Start or $key.Name - and then disposes the handle
+        so it can no longer block the unload.
+    #>
+    param([Parameter(Mandatory = $true)][Microsoft.Win32.RegistryKey]$Key)
+
+    $snapshot = [ordered]@{}
+    try {
+        $snapshot['Name'] = $Key.Name
+        $snapshot['PSChildName'] = ($Key.Name -split '\\')[-1]
+        foreach ($valueName in $Key.GetValueNames()) {
+            $propertyName = if ([string]::IsNullOrEmpty($valueName)) { '(default)' } else { $valueName }
+            if (-not $snapshot.Contains($propertyName)) {
+                try { $snapshot[$propertyName] = $Key.GetValue($valueName) }
+                catch { $snapshot[$propertyName] = $null }
+            }
+        }
+        try { $snapshot['PSSubKeyNames'] = @($Key.GetSubKeyNames()) }
+        catch { $snapshot['PSSubKeyNames'] = @() }
+    }
+    finally {
+        $Key.Dispose()
+    }
+    return [pscustomobject]$snapshot
+}
+
+function ConvertTo-OfflineInertValue {
+    <#
+    .SYNOPSIS
+        Returns a snapshot of a value with every live registry handle removed.
+
+    .DESCRIPTION
+        Invoke-WithHive has to unload the hive after the block runs, and a single live
+        Microsoft.Win32.RegistryKey - or a PSObject still bound to the registry provider,
+        which every Get-Item/Get-ItemProperty/Get-ChildItem result is through its PSDrive -
+        keeps a handle open on the hive and makes 'reg unload' fail.
+
+        This walks the block's output once and replaces ONLY those live objects with plain,
+        disconnected snapshots, disposing any handle it finds. Everything else is returned by
+        reference, unchanged: $null, strings, numbers and other value types, byte[] and other
+        value-type arrays, hashtables and PSCustomObjects that carry no registry reference are
+        never rebuilt. A subtree is rebuilt only on the path down to a registry object it
+        actually contains. A registry-backed object becomes a PSCustomObject exposing the same
+        value members (so a caller still reads $result.Start), but with no PSDrive/PSProvider
+        link and no open handle.
+
+        The ChangeCount reference is internal bookkeeping: it counts the live objects that
+        were neutralised so each level can tell whether it must rebuild or can hand back the
+        very same object it was given.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][AllowNull()]$InputObject,
+        [Parameter(Mandatory = $true)][ref]$ChangeCount,
+        [int]$Depth = 0
+    )
+
+    if ($null -eq $InputObject) { return $null }
+    # Real registry output is shallow; the guard only stops a pathological self-referential graph.
+    if ($Depth -gt 64) { return $InputObject }
+
+    $isPsObject = $InputObject -is [System.Management.Automation.PSObject]
+    $base = if ($isPsObject) { $InputObject.BaseObject } else { $InputObject }
+
+    if ($base -is [Microsoft.Win32.RegistryKey]) {
+        $ChangeCount.Value++
+        return ConvertTo-OfflineInertRegistryKey -Key $base
+    }
+
+    # Provider metadata that pins an output back to the mounted drive. Its name is inert.
+    if ($base -is [System.Management.Automation.PSDriveInfo] -or $base -is [System.Management.Automation.ProviderInfo]) {
+        $ChangeCount.Value++
+        return [string]$base
+    }
+
+    if ($base -is [string] -or $base -is [System.ValueType]) { return $InputObject }
+
+    if ($base -is [System.Array]) {
+        $elementType = $base.GetType().GetElementType()
+        if ($null -ne $elementType -and ($elementType.IsValueType -or $elementType -eq [string])) {
+            # byte[], int[], string[] and the like hold no handle and keep their exact type.
+            return $InputObject
+        }
+        $before = $ChangeCount.Value
+        $items = [object[]]::new($base.Length)
+        for ($index = 0; $index -lt $base.Length; $index++) {
+            $items[$index] = ConvertTo-OfflineInertValue -InputObject $base[$index] -ChangeCount $ChangeCount -Depth ($Depth + 1)
+        }
+        if ($ChangeCount.Value -gt $before) { return $items }
+        return $InputObject
+    }
+
+    if ($base -is [System.Collections.IDictionary]) {
+        $before = $ChangeCount.Value
+        $copy = [ordered]@{}
+        foreach ($entry in @($base.GetEnumerator())) {
+            $copy[$entry.Key] = ConvertTo-OfflineInertValue -InputObject $entry.Value -ChangeCount $ChangeCount -Depth ($Depth + 1)
+        }
+        if ($ChangeCount.Value -gt $before) { return $copy }
+        return $InputObject
+    }
+
+    if ($isPsObject) {
+        $before = $ChangeCount.Value
+        $snapshot = [ordered]@{}
+        foreach ($property in $InputObject.PSObject.Properties) {
+            # PSProvider and PSDrive are the live references that keep the hive rooted; drop them.
+            if ($property.Name -eq 'PSProvider' -or $property.Name -eq 'PSDrive') {
+                if ($null -ne $property.Value) { $ChangeCount.Value++ }
+                continue
+            }
+            $snapshot[$property.Name] = ConvertTo-OfflineInertValue -InputObject $property.Value -ChangeCount $ChangeCount -Depth ($Depth + 1)
+        }
+        if ($ChangeCount.Value -gt $before) { return [pscustomobject]$snapshot }
+        return $InputObject
+    }
+
+    # Any other reference type is passed through unchanged. The contract is to neutralise
+    # registry handles, not to deep-clone arbitrary objects a block might return.
+    return $InputObject
+}
+
+function Invoke-WithHive {
+    <#
+    .SYNOPSIS
+        Mounts one or more offline hives, runs a script block, and always unmounts them.
+
+    .DESCRIPTION
+        Nested calls are reference counted, so an inner call can reuse an outer mount
+        without unloading it from under the caller. Hives are unmounted in reverse order.
+
+        The block's output is materialised before the hive is unloaded. PowerShell's registry
+        provider keeps a key open behind every live object it returns - a
+        Microsoft.Win32.RegistryKey from Get-Item/Get-ChildItem, or the PSDrive carried by a
+        Get-ItemProperty result - and that open handle makes 'reg unload' fail with 'Access
+        is denied', which is the exact failure this helper exists to prevent. So the output is
+        passed through ConvertTo-OfflineInertValue, which replaces ONLY those live registry
+        objects with disconnected snapshots (a RegistryKey becomes a PSCustomObject exposing
+        the same values; a registry-backed PSObject loses its PSDrive/PSProvider link) and
+        disposes the handles. Ordinary results - strings, numbers, byte[], hashtables and
+        PSCustomObjects built from plain values - are returned unchanged.
+
+        A block that returned a live key and then read from it AFTER this function returned was
+        already unsafe, because the hive is unloaded by then; such a caller now receives the
+        snapshot's captured values instead of a dead handle.
+
+        The mount loop runs inside the try, so a hive that fails to load part-way through a
+        multi-hive mount does not strand the ones already mounted. If a hive cannot be
+        confirmed unloaded, its depth entry is kept (the mount is still real) and the call
+        throws rather than reporting a success that left the file locked.
+
+    .OUTPUTS
+        The script block's output, with any live registry handle replaced by an inert
+        snapshot. Shape and ordinary values are preserved.
+
+    .EXAMPLE
+        Invoke-WithHive 'SYSTEM' { Get-ItemProperty "$(Get-OfflineSystemRootPath)\Services\storvsc" }
+
+    .EXAMPLE
+        Invoke-WithHive 'SYSTEM','SOFTWARE' { ... }
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string[]]$Hive,
+        [Parameter(Mandatory = $true)][scriptblock]$ScriptBlock,
+        [Parameter(Mandatory = $false)][string]$WindowsPath
+    )
+
+    if (-not (Get-Variable -Name OfflineHiveLoadDepth -Scope Script -ErrorAction SilentlyContinue)) {
+        $script:OfflineHiveLoadDepth = @{}
+    }
+
+    if ([string]::IsNullOrWhiteSpace($WindowsPath)) {
+        if ([string]::IsNullOrWhiteSpace($script:OfflineWindowsDrive)) {
+            throw 'The offline Windows drive is unknown. Run Get-OfflineWindowsDisk first, or pass -WindowsPath.'
+        }
+        $WindowsPath = Join-OfflinePath -Root $script:OfflineWindowsDrive -ChildPath 'Windows'
+    }
+
+    $mountedHere = [System.Collections.Generic.List[string]]::new()
+    # Every hive whose depth counter this call incremented, in order, so the finally can undo
+    # exactly those - and no others - even when a later mount in the loop throws.
+    $acquired = [System.Collections.Generic.List[string]]::new()
+    $failedUnloads = [System.Collections.Generic.List[string]]::new()
+    $snapshot = $null
+    $scriptError = $null
+
+    try {
+        # The mount loop lives inside the try so that a failure part-way through is cleaned up
+        # by the finally: without this, a first hive stays mounted when a second fails to load.
+        foreach ($h in $Hive) {
+            $hiveName = $h.ToUpperInvariant()
+            $depth = if ($script:OfflineHiveLoadDepth.ContainsKey($hiveName)) { [int]$script:OfflineHiveLoadDepth[$hiveName] } else { 0 }
+            if ($depth -eq 0) {
+                Mount-OfflineHive -WindowsPath $WindowsPath -Hive $hiveName
+                [void]$mountedHere.Add($hiveName)
+            }
+            $script:OfflineHiveLoadDepth[$hiveName] = $depth + 1
+            [void]$acquired.Add($hiveName)
+        }
+
+        $rawOutput = & $ScriptBlock
+        # Sever every live registry handle before the finally tries to unload the hive.
+        $changeCount = 0
+        $snapshot = if ($null -eq $rawOutput) { $null } else { ConvertTo-OfflineInertValue -InputObject $rawOutput -ChangeCount ([ref]$changeCount) }
+        $rawOutput = $null
+    }
+    catch {
+        $scriptError = $_
+    }
+    finally {
+        # Release the provider's cached handles once, now that the output holds none, then unload.
+        [GC]::Collect()
+        [GC]::WaitForPendingFinalizers()
+        [GC]::Collect()
+
+        for ($i = $acquired.Count - 1; $i -ge 0; $i--) {
+            $hiveName = $acquired[$i]
+            $depth = if ($script:OfflineHiveLoadDepth.ContainsKey($hiveName)) { [int]$script:OfflineHiveLoadDepth[$hiveName] } else { 0 }
+            if ($depth -le 1) {
+                if ($mountedHere.Contains($hiveName)) {
+                    $unloaded = $false
+                    try { $unloaded = Dismount-OfflineHive -Hive $hiveName }
+                    catch { $unloaded = $false; Add-OfflineRepairLog -Level Error -Message "Unloading BROKEN$hiveName threw: $($_.Exception.Message)" }
+                    if ($unloaded) {
+                        # Only now is the hive really gone, so only now does the counter drop.
+                        [void]$script:OfflineHiveLoadDepth.Remove($hiveName)
+                    }
+                    else {
+                        # Keep the counter: the hive is still mounted and its file still locked.
+                        [void]$failedUnloads.Add($hiveName)
+                    }
+                }
+                else {
+                    # An outer scope owns this mount; just release our reference to it.
+                    [void]$script:OfflineHiveLoadDepth.Remove($hiveName)
+                }
+            }
+            else {
+                $script:OfflineHiveLoadDepth[$hiveName] = $depth - 1
+            }
+        }
+    }
+
+    # Surface the block's own failure first; any unload failure below is already logged Error.
+    if ($scriptError) { throw $scriptError }
+
+    if ($failedUnloads.Count -gt 0) {
+        throw "Failed to unload offline hive(s) $($failedUnloads -join ', '): the hive file(s) remain locked, so a later repair run against the same disk would fail. Unload them with 'reg unload HKLM\BROKEN<HIVE>' before retrying."
+    }
+
+    return $snapshot
+}
+
+function Get-OfflineSystemRootPath {
+    <#
+    .SYNOPSIS
+        Returns the active ControlSet path inside the mounted BROKENSYSTEM hive.
+
+    .DESCRIPTION
+        Falls back to ControlSet001 when the Select key is absent (e.g. offline WinPE disks).
+    #>
+    $current = (Get-ItemProperty 'HKLM:\BROKENSYSTEM\Select' -ErrorAction SilentlyContinue).Current
+    if ($current) { return 'HKLM:\BROKENSYSTEM\ControlSet{0:d3}' -f $current }
+    return 'HKLM:\BROKENSYSTEM\ControlSet001'
+}
+
+function Get-OfflineControlSetName {
+    <#
+    .SYNOPSIS
+        Returns the active ControlSet name, for example 'ControlSet001'.
+    #>
+    return (Split-Path -Path (Get-OfflineSystemRootPath) -Leaf)
+}
+
+function Get-OfflineReferencedControlSetName {
+    <#
+    .SYNOPSIS
+        Returns every ControlSet referenced by Select (Current, Default, LastKnownGood).
+    #>
+    $names = [System.Collections.Generic.List[string]]::new()
+    $select = Get-ItemProperty 'HKLM:\BROKENSYSTEM\Select' -ErrorAction SilentlyContinue
+
+    foreach ($value in @($select.Current, $select.Default, $select.LastKnownGood)) {
+        if ($null -eq $value) { continue }
+        $name = 'ControlSet{0:d3}' -f [int]$value
+        if (-not $names.Contains($name) -and (Test-Path "HKLM:\BROKENSYSTEM\$name")) {
+            [void]$names.Add($name)
+        }
+    }
+
+    if ($names.Count -eq 0 -and (Test-Path 'HKLM:\BROKENSYSTEM\ControlSet001')) {
+        [void]$names.Add('ControlSet001')
+    }
+
+    return @($names)
+}
+
+function Backup-OfflineHiveFile {
+    <#
+    .SYNOPSIS
+        Copies an offline hive file before it is modified, so a failed repair can be reverted.
+
+    .DESCRIPTION
+        The backup is written next to the hive with a .bak-<timestamp> suffix and the
+        full path is returned. The hive must NOT be mounted when this is called.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$WindowsPath,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('SYSTEM', 'SOFTWARE', 'COMPONENTS', 'SAM', 'SECURITY', 'DEFAULT')]
+        [string]$Hive
+    )
+
+    $source = Get-OfflineHiveFilePath -WindowsPath $WindowsPath -Hive $Hive
+    if (-not (Test-OfflinePath $source)) { throw "$Hive hive not found: $source" }
+
+    $backup = "$source.bak-$(Get-Date -Format yyyyMMddHHmmss)"
+    Copy-Item -LiteralPath $source -Destination $backup -Force
+    Add-OfflineRepairLog -Level Info -Message "Backed up the $Hive hive to $backup"
+    return $backup
+}
+
+function Test-OfflineHiveFile {
+    <#
+    .SYNOPSIS
+        Reports whether a registry hive file is structurally loadable by Windows.
+
+    .DESCRIPTION
+        A size and 'regf' signature check only proves the file looks like a hive. The
+        authoritative test is to have Windows parse it, which is done by loading a scratch
+        copy with reg.exe. The copy means the file on the offline disk is never modified by
+        the check, while log replay still happens exactly as it would at boot, so a dirty
+        hive whose logs are present and applicable is correctly reported as healthy.
+
+        This is a test of whether Windows will load the file as it stands, not a verdict on
+        whether the data is recoverable. A hive left unreconciled with no usable logs, which
+        is the normal state of a RegBack copy, is reported invalid here even though chkreg
+        can recover it. Callers that have a recovery path must try it before giving up.
+
+        It is also not a corruption check. reg.exe loads a hive with wrecked bins without
+        complaining, so structural damage needs chkreg on top of this.
+
+        RegLoadAppKey is deliberately not used. It rejects primary OS hives with
+        ERROR_BADDB (1009): measured on a healthy Windows Server 2022 disk, SAM and
+        COMPONENTS load through it but SYSTEM and SOFTWARE always fail, while reg.exe
+        loads the same SYSTEM file without error.
+
+        The scratch copy is made inside a per-run directory that is locked to SYSTEM and
+        Administrators with inheritance disabled BEFORE any hive bytes are written, because
+        SAM and SECURITY carry credential material that must not be left readable under a
+        default TEMP ACL. The validation unload is confirmed and the directory is deleted
+        afterwards; a copy that survives cleanup is reported as an error, not ignored.
+
+    .OUTPUTS
+        PSCustomObject with Path, Exists, Size, IsValid and Reason.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $result = [PSCustomObject]@{
+        Path    = $Path
+        Exists  = $false
+        Size    = 0
+        IsValid = $false
+        Reason  = $null
+    }
+
+    $scratchDir = $null
+    $mountKey = "RSLVALIDATE$([guid]::NewGuid().ToString('N').Substring(0, 8))"
+    $mounted = $false
+    try {
+        if (-not (Test-OfflinePath $Path)) { throw 'File does not exist.' }
+
+        $item = Get-Item -LiteralPath $Path -Force -ErrorAction Stop
+        if ($item.PSIsContainer) { throw 'Path is a directory, not a hive file.' }
+
+        $result.Exists = $true
+        $result.Size = $item.Length
+        if ($item.Length -eq 0) { throw 'File is 0 bytes.' }
+        if ($item.Length -lt 4096) { throw "File is $($item.Length) bytes, smaller than the 4096 byte minimum hive structure." }
+
+        $header = [byte[]]::new(4)
+        $stream = [System.IO.File]::Open($item.FullName, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+        try { [void]$stream.Read($header, 0, 4) } finally { $stream.Dispose() }
+        if ([System.Text.Encoding]::ASCII.GetString($header) -ne 'regf') { throw "Hive header signature 'regf' is missing." }
+
+        # Create the scratch directory and lock it down BEFORE copying any hive bytes into it,
+        # so SAM/SECURITY credential material is never written out under an inheritable TEMP ACL.
+        $scratchDir = Join-Path ([System.IO.Path]::GetTempPath()) ("rsl-hive-{0}-{1}" -f $PID, [guid]::NewGuid().ToString('N'))
+        [void][System.IO.Directory]::CreateDirectory($scratchDir)
+        $acl = Get-Acl -LiteralPath $scratchDir
+        $acl.SetAccessRuleProtection($true, $false)
+        foreach ($existingRule in @($acl.Access)) { [void]$acl.RemoveAccessRule($existingRule) }
+        $inheritBoth = [System.Security.AccessControl.InheritanceFlags]'ContainerInherit, ObjectInherit'
+        $noPropagation = [System.Security.AccessControl.PropagationFlags]::None
+        $allow = [System.Security.AccessControl.AccessControlType]::Allow
+        $fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
+        foreach ($wellKnownSid in @([System.Security.Principal.WellKnownSidType]::LocalSystemSid, [System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid)) {
+            $sid = [System.Security.Principal.SecurityIdentifier]::new($wellKnownSid, $null)
+            $acl.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($sid, $fullControl, $inheritBoth, $noPropagation, $allow))
+        }
+        Set-Acl -LiteralPath $scratchDir -AclObject $acl -ErrorAction Stop
+
+        $scratchHive = Join-Path $scratchDir ([System.IO.Path]::GetFileName($Path))
+        Copy-Item -LiteralPath $Path -Destination $scratchHive -Force -ErrorAction Stop
+
+        # The transaction logs travel with the hive so that a dirty hive is recovered the
+        # way Windows would recover it, instead of being reported as damaged.
+        foreach ($suffix in @('.LOG', '.LOG1', '.LOG2')) {
+            if (Test-OfflinePath "$Path$suffix") {
+                Copy-Item -LiteralPath "$Path$suffix" -Destination "$scratchHive$suffix" -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        $loadOutput = & reg.exe load "HKLM\$mountKey" $scratchHive 2>&1 | ForEach-Object { "$_" }
+        if ($LASTEXITCODE -ne 0) { throw "Windows could not load the hive: $((@($loadOutput) -join ' ').Trim())" }
+        $mounted = $true
+
+        $result.IsValid = $true
+    }
+    catch {
+        $result.Reason = $_.Exception.Message
+    }
+    finally {
+        if ($mounted) {
+            # Confirm the validation mount is gone; a copy left loaded keeps the scratch file locked.
+            if (-not (Invoke-OfflineRegUnload -HiveKey "HKLM\$mountKey")) {
+                Add-OfflineRepairLog -Level Error -Message "Could not unload the validation hive HKLM\$mountKey; a scratch copy of '$Path' may remain loaded."
+            }
+        }
+        if ($scratchDir -and (Test-Path -LiteralPath $scratchDir)) {
+            Remove-Item -LiteralPath $scratchDir -Recurse -Force -ErrorAction SilentlyContinue
+            if (Test-Path -LiteralPath $scratchDir) {
+                # A surviving copy of SAM/SECURITY is a credential exposure, so it is surfaced, not swallowed.
+                Add-OfflineRepairLog -Level Error -Message "Could not remove the validation scratch directory '$scratchDir'; it may hold a copy of hive '$Path' (which can include SAM/SECURITY credential material). Remove it manually."
+            }
+        }
+    }
+
+    return $result
+}
+
+function Resolve-OfflineImagePath {
+    <#
+    .SYNOPSIS
+        Translates a guest driver/service ImagePath into a path valid on the rescue VM.
+
+    .EXAMPLE
+        Resolve-OfflineImagePath '\SystemRoot\System32\drivers\storvsc.sys'
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$ImagePath,
+        [Parameter(Mandatory = $false)][string]$WindowsDrive
+    )
+
+    if ([string]::IsNullOrWhiteSpace($WindowsDrive)) { $WindowsDrive = $script:OfflineWindowsDrive }
+    if ([string]::IsNullOrWhiteSpace($WindowsDrive)) {
+        throw 'The offline Windows drive is unknown. Run Get-OfflineWindowsDisk first, or pass -WindowsDrive.'
+    }
+
+    $drive = $WindowsDrive.TrimEnd('\')
+    $resolved = $ImagePath `
+        -replace '(?i)\\SystemRoot\\', "$drive\Windows\" `
+        -replace '(?i)%SystemRoot%', "$drive\Windows" `
+        -replace '(?i)\\\?\?\\', '' `
+        -replace '(?i)^system32\\', "$drive\Windows\System32\" `
+        -replace '(?i)^"?[A-Z]:\\', "$drive\"
+
+    if ($resolved -match '^(.+?\.(?:sys|exe|dll))') { $resolved = $Matches[1] }
+    return $resolved
+}


### PR DESCRIPTION
## What this adds

The three helpers that read and modify the registry and other TrustedInstaller-owned resources of an
offline installation.

| Helper | Used by | Purpose |
|---|---|---|
| `Use-OfflineRegistryHive.ps1` | 17 | Guards writable hive mounts and unloads; validates hive files separately through the shared in-memory offreg reader |
| `Use-OfflineProtectedResource.ps1` | 8 | Takes ownership of a TrustedInstaller-owned file or key, makes the change, then restores the original owner and ACL |
| `Use-OfflinePrivilegedRegistry.ps1` | 2 | Privileged registry access, split out of the helper above |

No `map.json` entries are added. Helpers are not run-ids, so nothing new is invocable yet.

## Part of the #143 split

This came from the three-way split of #143. **#143 is now merged and stays unchanged.**
This PR also carries the shared `OfflineRepairCommon`/discovery support needed by both remaining
reviews, including the state bindings and VM-coordination primitives used by #147. Keeping that
shared layer here avoids another PR and conflicting copies of the same edits. The briefly opened
#148 split is closed; all remaining work stays in **#146 and #147**. Both must land before their
consuming scenario PRs.

`Use-OfflinePrivilegedRegistry.ps1` is new in the sense that it is a **file**, not new code: the
review asked for `Use-OfflineProtectedResource.ps1` to be broken up, and it divided cleanly at its
existing `#region Privileged registry access` boundary. Those functions were already named
`*OfflinePrivileged*` and only two scenarios call into them, so each gains one dot-source line.

## Why Use-OfflineRegistryHive exists

Unloading an offline hive is not reliable on its own. PowerShell's registry provider keeps keys open
after enumeration, so a `reg unload` that follows a read returns "Access is denied" and leaves the
hive mounted. That locks the file and makes every later run against the same disk fail, which is a
worse state than the fault being repaired. The helper closes the handles and confirms the hive is
gone before it returns.

The review found that this guarantee did not actually hold:

- The **mount loop sat outside the `try`**, so a failure part-way through mounting several hives left
  the earlier ones loaded with no dismount path.
- The depth entry was removed **before** the dismount, and the dismount result was discarded with
  `$null =`, so a failed unload was indistinguishable from a successful one.
- A non-zero `reg query` was treated as "not loaded, therefore success".

All three are fixed. Mounts are unwound in reverse order, unload failures are collected and thrown
rather than swallowed, and the hive is verified gone afterwards.

**Handle lifetime** was the other half of the problem: a scriptblock could return a live
`RegistryKey`, which kept the hive locked past the dismount. Rather than guess at the impact, every
call site was audited — **53 across 15 files**, classified by AST. **None** returns a live
`RegistryKey`, so that lifetime fix required no callback rewrite; the output is now snapshotted
so it cannot regress. The strict-selection follow-up below does update writing callers.

That audit also settled a design question. The mount key is a fixed `HKLM:\BROKEN<HIVE>`, and the
obvious hardening is a per-run unique key — but **35 references across 13 files** hardcode that name,
so changing it would have broken them all for a risk that is better closed directly. A stale mount is
now detected and refused fail-closed instead. Writable repair operations keep that contract;
read-only file inspection no longer needs a mount key at all.

## September 10: read-only validation without reg.exe

`Test-OfflineHiveFile` now shares the offreg reader introduced in #143's
`OfflineRepairCommon.ps1`. It opens the hive and recovers applicable logs in memory, without
mounting an HKLM key, copying credential-bearing hives to TEMP, or modifying the source. This
removes the validation mount/unload lifecycle rather than adding another retry loop.

Its result keeps the existing `Path`, `Exists`, `Size`, `IsValid` and `Reason` fields. `IsValid`
means offreg can open the file, not that the guest will boot or that a separate structural check
is unnecessary. An unavailable reader or failed close throws, so an environment/cleanup failure
cannot be mistaken for corruption and trigger an inappropriate restore.

This does not make writable registry editing mount-free: `Invoke-WithHive` retains its HKLM
contract. Its state checks and lifecycle are strengthened by the subsequent review fixes below.

## Remaining September 10 review findings

- **Localized output:** `RegOpenKeyExW` numeric results determine mounted-key existence, with
  deterministic `SafeRegistryHandle` disposal. `Present`, `Absent` and `Unknown` remain distinct;
  access denial never means absent.
  Unload decisions and verification no longer depend on English `reg.exe` messages. A file lock
  is not used as proof of registry-key identity.
- **File access:** only genuine sharing/lock violations count as "in use." Missing files and
  unrelated I/O failures are not evidence of a mount. Access denial explicitly identifies the
  file-access problem instead of advising the operator to unload an unproven foreign mount.
- **Write selection:** `-Strict` is available on the control-set selectors and is wired through
  the writing consumers. An invalid/unreadable Current value or absent current control set aborts
  the write path instead of silently selecting 001. Tolerant readers retain their fallback.
- **Dot-source reentrancy:** depth, active file bindings and the default Windows drive live in the
  shared repair state. Nested calls across scopes preserve the outer mount, balance exception
  unwinding, and refuse conflicting file/default-drive bindings. The discovery update in this
  PR publishes its result through `Set-OfflineWindowsDrive`.

The shared support also makes discovery refuse active helper-managed or unrelated guests before
disk preparation, using #147's persistent Notes marker and a reentrant host mutex. The marker is
not a reason to skip a running guest and online its disks. #147 contains the start/explicit-stop
implementation; it uses this shared layer. Both remaining PRs merge cleanly in either order.

The native lab test mounted only synthetic hives on a disposable attached VHD. It verified
Present/Absent/Unknown, an access-denied key, real sharing and file-access failures, inner
dot-source callbacks and exceptions, stale-gate removal, and strict writes persisted in
`ControlSet002` while `ControlSet001` stayed unchanged: **33 assertions passed**. The VM was an
English Windows image; this is native API/state evidence, not a claim of multilingual image coverage.

## Ownership and ACL restoration

These scenarios have to write to files and registry keys that TrustedInstaller owns. The helper takes
ownership, makes the change, and puts the original owner and ACL back, so a repaired image is not
left with permissions weaker than it started with.

Fixes from the review: the descriptor is now round-tripped in **binary** form rather than SDDL,
because machine-relative aliases can resolve to the wrong host or fail to parse on another
machine; restoration is **verified** rather than counted; a key that cannot be reopened is
a failure rather than a silent skip; captured descriptors are appended to a caller-owned list so a
mid-subtree failure no longer discards every capture; and `Assert-OfflineTarget` is called before any
privilege is enabled.

## Conventions followed

- Every repair is evidence-driven: nothing is written unless a specific fault is detected, so a
  healthy image produces no changes.
- No security protection is disabled as a workaround. Ownership is taken only for the duration of the
  change and the original descriptor is put back.
- Logging is ordered so the verdict is last, because `az vm run-command` keeps only the final 4096
  characters of the output stream.

## Testing

- **PSScriptAnalyzer: 0 findings**, at every severity.
- **140/140 dedicated registry regressions** pass on both PS5.1 and PS7 against the integrated tree.
- A call-site audit of all 53 `Invoke-WithHive` uses, included in the reply on #143.
- Defect-level tests for the hive base-name and mount/unload guarantees.
- The September 10 follow-up passed 53/53 cases on PS 5.1 and PS 7. The live Server 2022 run
  opened ten real hive types, including four dirty hives with their logs, with unchanged hashes,
  timestamps and file inventories and no validation HKLM mounts. Details are on #143.
- No `map.json` run-id resolves to a helper, so these files cannot be exercised through
  `az vm repair run` on their own. They are validated by the test suite and the call-site audit
  here; the scenario scripts that consume them are validated end-to-end in their own pull requests.
  The earlier binary-ACL validation and corrected SDDL rationale are recorded in the
  [September 8 follow-up](https://github.com/Azure/repair-script-library/pull/143#issuecomment-5589235133).
  This update does not change those ACL operations.
