### PR TITLE
Add the offline removal, BCD and nested-VM helpers (3 of 3)

### DIFF
--- a/src/windows/common/helpers/Get-OfflineBcdStore.ps1
+++ b/src/windows/common/helpers/Get-OfflineBcdStore.ps1
@@ -1,0 +1,579 @@
+<#
+.SYNOPSIS
+    Helper functions for reading and modifying the Boot Configuration Data (BCD) store
+    of an offline Windows installation attached to a rescue VM.
+
+.DESCRIPTION
+    Wraps bcdedit.exe /store so that repair scripts can inspect boot loader entries,
+    resolve the correct loader identifier, and apply changes safely against the offline
+    store rather than the rescue VM's own boot configuration.
+
+    Exposed functions:
+      Get-BcdStorePath          Build the store path for a boot drive and firmware generation.
+      Test-BcdStorePath         Test whether a BCD store exists (handles Hidden+System stores).
+      Get-BcdStoreItem          Return the FileInfo for a BCD store.
+      Assert-OfflineBcdStorePath Throw unless a store path is an offline store, not the rescue VM's.
+      Invoke-BcdEnum            Run a read-only bcdedit enumeration and report its exit code.
+      Get-BcdInventory          Parse the whole store into a structured object.
+      Get-BcdLoaderDetail      Parse a single loader entry.
+      Get-BcdBootLoaderId       Resolve the identifier of the real (non-setup) OS loader.
+      Get-BcdPreferredOsGuid    Resolve the preferred OS loader GUID.
+      Backup-BcdStore           Copy the store before it is modified.
+      Invoke-BcdEdit            Run a bcdedit command against the offline store.
+
+    Untrusted input
+    ---------------
+    Everything this file parses comes off the broken VM's disk, so every identifier,
+    device string and element name is attacker-controllable. Two consequences shape the
+    implementation:
+
+      * bcdedit is never invoked through a shell. Invoke-BcdEdit takes an argument
+        ARRAY and passes it to the executable directly, so a value such as
+        '{default} & format d:' is one literal argument to bcdedit rather than a second
+        command. A store parsed out of the broken disk therefore cannot execute code on
+        the rescue VM.
+      * The store path is validated before it is used, and a store on the rescue VM's own
+        system drive is rejected outright, so a degraded caller cannot rewrite the boot
+        configuration the rescue VM is currently running from.
+
+.NOTES
+    Name:   Get-OfflineBcdStore.ps1
+    Requires: common/setup/init.ps1 to be dot-sourced first (for the Log-* functions).
+    These functions return values, so they buffer their messages with Add-OfflineRepairLog
+    instead of calling Log-* directly. Call Write-OfflineRepairLog at script level to flush.
+    Every function targets an offline store explicitly. None of them ever modifies the
+    rescue VM's own BCD.
+
+.VERSION
+    v1.0: Initial version.
+    v1.1: Invoke-BcdEdit no longer runs bcdedit through cmd.exe and takes -Arguments
+          (string[]) instead of a -Command string; store paths and boot drives are
+          validated and the rescue VM's own drive is rejected; bcdedit exit codes are
+          inspected on the read paths so an enumeration failure is no longer reported as
+          an empty store; Backup-BcdStore verifies the copy before reporting success.
+#>
+
+if (-not (Get-Command Add-OfflineRepairLog -ErrorAction SilentlyContinue)) {
+    try {
+        . (Join-Path $PSScriptRoot 'OfflineRepairCommon.ps1')
+    }
+    catch {
+        throw "Get-OfflineBcdStore.ps1 could not load its dependency OfflineRepairCommon.ps1 from '$PSScriptRoot': $($_.Exception.Message)"
+    }
+}
+
+function Assert-OfflineBcdStorePath {
+    <#
+    .SYNOPSIS
+        Throws unless a BCD store path is a plausible offline store outside the rescue VM's
+        own system drive.
+
+    .DESCRIPTION
+        The rescue VM boots from its own BCD store. Rewriting that store instead of the
+        broken VM's makes the rescue VM itself unbootable, which is unrecoverable without
+        a second rescue pass. Because the drive letter reaches this file from a chain of
+        upstream lookups that can degrade quietly, the check is made here, at the point of
+        use, rather than trusted from the caller.
+
+        Where the shared offline root is bound (Get-OfflineWindowsDisk does this), the
+        store must also fall under it. That covers the case where a store sits on some
+        third attached disk that is neither the rescue VM's nor the one being repaired.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$StorePath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($StorePath)) {
+        throw 'Refusing to run bcdedit: the store path is empty.'
+    }
+
+    if ($StorePath -notmatch '^[A-Za-z]:\\') {
+        throw "Refusing to run bcdedit against '$StorePath': it is not rooted on a drive, so it would resolve against the rescue VM's current directory."
+    }
+
+    $storeDrive = $StorePath.Substring(0, 2).ToUpperInvariant()
+    $rescueDrive = ''
+    if ($env:SystemDrive) { $rescueDrive = $env:SystemDrive.TrimEnd('\').ToUpperInvariant() }
+
+    if ($rescueDrive -and $storeDrive -eq $rescueDrive) {
+        throw "Refusing to run bcdedit against '$StorePath': it is on the rescue VM's own system drive ($rescueDrive). Modifying it would break the rescue VM's own boot configuration."
+    }
+
+    # Only enforced once a root is bound; some callers legitimately inspect a store before
+    # the offline volume has been selected.
+    if ((Get-Command Get-OfflineRepairRoot -ErrorAction SilentlyContinue) -and (Get-OfflineRepairRoot)) {
+        Assert-OfflineTarget -Path $StorePath -Action 'run bcdedit against'
+    }
+}
+
+function Invoke-BcdEnum {
+    <#
+    .SYNOPSIS
+        Runs a read-only bcdedit enumeration and reports whether it actually succeeded.
+
+    .DESCRIPTION
+        bcdedit writes its errors to stdout and returns a non-zero exit code. Merging the
+        streams and ignoring the code makes "the store could not be opened" indistinguishable
+        from "the store is empty", and an empty inventory is what makes a repair script decide
+        the store must be rebuilt. The exit code is therefore returned alongside the text so
+        callers can tell the two apart.
+
+    .OUTPUTS
+        PSCustomObject with Success, ExitCode and Text.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$StorePath,
+        [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string[]]$Arguments
+    )
+
+    $raw = & bcdedit.exe /store $StorePath @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+
+    return [PSCustomObject]@{
+        Success  = ($exitCode -eq 0)
+        ExitCode = $exitCode
+        Text     = ($raw -join "`n")
+    }
+}
+
+function Get-BcdStorePath {
+    <#
+    .SYNOPSIS
+        Returns the BCD store path for a boot drive, based on the firmware generation.
+
+    .PARAMETER Generation
+        1 for BIOS/MBR (Gen1), 2 for UEFI/GPT (Gen2).
+
+    .PARAMETER BootDrive
+        The drive holding the offline boot partition, for example 'D:'. Only a bare drive
+        root is accepted. An unvalidated value here is how a store path silently becomes
+        the rescue VM's own, so the pattern is enforced rather than trimmed into shape.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][ValidateSet(1, 2)][int]$Generation,
+        [Parameter(Mandatory = $true)]
+        [ValidatePattern('^[A-Za-z]:\\?$')]
+        [string]$BootDrive
+    )
+
+    $BootDrive = $BootDrive.TrimEnd('\')
+    if ($Generation -eq 1) { return "$BootDrive\Boot\BCD" }
+    return "$BootDrive\EFI\Microsoft\Boot\BCD"
+}
+
+function Get-BcdStoreItem {
+    <#
+    .SYNOPSIS
+        Returns the FileInfo for a BCD store, including Hidden + System stores.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$StorePath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($StorePath)) { return $null }
+
+    $item = Get-Item -LiteralPath $StorePath -ErrorAction SilentlyContinue
+    if ($item) { return $item }
+
+    # Windows Server 2012 R2 commonly marks the BCD store Hidden + System.
+    # Retry with -Force so healthy legacy stores are not reported as missing.
+    return Get-Item -LiteralPath $StorePath -Force -ErrorAction SilentlyContinue
+}
+
+function Test-BcdStorePath {
+    <#
+    .SYNOPSIS
+        Returns $true when a BCD store exists at the given path.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$StorePath
+    )
+
+    return $null -ne (Get-BcdStoreItem -StorePath $StorePath)
+}
+
+function Get-BcdTextSection {
+    <#
+    .SYNOPSIS
+        Splits bcdedit output into Title/Body sections using its underline separators.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Text
+    )
+
+    $sections = [System.Collections.Generic.List[PSCustomObject]]::new()
+    $lines = @($Text -split "`r?`n")
+    $lineIndex = 0
+
+    while ($lineIndex -lt $lines.Count) {
+        $currentLine = $lines[$lineIndex]
+        $nextLine = if (($lineIndex + 1) -lt $lines.Count) { $lines[$lineIndex + 1] } else { '' }
+
+        if (-not [string]::IsNullOrWhiteSpace($currentLine) -and $nextLine -match '^-{3,}\s*$') {
+            $title = $currentLine.Trim()
+            $lineIndex += 2
+            $bodyLines = [System.Collections.Generic.List[string]]::new()
+
+            while ($lineIndex -lt $lines.Count) {
+                $probeLine = $lines[$lineIndex]
+                $probeNextLine = if (($lineIndex + 1) -lt $lines.Count) { $lines[$lineIndex + 1] } else { '' }
+                if (-not [string]::IsNullOrWhiteSpace($probeLine) -and $probeNextLine -match '^-{3,}\s*$') { break }
+                [void]$bodyLines.Add($probeLine)
+                $lineIndex++
+            }
+
+            $body = (($bodyLines | Where-Object { $null -ne $_ }) -join "`n").Trim()
+            if (-not [string]::IsNullOrWhiteSpace($body)) {
+                [void]$sections.Add([PSCustomObject]@{ Title = $title; Body = $body })
+            }
+            continue
+        }
+        $lineIndex++
+    }
+
+    return @($sections)
+}
+
+function ConvertTo-BcdLoaderObject {
+    <#
+    .SYNOPSIS
+        Parses the common loader fields out of a bcdedit section body.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Body,
+        [Parameter(Mandatory = $false)][string]$Title = ''
+    )
+
+    $identifier = [regex]::Match($Body, '(?im)^\s*identifier\s+(.+)$').Groups[1].Value.Trim()
+    if ([string]::IsNullOrWhiteSpace($identifier)) { return $null }
+
+    $description = [regex]::Match($Body, '(?im)^\s*description\s+(.+)$').Groups[1].Value.Trim()
+    $device = [regex]::Match($Body, '(?im)^\s*device\s+(.+)$').Groups[1].Value.Trim()
+    $osdevice = [regex]::Match($Body, '(?im)^\s*osdevice\s+(.+)$').Groups[1].Value.Trim()
+    $path = [regex]::Match($Body, '(?im)^\s*path\s+(.+)$').Groups[1].Value.Trim()
+    $systemroot = [regex]::Match($Body, '(?im)^\s*systemroot\s+(.+)$').Groups[1].Value.Trim()
+
+    $isOsLoader = ($Title -match '^Windows Boot Loader$') -or ($path -match '(?i)\\winload\.(efi|exe)$')
+    if (-not $isOsLoader) { return $null }
+
+    $partitionDrive = ''
+    foreach ($bcdValue in @($osdevice, $device)) {
+        $partitionMatch = [regex]::Match($bcdValue, '(?im)\bpartition\s*=\s*([A-Z]:)')
+        if ($partitionMatch.Success) {
+            $partitionDrive = $partitionMatch.Groups[1].Value.ToUpperInvariant()
+            break
+        }
+    }
+
+    return [PSCustomObject]@{
+        Identifier     = $identifier
+        Description    = $description
+        Device         = $device
+        OsDevice       = $osdevice
+        Path           = $path
+        SystemRoot     = $systemroot
+        PartitionDrive = $partitionDrive
+        IsSetupEntry   = (($description -match '(?i)windows setup|setup') -or ($path -match '(?i)setup'))
+    }
+}
+
+function Get-BcdInventory {
+    <#
+    .SYNOPSIS
+        Returns a structured view of an offline BCD store.
+
+    .DESCRIPTION
+        EnumSucceeded distinguishes a store that genuinely has no loader entries from one
+        that could not be read at all. Callers that rebuild a store on the strength of an
+        empty inventory must check it, otherwise a locked or access-denied store looks
+        identical to an empty one and gets needlessly rebuilt.
+
+    .OUTPUTS
+        PSCustomObject with StorePath, Exists, EnumSucceeded, EnumExitCode, RawText,
+        DefaultId, Timeout, DisplayBootMenu and Loaders.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$StorePath
+    )
+
+    $inventory = [ordered]@{
+        StorePath       = $StorePath
+        Exists          = $false
+        EnumSucceeded   = $false
+        EnumExitCode    = $null
+        RawText         = ''
+        DefaultId       = ''
+        Timeout         = ''
+        DisplayBootMenu = ''
+        Loaders         = @()
+    }
+
+    if (-not (Test-BcdStorePath -StorePath $StorePath)) {
+        return [PSCustomObject]$inventory
+    }
+
+    $inventory.Exists = $true
+
+    $enum = Invoke-BcdEnum -StorePath $StorePath -Arguments @('/enum', 'all')
+    $inventory.EnumSucceeded = $enum.Success
+    $inventory.EnumExitCode = $enum.ExitCode
+    $inventory.RawText = $enum.Text
+
+    if (-not $enum.Success) {
+        Add-OfflineRepairLog -Level Warning -Message "bcdedit could not enumerate $StorePath (exit $($enum.ExitCode)): $($enum.Text.Trim())"
+        return [PSCustomObject]$inventory
+    }
+
+    $loaders = [System.Collections.Generic.List[PSCustomObject]]::new()
+    foreach ($section in (Get-BcdTextSection -Text $inventory.RawText)) {
+        $title = $section.Title
+        $body = $section.Body
+
+        if ($title -match '^Windows Boot Manager$' -or $body -match '(?im)^\s*identifier\s+\{bootmgr\}\s*$') {
+            $inventory.DefaultId = [regex]::Match($body, '(?im)^\s*default\s+(.+)$').Groups[1].Value.Trim()
+            $inventory.Timeout = [regex]::Match($body, '(?im)^\s*timeout\s+(.+)$').Groups[1].Value.Trim()
+            $inventory.DisplayBootMenu = [regex]::Match($body, '(?im)^\s*displaybootmenu\s+(.+)$').Groups[1].Value.Trim()
+            continue
+        }
+
+        $loader = ConvertTo-BcdLoaderObject -Body $body -Title $title
+        if ($loader) { [void]$loaders.Add($loader) }
+    }
+
+    $inventory.Loaders = @($loaders)
+    return [PSCustomObject]$inventory
+}
+
+function Get-BcdLoaderDetail {
+    <#
+    .SYNOPSIS
+        Returns the parsed details of a single BCD loader entry.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$StorePath,
+        [Parameter(Mandatory = $true)][string]$Identifier
+    )
+
+    if (-not (Test-BcdStorePath -StorePath $StorePath)) { return $null }
+
+    $enum = Invoke-BcdEnum -StorePath $StorePath -Arguments @('/enum', $Identifier)
+    if (-not $enum.Success) {
+        Add-OfflineRepairLog -Level Warning -Message "bcdedit could not enumerate $Identifier in $StorePath (exit $($enum.ExitCode))."
+        return $null
+    }
+
+    $text = $enum.Text
+    if ([string]::IsNullOrWhiteSpace($text)) { return $null }
+
+    $device = [regex]::Match($text, '(?im)^\s*device\s+(.+)$').Groups[1].Value.Trim()
+    $osdevice = [regex]::Match($text, '(?im)^\s*osdevice\s+(.+)$').Groups[1].Value.Trim()
+    $path = [regex]::Match($text, '(?im)^\s*path\s+(.+)$').Groups[1].Value.Trim()
+    $systemroot = [regex]::Match($text, '(?im)^\s*systemroot\s+(.+)$').Groups[1].Value.Trim()
+    $description = [regex]::Match($text, '(?im)^\s*description\s+(.+)$').Groups[1].Value.Trim()
+
+    $partitionDrive = ''
+    foreach ($bcdValue in @($osdevice, $device)) {
+        $partitionMatch = [regex]::Match($bcdValue, '(?im)\bpartition\s*=\s*([A-Z]:)')
+        if ($partitionMatch.Success) {
+            $partitionDrive = $partitionMatch.Groups[1].Value.ToUpperInvariant()
+            break
+        }
+    }
+
+    return [PSCustomObject]@{
+        Identifier     = $Identifier
+        Description    = $description
+        Device         = $device
+        OsDevice       = $osdevice
+        Path           = $path
+        SystemRoot     = $systemroot
+        PartitionDrive = $partitionDrive
+        RawText        = $text
+        IsSetupEntry   = (($description -match '(?i)windows setup|setup') -or ($path -match '(?i)setup'))
+    }
+}
+
+function Select-BcdPreferredLoader {
+    <#
+    .SYNOPSIS
+        Picks the real OS loader from a set of loaders, preferring the default entry
+        and always skipping Windows Setup entries.
+    #>
+    param(
+        [Parameter(Mandatory = $false)][PSCustomObject[]]$Loaders = @(),
+        [Parameter(Mandatory = $false)][string]$DefaultId = ''
+    )
+
+    $preferred = @($Loaders | Where-Object { $_.Identifier -eq $DefaultId -and -not $_.IsSetupEntry } | Select-Object -First 1)
+    if (-not $preferred) { $preferred = @($Loaders | Where-Object { -not $_.IsSetupEntry } | Select-Object -First 1) }
+    if (-not $preferred) { $preferred = @($Loaders | Select-Object -First 1) }
+
+    if ($preferred) { return $preferred[0] }
+    return $null
+}
+
+function Get-BcdPreferredOsGuid {
+    <#
+    .SYNOPSIS
+        Returns the GUID of the preferred (non-setup) OS loader in an offline store.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$StorePath
+    )
+
+    if (-not (Test-BcdStorePath -StorePath $StorePath)) { return '' }
+
+    $inventory = Get-BcdInventory -StorePath $StorePath
+    $preferred = Select-BcdPreferredLoader -Loaders @($inventory.Loaders) -DefaultId $inventory.DefaultId
+
+    if ($preferred) { return [string]$preferred.Identifier }
+    return ''
+}
+
+function Get-BcdBootLoaderId {
+    <#
+    .SYNOPSIS
+        Resolves the identifier to pass to bcdedit for the real OS loader entry.
+
+    .DESCRIPTION
+        Returns the {default} alias only when it unambiguously refers to the preferred
+        loader, otherwise the explicit GUID. Falls back to parsing 'bcdedit /enum' when
+        the structured lookup finds nothing.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$StorePath
+    )
+
+    if (-not (Test-BcdStorePath -StorePath $StorePath)) {
+        Add-OfflineRepairLog -Level Warning -Message "BCD store not found at $StorePath."
+        return $null
+    }
+
+    $inventory = Get-BcdInventory -StorePath $StorePath
+    $preferredLoader = Select-BcdPreferredLoader -Loaders @($inventory.Loaders) -DefaultId $inventory.DefaultId
+
+    $identifier = ''
+    if ($preferredLoader) {
+        $canUseDefaultAlias = $false
+        if ($inventory.DefaultId) {
+            if ($preferredLoader.Identifier -eq $inventory.DefaultId) {
+                $canUseDefaultAlias = $true
+            }
+            elseif ($inventory.DefaultId -eq '{default}' -and @($inventory.Loaders).Count -eq 1) {
+                $canUseDefaultAlias = $true
+            }
+        }
+        $identifier = if ($canUseDefaultAlias) { [string]$inventory.DefaultId } else { [string]$preferredLoader.Identifier }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($identifier)) {
+        $enum = Invoke-BcdEnum -StorePath $StorePath -Arguments @('/enum')
+        if (-not $enum.Success) {
+            Add-OfflineRepairLog -Level Warning -Message "bcdedit could not enumerate $StorePath (exit $($enum.ExitCode)), so the boot loader identifier is unknown."
+            return $null
+        }
+
+        $fallbackIdentifier = [regex]::Match($enum.Text, '(?is)Windows Boot Loader.*?^\s*identifier\s+([^\r\n]+)',
+            [System.Text.RegularExpressions.RegexOptions]::Multiline).Groups[1].Value.Trim()
+
+        if (-not [string]::IsNullOrWhiteSpace($fallbackIdentifier)) { return $fallbackIdentifier }
+
+        Add-OfflineRepairLog -Level Warning -Message "Could not determine the boot loader identifier in $StorePath."
+        return $null
+    }
+
+    return $identifier
+}
+
+function Backup-BcdStore {
+    <#
+    .SYNOPSIS
+        Copies a BCD store before it is modified, so a failed repair can be reverted.
+
+    .DESCRIPTION
+        The copy is verified before success is reported. A backup that was never written
+        is worse than no backup at all, because the caller goes on to modify the store
+        believing it can roll back.
+
+    .OUTPUTS
+        The full path of the backup file.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$StorePath
+    )
+
+    if (-not (Test-BcdStorePath -StorePath $StorePath)) { throw "BCD store not found at $StorePath." }
+
+    $source = Get-BcdStoreItem -StorePath $StorePath
+    $backup = "$StorePath.bak-$(Get-Date -Format yyyyMMddHHmmss)"
+    Copy-Item -LiteralPath $StorePath -Destination $backup -Force -ErrorAction Stop
+
+    $copy = Get-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
+    if (-not $copy) { throw "The BCD store backup was reported as written but $backup does not exist." }
+    if ($source -and $copy.Length -ne $source.Length) {
+        throw "The BCD store backup at $backup is $($copy.Length) bytes but the store is $($source.Length) bytes."
+    }
+
+    Add-OfflineRepairLog -Level Info -Message "Backed up the BCD store to $backup"
+    return $backup
+}
+
+function Invoke-BcdEdit {
+    <#
+    .SYNOPSIS
+        Runs a bcdedit command against an offline store and validates the exit code.
+
+    .DESCRIPTION
+        bcdedit is invoked directly, never through cmd.exe, and the arguments are passed
+        as an array. Identifiers and element names reaching this function are parsed out
+        of the broken VM's own store, so they are untrusted: building a single command
+        line from them and handing it to a shell would let a crafted store run arbitrary
+        commands on the rescue VM as SYSTEM. Passing an array keeps each element a literal
+        argument to bcdedit no matter what it contains.
+
+        The store path is validated and a store on the rescue VM's own system drive is
+        refused, so a degraded caller cannot rewrite the boot configuration that the
+        rescue VM is running from.
+
+    .PARAMETER StorePath
+        Full path to the offline BCD store.
+
+    .PARAMETER Arguments
+        The bcdedit arguments that follow '/store <path>', one array element per argument.
+
+    .OUTPUTS
+        PSCustomObject with Success, ExitCode and Output.
+
+    .EXAMPLE
+        Invoke-BcdEdit -StorePath $store -Arguments @('/set', $loaderId, 'hypervisorlaunchtype', 'Off')
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$StorePath,
+        [Parameter(Mandatory = $true)][ValidateNotNullOrEmpty()][string[]]$Arguments
+    )
+
+    Assert-OfflineBcdStorePath -StorePath $StorePath
+
+    if (-not (Test-BcdStorePath -StorePath $StorePath)) {
+        throw "Refusing to run bcdedit: no BCD store exists at $StorePath."
+    }
+
+    Add-OfflineRepairLog -Level Info -Message "Running: bcdedit.exe /store `"$StorePath`" $($Arguments -join ' ')"
+
+    $output = & bcdedit.exe /store $StorePath @Arguments 2>&1 | Out-String
+    $exitCode = $LASTEXITCODE
+    $trimmed = $output.Trim()
+
+    if ($exitCode -ne 0) {
+        Add-OfflineRepairLog -Level Warning -Message "bcdedit returned exit code ${exitCode}: $trimmed"
+    }
+    elseif ($trimmed) {
+        Add-OfflineRepairLog -Level Info -Message $trimmed
+    }
+
+    return [PSCustomObject]@{
+        Success  = ($exitCode -eq 0)
+        ExitCode = $exitCode
+        Output   = $trimmed
+    }
+}

--- a/src/windows/common/helpers/Use-NestedRepairVm.ps1
+++ b/src/windows/common/helpers/Use-NestedRepairVm.ps1
@@ -27,6 +27,7 @@
       Test-NestedRepairVmSupported   Is the Hyper-V role, its PowerShell module and vmms usable here.
       Get-NestedRepairVm             Resolve exactly one nested guest, or explain why it cannot.
       Connect-NestedRepairVmDisk     Attach the offline disk to the guest and point its boot order at it.
+      Set-NestedRepairVmManaged      Persist the ownership marker that prevents automatic discovery shutdown.
       Start-NestedRepairVm           Take the disk offline on the host, attach it and start the guest.
       Wait-NestedRepairVmBoot        Block until the guest reports a heartbeat, or time out.
       Stop-NestedRepairVmGraceful    Ask the guest to shut down cleanly, pulling the power only if needed.
@@ -42,8 +43,14 @@
       ... edit the offline disk ...
       Start-NestedRepairVm           # host releases the disk, guest boots and applies the change
       Wait-NestedRepairVmBoot        # observe that it really booted
-      Stop-NestedRepairVm            # guest releases the disk again
+      Stop-NestedRepairVmGraceful    # confirm Stopped before taking the disk back
       Set-OfflineDisksOnline         # host takes it back to verify the result
+
+    Starting or adopting a running guest records a marker in its Notes without replacing existing
+    notes. Discovery refuses while any marked guest is active; it must not just skip the guest and
+    online its disks. The marker survives a new PowerShell process. A shared host mutex serializes
+    the short ownership/disk transitions, not an entire repair session. Callers must still sequence
+    their offline edits, guest execution and verified shutdown.
 
 .NOTES
     Name:   Use-NestedRepairVm.ps1
@@ -72,11 +79,15 @@
             - An all-skipped disk set (every requested disk unreadable or the rescue VM's own) is reported
               as a failure at both ends instead of starting a diskless guest that only burns the timeout.
             - Guests are resolved by Id, not by a name Get-VM treats as a wildcard; vmms must be running.
+    v1.2: Mark helper-managed guests persistently and serialize lifecycle transitions with discovery.
+          Report an unconfirmed or failed forced shutdown as failure, never as a completed hand-off.
 #>
 
 # Resolve the offline-repair core against this file's own folder, so a scenario loads the same
 # helper wherever it dot-sources this from, and fail loudly here rather than at the first log call.
-if (-not (Get-Command -Name Add-OfflineRepairLog -ErrorAction SilentlyContinue)) {
+if (-not (Get-Command -Name Add-OfflineRepairLog -ErrorAction SilentlyContinue) -or
+    -not (Get-Command -Name Enter-OfflineNestedVmLifecycle -ErrorAction SilentlyContinue) -or
+    -not (Get-Command -Name Test-OfflineNestedVmManaged -ErrorAction SilentlyContinue)) {
     $dependencyPath = Join-Path -Path $PSScriptRoot -ChildPath 'OfflineRepairCommon.ps1'
     try {
         . $dependencyPath
@@ -85,8 +96,11 @@ if (-not (Get-Command -Name Add-OfflineRepairLog -ErrorAction SilentlyContinue))
         throw "Use-NestedRepairVm.ps1 could not load its dependency OfflineRepairCommon.ps1 from '$dependencyPath': $($_.Exception.Message)"
     }
 }
-if (-not (Get-Command -Name Add-OfflineRepairLog -ErrorAction SilentlyContinue)) {
-    throw "Use-NestedRepairVm.ps1 requires 'Add-OfflineRepairLog', which OfflineRepairCommon.ps1 did not define."
+foreach ($required in @('Add-OfflineRepairLog', 'Get-OfflineNestedVmOwnershipTag',
+        'Test-OfflineNestedVmManaged', 'Enter-OfflineNestedVmLifecycle', 'Exit-OfflineNestedVmLifecycle')) {
+    if (-not (Get-Command -Name $required -ErrorAction SilentlyContinue)) {
+        throw "Use-NestedRepairVm.ps1 requires '$required', which OfflineRepairCommon.ps1 did not define."
+    }
 }
 
 # The name 'az vm repair create --enable-nested' gives the guest it builds.
@@ -378,6 +392,44 @@ function Connect-NestedRepairVmDisk {
     return $result
 }
 
+function Set-NestedRepairVmManaged {
+    <#
+    .SYNOPSIS
+        Protects an explicitly selected guest from automatic discovery shutdown.
+
+    .DESCRIPTION
+        Appends the shared ownership tag to Notes, preserving existing text, and verifies the
+        stored value by Id. An already tagged guest produces no write. This marker is persistent;
+        the caller must use the explicit graceful-stop helper for later disk hand-offs.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([bool])]
+    param([Parameter(Mandatory = $true)][ValidateNotNull()]$Vm)
+
+    $lease = Enter-OfflineNestedVmLifecycle
+    try {
+        $current = Get-VM -Id $Vm.Id -ErrorAction Stop
+        if (-not $current) { throw "Nested guest '$($Vm.Id)' could not be resolved before recording repair ownership." }
+        if (Test-OfflineNestedVmManaged -Vm $current) { return $true }
+        if (-not $PSCmdlet.ShouldProcess($current.Name, 'Record repair ownership in the guest Notes')) { return $false }
+
+        $notesProperty = $current.PSObject.Properties['Notes']
+        $notes = if ($notesProperty) { [string]$notesProperty.Value } else { '' }
+        $separator = if ([string]::IsNullOrEmpty($notes) -or $notes.EndsWith("`n")) { '' } else { [Environment]::NewLine }
+        $updatedNotes = $notes + $separator + (Get-OfflineNestedVmOwnershipTag)
+        Set-VM -VM $current -Notes $updatedNotes -ErrorAction Stop
+        $after = Get-VM -Id $current.Id -ErrorAction Stop
+        if (-not $after -or -not (Test-OfflineNestedVmManaged -Vm $after)) {
+            throw "Repair ownership of nested guest '$($current.Name)' could not be confirmed; the guest must not be started."
+        }
+        Add-OfflineRepairLog -Level Info -Message "Nested guest '$($current.Name)' is marked as helper-managed; automatic discovery will not interrupt it."
+        return $true
+    }
+    finally {
+        Exit-OfflineNestedVmLifecycle -Lease $lease
+    }
+}
+
 function Start-NestedRepairVm {
     <#
     .SYNOPSIS
@@ -393,6 +445,8 @@ function Start-NestedRepairVm {
         Already running is treated as success only when the guest genuinely has the requested disk
         attached. A guest that is up but was never given the disk is reported as a failure, because
         "running" would otherwise be mistaken for "attached and repairing the right disk".
+        Before success or a new start, ownership is recorded in Notes so a later discovery pass
+        cannot power the guest off. Failure to record ownership refuses the start.
 
         If the guest does not end up running, every disk this call took offline is brought back online
         before returning, so a failed start leaves the rescue VM no worse than it was found. Disks that
@@ -435,230 +489,259 @@ function Start-NestedRepairVm {
         return $result
     }
 
-    # Resolve the guest by its Id, not its name. Get-VM -Name treats its argument as a wildcard, so a
-    # name containing [ ] * or ? would match the wrong guest, or several. The Id is a GUID and exact.
-    $current = Get-VM -Id $Vm.Id -ErrorAction SilentlyContinue
-    if ($null -eq $current) {
-        $result.Reason = "the nested guest '$($Vm.Name)' no longer exists"
-        return $result
-    }
-
-    if ($current.State -eq 'Running') {
-        $result.AlreadyRunning = $true
-        $result.State = "$($current.State)"
-
-        # Running is not the same as attached. If the guest is already up but the requested disk was
-        # never handed to it, reporting success would tell the caller a disk is present that is not.
-        $requested = @($DiskNumber | Sort-Object -Unique)
-        if ($requested.Count -gt 0) {
-            try {
-                $attachedNow = @(Get-VMHardDiskDrive -VM $current -ErrorAction Stop |
-                        ForEach-Object { $_.DiskNumber } | Where-Object { $null -ne $_ })
-            }
-            catch {
-                $result.Reason = "the nested guest '$($current.Name)' is already running but the disks attached to it could not be read: $($_.Exception.Message)"
-                return $result
-            }
-
-            $missing = @($requested | Where-Object { $attachedNow -notcontains $_ })
-            if ($missing.Count -gt 0) {
-                $result.Reason = "the nested guest '$($current.Name)' is already running but does not have disk(s) $($missing -join ', ') attached, so it is not running on the disk this repair targets. Stop it and start it again so the disk is attached"
-                return $result
-            }
-        }
-
-        $result.Started = $true
-        Add-OfflineRepairLog -Level Info -Message "Nested guest '$($current.Name)' is already running with the requested disk(s) attached."
-        return $result
-    }
-
-    # Everything from here takes disks offline on the host, so this is where -WhatIf has to stop.
-    # It returns the same shape every other exit path returns, with Started left $false, so a preview
-    # run can never be mistaken by the caller for a guest that is actually up on the repaired disk.
-    $requestedDisks = @($DiskNumber | Sort-Object -Unique)
-    $whatIfTarget = if ($requestedDisks.Count -gt 0) {
-        "nested guest '$($current.Name)' with host disk(s) $($requestedDisks -join ', ')"
-    }
-    else {
-        "nested guest '$($current.Name)'"
-    }
-    if (-not $PSCmdlet.ShouldProcess($whatIfTarget, 'Take the disk(s) offline on the host, attach them and start the guest')) {
-        $result.State = "$($current.State)"
-        $result.Reason = 'the guest was not started because -WhatIf was specified'
-        return $result
-    }
-
-    # Everything from here takes disks offline on the host. If the guest does not end up running, the
-    # finally hands those disks back, so a failed start never leaves the rescue VM without volumes it
-    # had at entry. Only disks THIS call took offline are restored: disks already offline at entry were
-    # offline for a reason this function does not own, and disks the guest is now running on stay with
-    # the guest.
-    $offlined = @()      # every requested disk that is now offline, so the guest can claim and boot it
-    $weOfflined = @()    # only the disks this call took offline; these are the ones the finally restores
-    $skipped = @()       # why each requested disk never reached offline, so an all-skipped run can say so
+    $lease = Enter-OfflineNestedVmLifecycle
     try {
-        foreach ($number in ($DiskNumber | Sort-Object -Unique)) {
-            try {
-                $disk = Get-Disk -Number $number -ErrorAction Stop
-            }
-            catch {
-                $skipped += "disk $number could not be read"
-                Add-OfflineRepairLog -Level Warning -Message "Disk $number could not be read, so it was not taken offline: $($_.Exception.Message)"
-                continue
-            }
-
-            if ($disk.IsBoot -or $disk.IsSystem) {
-                $skipped += "disk $number is the rescue VM's own system disk"
-                Add-OfflineRepairLog -Level Warning -Message "Disk $number is the rescue VM's own system disk and was left online."
-                continue
-            }
-
-            if ($disk.IsOffline) {
-                # Already offline at entry: usable by the guest, but not ours to bring back afterwards.
-                $offlined += $number
-                continue
-            }
-
-            try {
-                Set-Disk -Number $number -IsOffline $true -ErrorAction Stop
-            }
-            catch {
-                $result.Reason = "disk $number could not be taken offline, so the guest cannot claim it: $($_.Exception.Message)"
-                return $result
-            }
-
-            # Read it back. A disk that is still online here means the guest will fail to start for a
-            # reason that would otherwise be reported as an unrelated Hyper-V error.
-            $after = Get-Disk -Number $number -ErrorAction SilentlyContinue
-            if ($null -eq $after -or -not $after.IsOffline) {
-                $result.Reason = "disk $number still reports as online after being taken offline, so the guest cannot claim it"
-                return $result
-            }
-
-            Add-OfflineRepairLog -Level Info -Message "Disk $number taken offline so the nested guest can claim it."
-            $offlined += $number
-            $weOfflined += $number
-        }
-        $result.DisksOffline = $offlined
-
-        # If nothing reached the offline state there is no disk for the guest to boot, and a Hyper-V VM
-        # starts perfectly well with no disk attached. Going on would set Started = $true for a guest that
-        # cannot run the repair and leave the caller waiting out its full heartbeat timeout. Stop here, and
-        # say whether each disk was unreadable or was the rescue VM's own, so the reason is actionable on
-        # its own without having to read the log.
-        if ($offlined.Count -eq 0) {
-            $detail = if ($skipped.Count -gt 0) { $skipped -join '; ' } else { 'no disks were requested' }
-            $result.Reason = "no disk could be taken offline for the nested guest, so it has nothing to boot: $detail"
-            Add-OfflineRepairLog -Level Error -Message $result.Reason
+        # Resolve the guest by its Id, not its name. Get-VM -Name treats its argument as a wildcard, so a
+        # name containing [ ] * or ? would match the wrong guest, or several. The Id is a GUID and exact.
+        $current = Get-VM -Id $Vm.Id -ErrorAction SilentlyContinue
+        if ($null -eq $current) {
+            $result.Reason = "the nested guest '$($Vm.Name)' no longer exists"
             return $result
         }
 
-        # The disk has to be attached before the guest is started, and it has to be offline before it
-        # can be attached, so this sits between the two. Attach the disks that are actually offline now,
-        # not the raw request, which may include a disk that could not be offlined. See
-        # Connect-NestedRepairVmDisk for why the guest may otherwise arrive with no disk at all.
-        $attach = Connect-NestedRepairVmDisk -Vm $current -DiskNumber $offlined
-        if ($attach.Reason) {
-            $result.Reason = $attach.Reason
-            return $result
-        }
-        $result.DisksAttached = $attach.Attached
+        if ($current.State -eq 'Running') {
+            $result.AlreadyRunning = $true
+            $result.State = "$($current.State)"
 
-        # A rescue VM is often small. Work out a startup-memory size that fits its free physical memory,
-        # so the guest can boot even when it was configured for more than the host can spare.
-        $startBytes = 0
-        try { $startBytes = [int64]$current.MemoryStartup } catch { $startBytes = 0 }
+            # Running is not the same as attached. If the guest is already up but the requested disk was
+            # never handed to it, reporting success would tell the caller a disk is present that is not.
+            $requested = @($DiskNumber | Sort-Object -Unique)
+            if ($requested.Count -gt 0) {
+                try {
+                    $attachedNow = @(Get-VMHardDiskDrive -VM $current -ErrorAction Stop |
+                            ForEach-Object { $_.DiskNumber } | Where-Object { $null -ne $_ })
+                }
+                catch {
+                    $result.Reason = "the nested guest '$($current.Name)' is already running but the disks attached to it could not be read: $($_.Exception.Message)"
+                    return $result
+                }
 
-        $freeBytes = 0
-        try { $freeBytes = [int64]((Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop).FreePhysicalMemory) * 1024 }
-        catch { $freeBytes = 0 }
+                $missing = @($requested | Where-Object { $attachedNow -notcontains $_ })
+                if ($missing.Count -gt 0) {
+                    $result.Reason = "the nested guest '$($current.Name)' is already running but does not have disk(s) $($missing -join ', ') attached, so it is not running on the disk this repair targets. Stop it and start it again so the disk is attached"
+                    return $result
+                }
+            }
 
-        $memoryFloor = 512MB    # Windows will not boot in less; also the dynamic-memory minimum used here.
-        $hostHeadroom = 512MB   # Leave the host room; Hyper-V cannot hand a guest every free byte.
-
-        $fitStartup = 0
-        if ($startBytes -gt $memoryFloor) {
-            if ($freeBytes -gt 0) { $fitStartup = [int64]($freeBytes - $hostHeadroom) }
-            else { $fitStartup = [int64]1GB }   # free memory unreadable: a size the guest can grow from
-            if ($fitStartup -gt $startBytes) { $fitStartup = $startBytes }
-            if ($fitStartup -lt $memoryFloor) { $fitStartup = $memoryFloor }
-            $fitStartup = [int64]([math]::Floor($fitStartup / 2MB) * 2MB)   # dynamic memory aligns to 2 MB
-        }
-
-        $startupFits = ($freeBytes -le 0) -or ($startBytes -le ($freeBytes - $hostHeadroom))
-
-        $memoryReduced = $false
-        if (-not $startupFits -and $fitStartup -gt 0 -and $fitStartup -lt $startBytes) {
-            # The configured startup size will not fit free memory. Shrink it and let dynamic memory grow
-            # it back if the host frees up, rather than failing before Windows even loads.
             try {
-                Set-VMMemory -VM $current -DynamicMemoryEnabled $true -MinimumBytes $memoryFloor -StartupBytes $fitStartup -MaximumBytes $startBytes -ErrorAction Stop
-                $memoryReduced = $true
-                Add-OfflineRepairLog -Level Warning -Message "Nested guest '$($current.Name)' asks for $([math]::Round($startBytes / 1GB, 2)) GB at start but only about $([math]::Round($freeBytes / 1GB, 2)) GB is free, so its startup memory was reduced to $([math]::Round($fitStartup / 1GB, 2)) GB with dynamic memory enabled."
+                if (-not (Set-NestedRepairVmManaged -Vm $current)) {
+                    $result.Reason = 'the running guest was not adopted because recording repair ownership was declined'
+                    return $result
+                }
             }
             catch {
-                Add-OfflineRepairLog -Level Warning -Message "The startup memory of '$($current.Name)' could not be reduced before starting: $($_.Exception.Message)"
+                $result.Reason = "the running guest could not be protected from automatic discovery: $($_.Exception.Message)"
+                Add-OfflineRepairLog -Level Error -Message $result.Reason
+                return $result
             }
+            $result.Started = $true
+            Add-OfflineRepairLog -Level Info -Message "Nested guest '$($current.Name)' is already running with the requested disk(s) attached."
+            return $result
         }
 
+        # Everything from here takes disks offline on the host, so this is where -WhatIf has to stop.
+        # It returns the same shape every other exit path returns, with Started left $false, so a preview
+        # run can never be mistaken by the caller for a guest that is actually up on the repaired disk.
+        $requestedDisks = @($DiskNumber | Sort-Object -Unique)
+        $whatIfTarget = if ($requestedDisks.Count -gt 0) {
+            "nested guest '$($current.Name)' with host disk(s) $($requestedDisks -join ', ')"
+        }
+        else {
+            "nested guest '$($current.Name)'"
+        }
+        if (-not $PSCmdlet.ShouldProcess($whatIfTarget, 'Take the disk(s) offline on the host, attach them and start the guest')) {
+            $result.State = "$($current.State)"
+            $result.Reason = 'the guest was not started because -WhatIf was specified'
+            return $result
+        }
+
+        # Everything from here takes disks offline on the host. If the guest does not end up running, the
+        # finally hands those disks back, so a failed start never leaves the rescue VM without volumes it
+        # had at entry. Only disks THIS call took offline are restored: disks already offline at entry were
+        # offline for a reason this function does not own, and disks the guest is now running on stay with
+        # the guest.
+        $offlined = @()      # every requested disk that is now offline, so the guest can claim and boot it
+        $weOfflined = @()    # only the disks this call took offline; these are the ones the finally restores
+        $skipped = @()       # why each requested disk never reached offline, so an all-skipped run can say so
         try {
-            Start-VM -VM $current -ErrorAction Stop | Out-Null
-        }
-        catch {
-            $startError = $_.Exception.Message
+            foreach ($number in ($DiskNumber | Sort-Object -Unique)) {
+                try {
+                    $disk = Get-Disk -Number $number -ErrorAction Stop
+                }
+                catch {
+                    $skipped += "disk $number could not be read"
+                    Add-OfflineRepairLog -Level Warning -Message "Disk $number could not be read, so it was not taken offline: $($_.Exception.Message)"
+                    continue
+                }
 
-            if ($startError -notmatch 'memory') {
-                $result.Reason = "the nested guest '$($current.Name)' failed to start: $startError"
+                if ($disk.IsBoot -or $disk.IsSystem) {
+                    $skipped += "disk $number is the rescue VM's own system disk"
+                    Add-OfflineRepairLog -Level Warning -Message "Disk $number is the rescue VM's own system disk and was left online."
+                    continue
+                }
+
+                if ($disk.IsOffline) {
+                    # Already offline at entry: usable by the guest, but not ours to bring back afterwards.
+                    $offlined += $number
+                    continue
+                }
+
+                try {
+                    Set-Disk -Number $number -IsOffline $true -ErrorAction Stop
+                }
+                catch {
+                    $result.Reason = "disk $number could not be taken offline, so the guest cannot claim it: $($_.Exception.Message)"
+                    return $result
+                }
+
+                # Read it back. A disk that is still online here means the guest will fail to start for a
+                # reason that would otherwise be reported as an unrelated Hyper-V error.
+                $after = Get-Disk -Number $number -ErrorAction SilentlyContinue
+                if ($null -eq $after -or -not $after.IsOffline) {
+                    $result.Reason = "disk $number still reports as online after being taken offline, so the guest cannot claim it"
+                    return $result
+                }
+
+                Add-OfflineRepairLog -Level Info -Message "Disk $number taken offline so the nested guest can claim it."
+                $offlined += $number
+                $weOfflined += $number
+            }
+            $result.DisksOffline = $offlined
+
+            # If nothing reached the offline state there is no disk for the guest to boot, and a Hyper-V VM
+            # starts perfectly well with no disk attached. Going on would set Started = $true for a guest that
+            # cannot run the repair and leave the caller waiting out its full heartbeat timeout. Stop here, and
+            # say whether each disk was unreadable or was the rescue VM's own, so the reason is actionable on
+            # its own without having to read the log.
+            if ($offlined.Count -eq 0) {
+                $detail = if ($skipped.Count -gt 0) { $skipped -join '; ' } else { 'no disks were requested' }
+                $result.Reason = "no disk could be taken offline for the nested guest, so it has nothing to boot: $detail"
+                Add-OfflineRepairLog -Level Error -Message $result.Reason
                 return $result
             }
 
-            # The start failed for a memory reason. If a smaller footprint has not been applied yet, apply
-            # it now and retry once; otherwise report the real reason, not a generic start failure.
-            if ($memoryReduced -or $fitStartup -le 0 -or $fitStartup -ge $startBytes) {
-                $result.Reason = "the nested guest '$($current.Name)' could not start because the rescue VM does not have enough free memory for it: $startError"
+            # The disk has to be attached before the guest is started, and it has to be offline before it
+            # can be attached, so this sits between the two. Attach the disks that are actually offline now,
+            # not the raw request, which may include a disk that could not be offlined. See
+            # Connect-NestedRepairVmDisk for why the guest may otherwise arrive with no disk at all.
+            $attach = Connect-NestedRepairVmDisk -Vm $current -DiskNumber $offlined
+            if ($attach.Reason) {
+                $result.Reason = $attach.Reason
                 return $result
+            }
+            $result.DisksAttached = $attach.Attached
+
+            try {
+                if (-not (Set-NestedRepairVmManaged -Vm $current)) {
+                    $result.Reason = 'the guest was not started because recording repair ownership was declined'
+                    return $result
+                }
+            }
+            catch {
+                $result.Reason = "the guest could not be protected from automatic discovery and was not started: $($_.Exception.Message)"
+                Add-OfflineRepairLog -Level Error -Message $result.Reason
+                return $result
+            }
+
+            # A rescue VM is often small. Work out a startup-memory size that fits its free physical memory,
+            # so the guest can boot even when it was configured for more than the host can spare.
+            $startBytes = 0
+            try { $startBytes = [int64]$current.MemoryStartup } catch { $startBytes = 0 }
+
+            $freeBytes = 0
+            try { $freeBytes = [int64]((Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop).FreePhysicalMemory) * 1024 }
+            catch { $freeBytes = 0 }
+
+            $memoryFloor = 512MB    # Windows will not boot in less; also the dynamic-memory minimum used here.
+            $hostHeadroom = 512MB   # Leave the host room; Hyper-V cannot hand a guest every free byte.
+
+            $fitStartup = 0
+            if ($startBytes -gt $memoryFloor) {
+                if ($freeBytes -gt 0) { $fitStartup = [int64]($freeBytes - $hostHeadroom) }
+                else { $fitStartup = [int64]1GB }   # free memory unreadable: a size the guest can grow from
+                if ($fitStartup -gt $startBytes) { $fitStartup = $startBytes }
+                if ($fitStartup -lt $memoryFloor) { $fitStartup = $memoryFloor }
+                $fitStartup = [int64]([math]::Floor($fitStartup / 2MB) * 2MB)   # dynamic memory aligns to 2 MB
+            }
+
+            $startupFits = ($freeBytes -le 0) -or ($startBytes -le ($freeBytes - $hostHeadroom))
+
+            $memoryReduced = $false
+            if (-not $startupFits -and $fitStartup -gt 0 -and $fitStartup -lt $startBytes) {
+                # The configured startup size will not fit free memory. Shrink it and let dynamic memory grow
+                # it back if the host frees up, rather than failing before Windows even loads.
+                try {
+                    Set-VMMemory -VM $current -DynamicMemoryEnabled $true -MinimumBytes $memoryFloor -StartupBytes $fitStartup -MaximumBytes $startBytes -ErrorAction Stop
+                    $memoryReduced = $true
+                    Add-OfflineRepairLog -Level Warning -Message "Nested guest '$($current.Name)' asks for $([math]::Round($startBytes / 1GB, 2)) GB at start but only about $([math]::Round($freeBytes / 1GB, 2)) GB is free, so its startup memory was reduced to $([math]::Round($fitStartup / 1GB, 2)) GB with dynamic memory enabled."
+                }
+                catch {
+                    Add-OfflineRepairLog -Level Warning -Message "The startup memory of '$($current.Name)' could not be reduced before starting: $($_.Exception.Message)"
+                }
             }
 
             try {
-                Set-VMMemory -VM $current -DynamicMemoryEnabled $true -MinimumBytes $memoryFloor -StartupBytes $fitStartup -MaximumBytes $startBytes -ErrorAction Stop
-                $memoryReduced = $true
-                Add-OfflineRepairLog -Level Warning -Message "Nested guest '$($current.Name)' could not start with its configured memory, so it was reduced to $([math]::Round($fitStartup / 1GB, 2)) GB with dynamic memory enabled and retried."
                 Start-VM -VM $current -ErrorAction Stop | Out-Null
             }
             catch {
-                $result.Reason = "the nested guest '$($current.Name)' could not start even after its memory was reduced to fit the rescue VM: $($_.Exception.Message)"
-                return $result
-            }
-        }
+                $startError = $_.Exception.Message
 
-        $state = (Get-VM -Id $current.Id -ErrorAction SilentlyContinue).State
-        $result.State = "$state"
-        $result.Started = ($state -eq 'Running')
+                if ($startError -notmatch 'memory') {
+                    $result.Reason = "the nested guest '$($current.Name)' failed to start: $startError"
+                    return $result
+                }
 
-        if ($result.Started) {
-            Add-OfflineRepairLog -Level Info -Message "Nested guest '$($current.Name)' started."
-        }
-        else {
-            $result.Reason = "the nested guest '$($current.Name)' was asked to start but reports state '$state'"
-        }
-    }
-    finally {
-        # Restore only the disks this call took offline, and only when the guest is not running on them.
-        # A guest that started owns its disks; disks already offline at entry are left as they were found.
-        if (-not $result.Started) {
-            foreach ($number in $weOfflined) {
+                # The start failed for a memory reason. If a smaller footprint has not been applied yet, apply
+                # it now and retry once; otherwise report the real reason, not a generic start failure.
+                if ($memoryReduced -or $fitStartup -le 0 -or $fitStartup -ge $startBytes) {
+                    $result.Reason = "the nested guest '$($current.Name)' could not start because the rescue VM does not have enough free memory for it: $startError"
+                    return $result
+                }
+
                 try {
-                    Set-Disk -Number $number -IsOffline $false -ErrorAction Stop
-                    Add-OfflineRepairLog -Level Info -Message "Disk $number was returned online after the nested guest did not start, so the rescue VM keeps the access it had at entry."
+                    Set-VMMemory -VM $current -DynamicMemoryEnabled $true -MinimumBytes $memoryFloor -StartupBytes $fitStartup -MaximumBytes $startBytes -ErrorAction Stop
+                    $memoryReduced = $true
+                    Add-OfflineRepairLog -Level Warning -Message "Nested guest '$($current.Name)' could not start with its configured memory, so it was reduced to $([math]::Round($fitStartup / 1GB, 2)) GB with dynamic memory enabled and retried."
+                    Start-VM -VM $current -ErrorAction Stop | Out-Null
                 }
                 catch {
-                    Add-OfflineRepairLog -Level Warning -Message "Disk $number could not be returned online after the nested guest did not start: $($_.Exception.Message)"
+                    $result.Reason = "the nested guest '$($current.Name)' could not start even after its memory was reduced to fit the rescue VM: $($_.Exception.Message)"
+                    return $result
+                }
+            }
+
+            $state = (Get-VM -Id $current.Id -ErrorAction SilentlyContinue).State
+            $result.State = "$state"
+            $result.Started = ($state -eq 'Running')
+
+            if ($result.Started) {
+                Add-OfflineRepairLog -Level Info -Message "Nested guest '$($current.Name)' started."
+            }
+            else {
+                $result.Reason = "the nested guest '$($current.Name)' was asked to start but reports state '$state'"
+            }
+        }
+        finally {
+            # Restore only the disks this call took offline, and only when the guest is not running on them.
+            # A guest that started owns its disks; disks already offline at entry are left as they were found.
+            if (-not $result.Started) {
+                foreach ($number in $weOfflined) {
+                    try {
+                        Set-Disk -Number $number -IsOffline $false -ErrorAction Stop
+                        Add-OfflineRepairLog -Level Info -Message "Disk $number was returned online after the nested guest did not start, so the rescue VM keeps the access it had at entry."
+                    }
+                    catch {
+                        Add-OfflineRepairLog -Level Warning -Message "Disk $number could not be returned online after the nested guest did not start: $($_.Exception.Message)"
+                    }
                 }
             }
         }
-    }
 
-    return $result
+        return $result
+    }
+    finally {
+        Exit-OfflineNestedVmLifecycle -Lease $lease
+    }
 }
 
 function Wait-NestedRepairVmBoot {
@@ -819,84 +902,104 @@ function Stop-NestedRepairVmGraceful {
         return $result
     }
 
-    $name = $Vm.Name
-    # Resolve and act on the guest by its Id. Get-VM (and Stop-VM -Name) treat the name as a wildcard,
-    # so a name containing [ ] * or ? could match the wrong guest, or several.
-    $id = $Vm.Id
-
-    $current = Get-VM -Id $id -ErrorAction SilentlyContinue
-    if (-not $current) {
-        $result.Reason = "the nested guest '$name' no longer exists"
-        return $result
-    }
-
-    if ($current.State -eq 'Off') {
-        # Deliberately not reported as graceful. Reaching here means the guest powered off on its
-        # own before it was asked to, and there is no way from the host to tell an orderly shutdown
-        # apart from a crash, so the caller is told to re-check the disk rather than trust it.
-        $result.Stopped = $true
-        $result.State = 'Off'
-        $result.Reason = "the nested guest '$name' was already off, so it is not known whether it shut down cleanly"
-        Add-OfflineRepairLog -Level Info -Message $result.Reason
-        return $result
-    }
-
-    # The shutdown request is the first thing that changes state, so -WhatIf stops here. Stopped stays
-    # $false, which is what the caller already treats as "the guest is still running".
-    if (-not $PSCmdlet.ShouldProcess("nested guest '$name'", 'Request a clean shutdown, turning it off only if it does not comply')) {
-        $result.State = [string]$current.State
-        $result.Reason = 'the guest was not stopped because -WhatIf was specified'
-        return $result
-    }
-
-    Add-OfflineRepairLog -Level Info -Message "Asking the nested guest '$name' to shut down cleanly so anything it wrote to the registry is flushed to its disk."
-
+    $lease = Enter-OfflineNestedVmLifecycle
     try {
-        Stop-VM -VM $current -Force -AsJob -ErrorAction Stop | Out-Null
-    }
-    catch {
-        # Return here. Falling through to the wait loop and the power-off path would overwrite this with
-        # the generic "had to be turned off" reason and lose the real cause of the failed request.
-        $result.State = [string]$current.State
-        $result.Reason = "the shutdown request to '$name' failed: $($_.Exception.Message)"
-        Add-OfflineRepairLog -Level Warning -Message $result.Reason
-        return $result
-    }
+        $name = $Vm.Name
+        # Resolve and act on the guest by its Id. Get-VM (and Stop-VM -Name) treat the name as a wildcard,
+        # so a name containing [ ] * or ? could match the wrong guest, or several.
+        $id = $Vm.Id
 
-    $started = Get-Date
-    while (((Get-Date) - $started).TotalSeconds -lt $TimeoutSeconds) {
         $current = Get-VM -Id $id -ErrorAction SilentlyContinue
-
         if (-not $current) {
-            $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
-            $result.Reason = "the nested guest '$name' disappeared while it was shutting down"
-            Add-OfflineRepairLog -Level Warning -Message $result.Reason
+            $result.Reason = "the nested guest '$name' no longer exists"
             return $result
         }
 
         if ($current.State -eq 'Off') {
+            # Deliberately not reported as graceful. Reaching here means the guest powered off on its
+            # own before it was asked to, and there is no way from the host to tell an orderly shutdown
+            # apart from a crash, so the caller is told to re-check the disk rather than trust it.
             $result.Stopped = $true
-            $result.Graceful = $true
             $result.State = 'Off'
-            $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
-            Add-OfflineRepairLog -Level Info -Message "The nested guest '$name' shut down cleanly after $($result.WaitedSeconds) seconds."
+            $result.Reason = "the nested guest '$name' was already off, so it is not known whether it shut down cleanly"
+            Add-OfflineRepairLog -Level Info -Message $result.Reason
             return $result
         }
 
-        Start-Sleep -Seconds $PollSeconds
+        # The shutdown request is the first thing that changes state, so -WhatIf stops here. Stopped stays
+        # $false, which is what the caller already treats as "the guest is still running".
+        if (-not $PSCmdlet.ShouldProcess("nested guest '$name'", 'Request a clean shutdown, turning it off only if it does not comply')) {
+            $result.State = [string]$current.State
+            $result.Reason = 'the guest was not stopped because -WhatIf was specified'
+            return $result
+        }
+
+        Add-OfflineRepairLog -Level Info -Message "Asking the nested guest '$name' to shut down cleanly so anything it wrote to the registry is flushed to its disk."
+
+        try {
+            Stop-VM -VM $current -Force -AsJob -ErrorAction Stop | Out-Null
+        }
+        catch {
+            # Return here. Falling through to the wait loop and the power-off path would overwrite this with
+            # the generic "had to be turned off" reason and lose the real cause of the failed request.
+            $result.State = [string]$current.State
+            $result.Reason = "the shutdown request to '$name' failed: $($_.Exception.Message)"
+            Add-OfflineRepairLog -Level Warning -Message $result.Reason
+            return $result
+        }
+
+        $started = Get-Date
+        while (((Get-Date) - $started).TotalSeconds -lt $TimeoutSeconds) {
+            $current = Get-VM -Id $id -ErrorAction SilentlyContinue
+
+            if (-not $current) {
+                $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
+                $result.Reason = "the nested guest '$name' disappeared while it was shutting down"
+                Add-OfflineRepairLog -Level Warning -Message $result.Reason
+                return $result
+            }
+
+            if ($current.State -eq 'Off') {
+                $result.Stopped = $true
+                $result.Graceful = $true
+                $result.State = 'Off'
+                $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
+                Add-OfflineRepairLog -Level Info -Message "The nested guest '$name' shut down cleanly after $($result.WaitedSeconds) seconds."
+                return $result
+            }
+
+            Start-Sleep -Seconds $PollSeconds
+        }
+
+        $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
+        Add-OfflineRepairLog -Level Warning -Message "The nested guest '$name' did not shut down within $($result.WaitedSeconds) seconds, so its power is being turned off. Anything it wrote to the registry and that Windows had not flushed yet is lost, so the disk has to be re-checked rather than trusted."
+
+        try {
+            Stop-VM -VM $current -TurnOff -Force -ErrorAction Stop
+            Start-Sleep -Seconds 3
+            $current = Get-VM -Id $id -ErrorAction Stop
+        }
+        catch {
+            $result.State = [string]$current.State
+            $result.Reason = "the nested guest '$name' could not be confirmed stopped after the shutdown timeout: $($_.Exception.Message)"
+            Add-OfflineRepairLog -Level Error -Message $result.Reason
+            return $result
+        }
+
+        $result.State = if ($current) { [string]$current.State } else { $null }
+        $result.Stopped = ($null -ne $current -and $current.State -eq 'Off')
+        $result.Graceful = $false
+        if ($result.Stopped) {
+            $result.Reason = "the nested guest '$name' had to be turned off at the power button after $($result.WaitedSeconds) seconds"
+        }
+        else {
+            $result.Reason = "the nested guest '$name' could not be confirmed Off after a forced shutdown; its disk must not be taken back"
+            Add-OfflineRepairLog -Level Error -Message $result.Reason
+        }
+
+        return $result
     }
-
-    $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
-    Add-OfflineRepairLog -Level Warning -Message "The nested guest '$name' did not shut down within $($result.WaitedSeconds) seconds, so its power is being turned off. Anything it wrote to the registry and that Windows had not flushed yet is lost, so the disk has to be re-checked rather than trusted."
-
-    Stop-VM -VM $current -TurnOff -Force -ErrorAction SilentlyContinue
-    Start-Sleep -Seconds 3
-
-    $current = Get-VM -Id $id -ErrorAction SilentlyContinue
-    $result.State = if ($current) { [string]$current.State } else { $null }
-    $result.Stopped = (-not $current) -or ($current.State -eq 'Off')
-    $result.Graceful = $false
-    $result.Reason = "the nested guest '$name' had to be turned off at the power button after $($result.WaitedSeconds) seconds"
-
-    return $result
+    finally {
+        Exit-OfflineNestedVmLifecycle -Lease $lease
+    }
 }

--- a/src/windows/common/helpers/Use-NestedRepairVm.ps1
+++ b/src/windows/common/helpers/Use-NestedRepairVm.ps1
@@ -1,0 +1,902 @@
+<#
+.SYNOPSIS
+    Helper functions for driving a nested Hyper-V guest that already exists on a rescue VM.
+
+.DESCRIPTION
+    'az vm repair create --enable-nested' builds the nested guest for us. It picks a SKU that
+    supports nested virtualization, derives the guest generation from the source VM, installs the
+    Hyper-V role, restarts the rescue VM across the reboot the role install needs, and then runs
+    win-enable-nested-hyperv.ps1 a second time to create 'ProblemVM' with the broken OS disk
+    attached and started.
+
+    None of that is repeated here. This helper covers only what a *scenario script* needs once the
+    guest exists, which is the part every existing consumer improvises:
+
+      - Find the guest deterministically. Twelve scripts in this library run a bare 'Get-VM' with no
+        name filter and assign the result straight to a variable. That silently yields an array if
+        more than one guest is ever present, and $null with no explanation if the role is installed
+        but no guest was created.
+      - Hand the disk between host and guest. The disk can only be online in one place at a time:
+        the host needs it online to edit files offline, and the guest cannot start unless the host
+        has it offline.
+      - Wait for the guest to actually boot, and report honestly when it did not. This is what lets
+        a caller verify a repair that only takes effect inside the running guest, instead of
+        starting the VM and asserting success.
+
+    Exposed functions:
+      Test-NestedRepairVmSupported   Is the Hyper-V role, its PowerShell module and vmms usable here.
+      Get-NestedRepairVm             Resolve exactly one nested guest, or explain why it cannot.
+      Connect-NestedRepairVmDisk     Attach the offline disk to the guest and point its boot order at it.
+      Start-NestedRepairVm           Take the disk offline on the host, attach it and start the guest.
+      Wait-NestedRepairVmBoot        Block until the guest reports a heartbeat, or time out.
+      Stop-NestedRepairVmGraceful    Ask the guest to shut down cleanly, pulling the power only if needed.
+
+    The reverse direction already exists and is not duplicated here:
+      Stop-NestedRepairVm            (Get-OfflineWindowsDisk.ps1) stop the guest holding the disk.
+      Set-OfflineDisksOnline         (Get-OfflineWindowsDisk.ps1) bring the disk back to the host.
+
+    A scenario script that needs the guest to run therefore follows this cycle:
+
+      Stop-NestedRepairVm            # guest releases the disk
+      Set-OfflineDisksOnline         # host takes the disk
+      ... edit the offline disk ...
+      Start-NestedRepairVm           # host releases the disk, guest boots and applies the change
+      Wait-NestedRepairVmBoot        # observe that it really booted
+      Stop-NestedRepairVm            # guest releases the disk again
+      Set-OfflineDisksOnline         # host takes it back to verify the result
+
+.NOTES
+    Name:   Use-NestedRepairVm.ps1
+    Requires: common/setup/init.ps1 dot-sourced first (for the Log-* functions), and
+              common/helpers/OfflineRepairCommon.ps1 (for Add-OfflineRepairLog).
+    These functions return values, so they buffer their messages with Add-OfflineRepairLog
+    instead of calling Log-* directly. Call Write-OfflineRepairLog at script level to flush.
+
+    A heartbeat proves the guest booted far enough to run Integration Services. Its absence does
+    not prove the opposite, because a guest can be up with the service disabled. Every function
+    here reports what it observed and never converts a timeout into success.
+
+.VERSION
+    v1.0: Initial version.
+    v1.1: Reliability fixes to the resource lifecycle so a failed operation never leaves the rescue VM
+          worse off while reporting success.
+            - Start-NestedRepairVm restores, in a finally, exactly the disks it took offline whenever the
+              guest does not end up running; attaches the disks it actually offlined instead of the raw
+              request; treats "already running" as success only when the requested disk is truly attached;
+              and fits the guest's startup memory to the host, retrying with dynamic memory on a memory
+              failure.
+            - Wait-NestedRepairVmBoot stops on every terminal state (Off, Paused, Saved, PausedCritical).
+            - Connect-NestedRepairVmDisk fails, rather than warning, when a Generation 2 guest cannot be
+              pointed at its disk.
+            - Stop-NestedRepairVmGraceful returns the real reason when the shutdown request itself fails.
+            - An all-skipped disk set (every requested disk unreadable or the rescue VM's own) is reported
+              as a failure at both ends instead of starting a diskless guest that only burns the timeout.
+            - Guests are resolved by Id, not by a name Get-VM treats as a wildcard; vmms must be running.
+#>
+
+# Resolve the offline-repair core against this file's own folder, so a scenario loads the same
+# helper wherever it dot-sources this from, and fail loudly here rather than at the first log call.
+if (-not (Get-Command -Name Add-OfflineRepairLog -ErrorAction SilentlyContinue)) {
+    $dependencyPath = Join-Path -Path $PSScriptRoot -ChildPath 'OfflineRepairCommon.ps1'
+    try {
+        . $dependencyPath
+    }
+    catch {
+        throw "Use-NestedRepairVm.ps1 could not load its dependency OfflineRepairCommon.ps1 from '$dependencyPath': $($_.Exception.Message)"
+    }
+}
+if (-not (Get-Command -Name Add-OfflineRepairLog -ErrorAction SilentlyContinue)) {
+    throw "Use-NestedRepairVm.ps1 requires 'Add-OfflineRepairLog', which OfflineRepairCommon.ps1 did not define."
+}
+
+# The name 'az vm repair create --enable-nested' gives the guest it builds.
+$script:NestedRepairVmDefaultName = 'ProblemVM'
+
+function Test-NestedRepairVmSupported {
+    <#
+    .SYNOPSIS
+        Reports whether this machine can drive a nested Hyper-V guest.
+
+    .DESCRIPTION
+        Checks the three things a caller actually depends on: the Hyper-V role being installed, the
+        Hyper-V PowerShell module being present so Get-VM exists, and the Virtual Machine Management
+        service (vmms) actually running. They are independent: the role and module can be present while
+        vmms is stopped or disabled, in which case every later call against a guest fails with a
+        confusing error, so that case is reported here as not supported.
+
+    .OUTPUTS
+        PSCustomObject with Supported, RoleInstalled, ModuleAvailable, ServiceRunning and Reason.
+    #>
+    $result = [PSCustomObject]@{
+        Supported       = $false
+        RoleInstalled   = $false
+        ModuleAvailable = $false
+        ServiceRunning  = $false
+        Reason          = $null
+    }
+
+    $result.ModuleAvailable = [bool](Get-Command -Name 'Get-VM' -ErrorAction SilentlyContinue)
+
+    try {
+        $feature = Get-WindowsFeature -Name 'Hyper-V' -ErrorAction Stop
+        $result.RoleInstalled = [bool]$feature.Installed
+    }
+    catch {
+        # Get-WindowsFeature is Server-only. On a client rescue image fall back to the module,
+        # which is the capability the caller actually needs.
+        $result.RoleInstalled = $result.ModuleAvailable
+    }
+
+    # The role and module can both be present while the Virtual Machine Management service is stopped or
+    # disabled. Get-VM still exists in that state, but every later call against a guest fails with a
+    # confusing error, so a stopped vmms is treated here as "not supported" with one clear reason.
+    $vmms = Get-Service -Name 'vmms' -ErrorAction SilentlyContinue
+    $result.ServiceRunning = ($null -ne $vmms -and $vmms.Status -eq 'Running')
+
+    if (-not $result.RoleInstalled) {
+        $result.Reason = 'the Hyper-V role is not installed on this rescue VM'
+    }
+    elseif (-not $result.ModuleAvailable) {
+        $result.Reason = 'the Hyper-V role is installed but its PowerShell module is missing, so Get-VM is unavailable'
+    }
+    elseif (-not $result.ServiceRunning) {
+        $result.Reason = 'the Hyper-V role is installed but its Virtual Machine Management service (vmms) is not running, so no nested guest can be managed'
+    }
+    else {
+        $result.Supported = $true
+    }
+
+    return $result
+}
+
+function Get-NestedRepairVm {
+    <#
+    .SYNOPSIS
+        Resolves exactly one nested Hyper-V guest on this rescue VM.
+
+    .DESCRIPTION
+        Prefers the guest that 'az vm repair create --enable-nested' creates, which is named
+        'ProblemVM'. When that name is absent and exactly one guest exists, that guest is used and
+        the substitution is logged. When several guests exist and none carries the expected name,
+        no guess is made: picking one at random is how a repair ends up applied to the wrong disk.
+
+    .PARAMETER Name
+        Look for this guest instead of the default 'ProblemVM'.
+
+    .OUTPUTS
+        PSCustomObject with Vm, Found, Name, State, Generation and Reason. Vm is $null unless
+        exactly one guest was resolved.
+    #>
+    param(
+        [Parameter(Mandatory = $false)][string]$Name = $script:NestedRepairVmDefaultName
+    )
+
+    $result = [PSCustomObject]@{
+        Vm         = $null
+        Found      = $false
+        Name       = $null
+        State      = $null
+        Generation = $null
+        Reason     = $null
+    }
+
+    $support = Test-NestedRepairVmSupported
+    if (-not $support.Supported) {
+        $result.Reason = $support.Reason
+        return $result
+    }
+
+    try {
+        $all = @(Get-VM -ErrorAction Stop)
+    }
+    catch {
+        $result.Reason = "the Hyper-V guests could not be enumerated: $($_.Exception.Message)"
+        return $result
+    }
+
+    if ($all.Count -eq 0) {
+        $result.Reason = 'the Hyper-V role is installed but no nested guest exists. Create the rescue VM with "az vm repair create --enable-nested" so the broken disk is attached to a guest'
+        return $result
+    }
+
+    $match = @($all | Where-Object { $_.Name -eq $Name })
+
+    if ($match.Count -eq 1) {
+        $vm = $match[0]
+    }
+    elseif ($match.Count -gt 1) {
+        $result.Reason = "more than one Hyper-V guest is named '$Name', so the correct one cannot be identified"
+        return $result
+    }
+    elseif ($all.Count -eq 1) {
+        $vm = $all[0]
+        Add-OfflineRepairLog -Level Info -Message "No guest named '$Name' was found, but exactly one nested guest exists, so '$($vm.Name)' is being used."
+    }
+    else {
+        $names = ($all | ForEach-Object { $_.Name }) -join ', '
+        $result.Reason = "no guest is named '$Name' and $($all.Count) guests exist ($names), so the correct one cannot be identified. Pass -Name to choose"
+        return $result
+    }
+
+    $result.Vm = $vm
+    $result.Found = $true
+    $result.Name = $vm.Name
+    $result.State = "$($vm.State)"
+
+    try { $result.Generation = [int]$vm.Generation } catch { $result.Generation = $null }
+
+    return $result
+}
+
+function Connect-NestedRepairVmDisk {
+    <#
+    .SYNOPSIS
+        Makes sure the guest actually has the disk before it is asked to boot from it.
+
+    .DESCRIPTION
+        This exists because of a defect in win-enable-nested-hyperv, which is what
+        'az vm repair create --enable-nested' runs to build the guest. That script selects the
+        passthrough disk with:
+
+            get-disk | where {$_.FriendlyName -eq 'Msft Virtual Disk'}
+
+        Every disk on an Azure VM answers to that name, including the rescue VM's own boot disk,
+        so the pipeline that follows tries to take the boot disk offline. That fails, the script is
+        running with -ErrorAction Stop, and it aborts before it ever reaches Add-VMHardDiskDrive.
+        The guest is left created but empty, with a boot order containing only a network adapter.
+
+        A guest in that state starts happily and then sits in its firmware finding nothing to boot,
+        which looks exactly like a slow boot until the wait times out. Attaching the disk here turns
+        a silent ten minute failure into a working repair.
+
+        The disk has to be offline on the host before it can be attached, so this runs after the
+        caller has taken it offline.
+
+        For a Generation 2 guest the boot order is then pointed at that disk. If it cannot be, whether
+        the firmware exposes no drive or the promotion does not take, this reports a Reason and stops
+        rather than only warning, because such a guest PXE boots and never loads Windows, which the
+        caller would otherwise discover only when its heartbeat wait times out.
+
+        Being asked to attach no disk at all is treated as a failure, not a no-op. A caller that reaches
+        here with an empty set has lost track of the disks it meant to repair, and silently succeeding
+        would let the guest start with nothing attached.
+
+    .PARAMETER Vm
+        The guest to attach to, as returned in the Vm property of Get-NestedRepairVm.
+
+    .PARAMETER DiskNumber
+        Host disk numbers that the guest must be able to boot from.
+
+    .OUTPUTS
+        PSCustomObject with Attached, AlreadyAttached, BootOrderSet and Reason.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][AllowNull()]$Vm,
+        [Parameter(Mandatory = $false)][int[]]$DiskNumber = @()
+    )
+
+    $result = [PSCustomObject]@{
+        Attached        = @()
+        AlreadyAttached = @()
+        BootOrderSet    = $false
+        Reason          = $null
+    }
+
+    if ($null -eq $Vm) {
+        $result.Reason = 'no nested guest was supplied'
+        return $result
+    }
+
+    if ($DiskNumber.Count -eq 0) {
+        # Attaching nothing is never legitimate: a caller that reaches here has lost track of the disks it
+        # meant to repair. Report it rather than returning a silent success, which would let the guest
+        # start with no disk and boot to firmware until the caller's heartbeat wait times out.
+        $result.Reason = 'no disk was supplied to attach to the nested guest'
+        return $result
+    }
+
+    $generation = 1
+    try { $generation = [int]$Vm.Generation } catch { $generation = 1 }
+
+    try {
+        # Address the guest by object, not by a name Get-VMHardDiskDrive would treat as a wildcard.
+        $existing = @(Get-VMHardDiskDrive -VM $Vm -ErrorAction Stop)
+    }
+    catch {
+        $result.Reason = "the disks attached to '$($Vm.Name)' could not be read: $($_.Exception.Message)"
+        return $result
+    }
+
+    $present = @($existing | ForEach-Object { $_.DiskNumber } | Where-Object { $null -ne $_ })
+
+    foreach ($number in ($DiskNumber | Sort-Object -Unique)) {
+        if ($present -contains $number) {
+            $result.AlreadyAttached += $number
+            continue
+        }
+
+        try {
+            if ($generation -ge 2) {
+                Add-VMHardDiskDrive -VM $Vm -DiskNumber $number -ControllerType SCSI -ControllerNumber 0 -ErrorAction Stop
+            }
+            else {
+                Add-VMHardDiskDrive -VM $Vm -DiskNumber $number -ErrorAction Stop
+            }
+        }
+        catch {
+            $result.Reason = "disk $number could not be attached to '$($Vm.Name)': $($_.Exception.Message)"
+            return $result
+        }
+
+        # Read it back. An attach that silently did nothing produces a guest that boots to its
+        # firmware and waits, which is the failure this function exists to prevent.
+        $now = @(Get-VMHardDiskDrive -VM $Vm -ErrorAction SilentlyContinue | ForEach-Object { $_.DiskNumber })
+        if ($now -notcontains $number) {
+            $result.Reason = "disk $number does not appear on '$($Vm.Name)' after being attached"
+            return $result
+        }
+
+        Add-OfflineRepairLog -Level Info -Message "Disk $number attached to nested guest '$($Vm.Name)'."
+        $result.Attached += $number
+    }
+
+    # A Generation 2 guest boots in UEFI order. The guest created by the library ships with a
+    # network adapter first, so a drive has to be promoted or the guest will try to PXE boot.
+    if ($generation -ge 2) {
+        # A Generation 2 guest boots in UEFI order. The guest created by the library ships with a
+        # network adapter first, so a drive has to be promoted or the guest will PXE boot and find
+        # nothing, which looks like a slow boot until the caller's heartbeat wait times out ~10 minutes
+        # later. If the boot order cannot be pointed at the disk, that is a failure, not a warning:
+        # report it now so the caller does not wait out that timeout on a guest that can never boot.
+        try {
+            $drives = @((Get-VMFirmware -VM $Vm -ErrorAction Stop).BootOrder |
+                    Where-Object { $_.BootType -eq 'Drive' })
+
+            if ($drives.Count -eq 0) {
+                $result.Reason = "nested guest '$($Vm.Name)' has no disk in its boot order, so it would PXE boot and never load Windows"
+                return $result
+            }
+
+            Set-VMFirmware -VM $Vm -FirstBootDevice $drives[0] -ErrorAction Stop
+
+            $first = @((Get-VMFirmware -VM $Vm -ErrorAction SilentlyContinue).BootOrder)[0]
+            $result.BootOrderSet = ($null -ne $first -and $first.BootType -eq 'Drive')
+
+            if (-not $result.BootOrderSet) {
+                $result.Reason = "nested guest '$($Vm.Name)' still lists a non-disk device first in its boot order, so it would PXE boot and never load Windows"
+                return $result
+            }
+
+            Add-OfflineRepairLog -Level Info -Message "Nested guest '$($Vm.Name)' set to boot from its disk rather than the network."
+        }
+        catch {
+            $result.Reason = "the boot order of nested guest '$($Vm.Name)' could not be set, so it cannot be made to boot from its disk: $($_.Exception.Message)"
+            return $result
+        }
+    }
+
+    return $result
+}
+
+function Start-NestedRepairVm {
+    <#
+    .SYNOPSIS
+        Releases the disk from the host and starts the nested guest.
+
+    .DESCRIPTION
+        A passthrough disk can only be claimed by one side at a time. The guest refuses to start
+        while the host still holds the disk online, so the disk is taken offline first.
+
+        Only the disks the caller names are touched. The rescue VM's own system disk is never a
+        candidate, because it is not offline-able and is not what the guest boots from.
+
+        Already running is treated as success only when the guest genuinely has the requested disk
+        attached. A guest that is up but was never given the disk is reported as a failure, because
+        "running" would otherwise be mistaken for "attached and repairing the right disk".
+
+        If the guest does not end up running, every disk this call took offline is brought back online
+        before returning, so a failed start leaves the rescue VM no worse than it was found. Disks that
+        were already offline at entry are left alone. If none of the requested disks could be taken
+        offline, whether unreadable or because they are the rescue VM's own system disk, the guest is
+        never started, because a guest with no disk boots to firmware and only burns the caller's
+        heartbeat timeout; the returned Reason names which disks were skipped and why. On a host too
+        small for the guest's configured startup memory, that memory is fitted to the host's free memory
+        with dynamic memory enabled, and a memory-related start failure is retried the same way before
+        it is reported as one.
+
+    .PARAMETER Vm
+        The guest to start, as returned in the Vm property of Get-NestedRepairVm.
+
+    .PARAMETER DiskNumber
+        Disk numbers to take offline before starting. Usually the DiskNumber of the offline
+        Windows install being repaired.
+
+    .OUTPUTS
+        PSCustomObject with Started, AlreadyRunning, State, DisksOffline, DisksAttached and Reason.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true)][AllowNull()]$Vm,
+        [Parameter(Mandatory = $false)][int[]]$DiskNumber = @()
+    )
+
+    $result = [PSCustomObject]@{
+        Started        = $false
+        AlreadyRunning = $false
+        State          = $null
+        DisksOffline   = @()
+        DisksAttached  = @()
+        Reason         = $null
+    }
+
+    if ($null -eq $Vm) {
+        $result.Reason = 'no nested guest was supplied'
+        return $result
+    }
+
+    # Resolve the guest by its Id, not its name. Get-VM -Name treats its argument as a wildcard, so a
+    # name containing [ ] * or ? would match the wrong guest, or several. The Id is a GUID and exact.
+    $current = Get-VM -Id $Vm.Id -ErrorAction SilentlyContinue
+    if ($null -eq $current) {
+        $result.Reason = "the nested guest '$($Vm.Name)' no longer exists"
+        return $result
+    }
+
+    if ($current.State -eq 'Running') {
+        $result.AlreadyRunning = $true
+        $result.State = "$($current.State)"
+
+        # Running is not the same as attached. If the guest is already up but the requested disk was
+        # never handed to it, reporting success would tell the caller a disk is present that is not.
+        $requested = @($DiskNumber | Sort-Object -Unique)
+        if ($requested.Count -gt 0) {
+            try {
+                $attachedNow = @(Get-VMHardDiskDrive -VM $current -ErrorAction Stop |
+                        ForEach-Object { $_.DiskNumber } | Where-Object { $null -ne $_ })
+            }
+            catch {
+                $result.Reason = "the nested guest '$($current.Name)' is already running but the disks attached to it could not be read: $($_.Exception.Message)"
+                return $result
+            }
+
+            $missing = @($requested | Where-Object { $attachedNow -notcontains $_ })
+            if ($missing.Count -gt 0) {
+                $result.Reason = "the nested guest '$($current.Name)' is already running but does not have disk(s) $($missing -join ', ') attached, so it is not running on the disk this repair targets. Stop it and start it again so the disk is attached"
+                return $result
+            }
+        }
+
+        $result.Started = $true
+        Add-OfflineRepairLog -Level Info -Message "Nested guest '$($current.Name)' is already running with the requested disk(s) attached."
+        return $result
+    }
+
+    # Everything from here takes disks offline on the host, so this is where -WhatIf has to stop.
+    # It returns the same shape every other exit path returns, with Started left $false, so a preview
+    # run can never be mistaken by the caller for a guest that is actually up on the repaired disk.
+    $requestedDisks = @($DiskNumber | Sort-Object -Unique)
+    $whatIfTarget = if ($requestedDisks.Count -gt 0) {
+        "nested guest '$($current.Name)' with host disk(s) $($requestedDisks -join ', ')"
+    }
+    else {
+        "nested guest '$($current.Name)'"
+    }
+    if (-not $PSCmdlet.ShouldProcess($whatIfTarget, 'Take the disk(s) offline on the host, attach them and start the guest')) {
+        $result.State = "$($current.State)"
+        $result.Reason = 'the guest was not started because -WhatIf was specified'
+        return $result
+    }
+
+    # Everything from here takes disks offline on the host. If the guest does not end up running, the
+    # finally hands those disks back, so a failed start never leaves the rescue VM without volumes it
+    # had at entry. Only disks THIS call took offline are restored: disks already offline at entry were
+    # offline for a reason this function does not own, and disks the guest is now running on stay with
+    # the guest.
+    $offlined = @()      # every requested disk that is now offline, so the guest can claim and boot it
+    $weOfflined = @()    # only the disks this call took offline; these are the ones the finally restores
+    $skipped = @()       # why each requested disk never reached offline, so an all-skipped run can say so
+    try {
+        foreach ($number in ($DiskNumber | Sort-Object -Unique)) {
+            try {
+                $disk = Get-Disk -Number $number -ErrorAction Stop
+            }
+            catch {
+                $skipped += "disk $number could not be read"
+                Add-OfflineRepairLog -Level Warning -Message "Disk $number could not be read, so it was not taken offline: $($_.Exception.Message)"
+                continue
+            }
+
+            if ($disk.IsBoot -or $disk.IsSystem) {
+                $skipped += "disk $number is the rescue VM's own system disk"
+                Add-OfflineRepairLog -Level Warning -Message "Disk $number is the rescue VM's own system disk and was left online."
+                continue
+            }
+
+            if ($disk.IsOffline) {
+                # Already offline at entry: usable by the guest, but not ours to bring back afterwards.
+                $offlined += $number
+                continue
+            }
+
+            try {
+                Set-Disk -Number $number -IsOffline $true -ErrorAction Stop
+            }
+            catch {
+                $result.Reason = "disk $number could not be taken offline, so the guest cannot claim it: $($_.Exception.Message)"
+                return $result
+            }
+
+            # Read it back. A disk that is still online here means the guest will fail to start for a
+            # reason that would otherwise be reported as an unrelated Hyper-V error.
+            $after = Get-Disk -Number $number -ErrorAction SilentlyContinue
+            if ($null -eq $after -or -not $after.IsOffline) {
+                $result.Reason = "disk $number still reports as online after being taken offline, so the guest cannot claim it"
+                return $result
+            }
+
+            Add-OfflineRepairLog -Level Info -Message "Disk $number taken offline so the nested guest can claim it."
+            $offlined += $number
+            $weOfflined += $number
+        }
+        $result.DisksOffline = $offlined
+
+        # If nothing reached the offline state there is no disk for the guest to boot, and a Hyper-V VM
+        # starts perfectly well with no disk attached. Going on would set Started = $true for a guest that
+        # cannot run the repair and leave the caller waiting out its full heartbeat timeout. Stop here, and
+        # say whether each disk was unreadable or was the rescue VM's own, so the reason is actionable on
+        # its own without having to read the log.
+        if ($offlined.Count -eq 0) {
+            $detail = if ($skipped.Count -gt 0) { $skipped -join '; ' } else { 'no disks were requested' }
+            $result.Reason = "no disk could be taken offline for the nested guest, so it has nothing to boot: $detail"
+            Add-OfflineRepairLog -Level Error -Message $result.Reason
+            return $result
+        }
+
+        # The disk has to be attached before the guest is started, and it has to be offline before it
+        # can be attached, so this sits between the two. Attach the disks that are actually offline now,
+        # not the raw request, which may include a disk that could not be offlined. See
+        # Connect-NestedRepairVmDisk for why the guest may otherwise arrive with no disk at all.
+        $attach = Connect-NestedRepairVmDisk -Vm $current -DiskNumber $offlined
+        if ($attach.Reason) {
+            $result.Reason = $attach.Reason
+            return $result
+        }
+        $result.DisksAttached = $attach.Attached
+
+        # A rescue VM is often small. Work out a startup-memory size that fits its free physical memory,
+        # so the guest can boot even when it was configured for more than the host can spare.
+        $startBytes = 0
+        try { $startBytes = [int64]$current.MemoryStartup } catch { $startBytes = 0 }
+
+        $freeBytes = 0
+        try { $freeBytes = [int64]((Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop).FreePhysicalMemory) * 1024 }
+        catch { $freeBytes = 0 }
+
+        $memoryFloor = 512MB    # Windows will not boot in less; also the dynamic-memory minimum used here.
+        $hostHeadroom = 512MB   # Leave the host room; Hyper-V cannot hand a guest every free byte.
+
+        $fitStartup = 0
+        if ($startBytes -gt $memoryFloor) {
+            if ($freeBytes -gt 0) { $fitStartup = [int64]($freeBytes - $hostHeadroom) }
+            else { $fitStartup = [int64]1GB }   # free memory unreadable: a size the guest can grow from
+            if ($fitStartup -gt $startBytes) { $fitStartup = $startBytes }
+            if ($fitStartup -lt $memoryFloor) { $fitStartup = $memoryFloor }
+            $fitStartup = [int64]([math]::Floor($fitStartup / 2MB) * 2MB)   # dynamic memory aligns to 2 MB
+        }
+
+        $startupFits = ($freeBytes -le 0) -or ($startBytes -le ($freeBytes - $hostHeadroom))
+
+        $memoryReduced = $false
+        if (-not $startupFits -and $fitStartup -gt 0 -and $fitStartup -lt $startBytes) {
+            # The configured startup size will not fit free memory. Shrink it and let dynamic memory grow
+            # it back if the host frees up, rather than failing before Windows even loads.
+            try {
+                Set-VMMemory -VM $current -DynamicMemoryEnabled $true -MinimumBytes $memoryFloor -StartupBytes $fitStartup -MaximumBytes $startBytes -ErrorAction Stop
+                $memoryReduced = $true
+                Add-OfflineRepairLog -Level Warning -Message "Nested guest '$($current.Name)' asks for $([math]::Round($startBytes / 1GB, 2)) GB at start but only about $([math]::Round($freeBytes / 1GB, 2)) GB is free, so its startup memory was reduced to $([math]::Round($fitStartup / 1GB, 2)) GB with dynamic memory enabled."
+            }
+            catch {
+                Add-OfflineRepairLog -Level Warning -Message "The startup memory of '$($current.Name)' could not be reduced before starting: $($_.Exception.Message)"
+            }
+        }
+
+        try {
+            Start-VM -VM $current -ErrorAction Stop | Out-Null
+        }
+        catch {
+            $startError = $_.Exception.Message
+
+            if ($startError -notmatch 'memory') {
+                $result.Reason = "the nested guest '$($current.Name)' failed to start: $startError"
+                return $result
+            }
+
+            # The start failed for a memory reason. If a smaller footprint has not been applied yet, apply
+            # it now and retry once; otherwise report the real reason, not a generic start failure.
+            if ($memoryReduced -or $fitStartup -le 0 -or $fitStartup -ge $startBytes) {
+                $result.Reason = "the nested guest '$($current.Name)' could not start because the rescue VM does not have enough free memory for it: $startError"
+                return $result
+            }
+
+            try {
+                Set-VMMemory -VM $current -DynamicMemoryEnabled $true -MinimumBytes $memoryFloor -StartupBytes $fitStartup -MaximumBytes $startBytes -ErrorAction Stop
+                $memoryReduced = $true
+                Add-OfflineRepairLog -Level Warning -Message "Nested guest '$($current.Name)' could not start with its configured memory, so it was reduced to $([math]::Round($fitStartup / 1GB, 2)) GB with dynamic memory enabled and retried."
+                Start-VM -VM $current -ErrorAction Stop | Out-Null
+            }
+            catch {
+                $result.Reason = "the nested guest '$($current.Name)' could not start even after its memory was reduced to fit the rescue VM: $($_.Exception.Message)"
+                return $result
+            }
+        }
+
+        $state = (Get-VM -Id $current.Id -ErrorAction SilentlyContinue).State
+        $result.State = "$state"
+        $result.Started = ($state -eq 'Running')
+
+        if ($result.Started) {
+            Add-OfflineRepairLog -Level Info -Message "Nested guest '$($current.Name)' started."
+        }
+        else {
+            $result.Reason = "the nested guest '$($current.Name)' was asked to start but reports state '$state'"
+        }
+    }
+    finally {
+        # Restore only the disks this call took offline, and only when the guest is not running on them.
+        # A guest that started owns its disks; disks already offline at entry are left as they were found.
+        if (-not $result.Started) {
+            foreach ($number in $weOfflined) {
+                try {
+                    Set-Disk -Number $number -IsOffline $false -ErrorAction Stop
+                    Add-OfflineRepairLog -Level Info -Message "Disk $number was returned online after the nested guest did not start, so the rescue VM keeps the access it had at entry."
+                }
+                catch {
+                    Add-OfflineRepairLog -Level Warning -Message "Disk $number could not be returned online after the nested guest did not start: $($_.Exception.Message)"
+                }
+            }
+        }
+    }
+
+    return $result
+}
+
+function Wait-NestedRepairVmBoot {
+    <#
+    .SYNOPSIS
+        Waits for a nested guest to boot far enough to report a heartbeat.
+
+    .DESCRIPTION
+        A repair that only takes effect inside the running guest cannot be confirmed by starting
+        the VM, because Start-VM returns as soon as the VM is powered on and says nothing about
+        whether Windows loaded. The Integration Services heartbeat is the first signal the host
+        can see that the guest OS is actually running.
+
+        A timeout is reported as a timeout. It is never converted into success, and it is not
+        treated as proof of failure either: a guest can be running with the heartbeat service
+        disabled, so the caller must still verify the repair itself.
+
+        The wait ends early when the guest reaches a state it cannot boot out of on its own (Off,
+        Paused, Saved or PausedCritical) rather than waiting out the full timeout. PausedCritical in
+        particular means the host is out of memory or disk for the guest and it will never progress.
+
+    .PARAMETER Vm
+        The guest to wait for, as returned in the Vm property of Get-NestedRepairVm.
+
+    .PARAMETER TimeoutSeconds
+        How long to wait for the first heartbeat. Defaults to 600, which covers a cold boot of a
+        Windows Server guest on a two-processor rescue VM.
+
+    .PARAMETER PollSeconds
+        How often to re-check. Defaults to 10.
+
+    .OUTPUTS
+        PSCustomObject with Booted, Heartbeat, State, WaitedSeconds and Reason.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][AllowNull()]$Vm,
+        [Parameter(Mandatory = $false)][int]$TimeoutSeconds = 600,
+        [Parameter(Mandatory = $false)][int]$PollSeconds = 10
+    )
+
+    $result = [PSCustomObject]@{
+        Booted        = $false
+        Heartbeat     = $null
+        State         = $null
+        WaitedSeconds = 0
+        Reason        = $null
+    }
+
+    if ($null -eq $Vm) {
+        $result.Reason = 'no nested guest was supplied'
+        return $result
+    }
+
+    if ($PollSeconds -lt 1) { $PollSeconds = 1 }
+
+    Add-OfflineRepairLog -Level Info -Message "Waiting up to $TimeoutSeconds seconds for nested guest '$($Vm.Name)' to report a heartbeat."
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $started = Get-Date
+
+    while ((Get-Date) -lt $deadline) {
+        # Resolve by Id, not by a name Get-VM would treat as a wildcard.
+        $current = Get-VM -Id $Vm.Id -ErrorAction SilentlyContinue
+
+        if ($null -eq $current) {
+            $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
+            $result.Reason = "the nested guest '$($Vm.Name)' disappeared while waiting for it to boot"
+            return $result
+        }
+
+        $result.State = "$($current.State)"
+        $heartbeat = "$($current.Heartbeat)"
+        $result.Heartbeat = $heartbeat
+
+        # Off, Paused, Saved and PausedCritical are all terminal for a boot: the guest will not reach a
+        # heartbeat on its own from any of them. PausedCritical in particular means the host has run out
+        # of memory or disk for the guest, so waiting out the full timeout would only delay an honest
+        # failure with a misleading "no heartbeat" reason.
+        if ($result.State -in @('Off', 'Paused', 'Saved', 'PausedCritical')) {
+            $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
+            $result.Reason = "the nested guest '$($Vm.Name)' stopped making progress in state '$($result.State)' after $($result.WaitedSeconds) seconds, so it will not report a heartbeat"
+            return $result
+        }
+
+        # OkApplicationsUnknown is the normal reading for a Server guest that has booted but has no
+        # application reporting through Integration Services. It still proves the OS is running.
+        if ($heartbeat -like 'Ok*') {
+            $result.Booted = $true
+            $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
+            Add-OfflineRepairLog -Level Info -Message "Nested guest '$($Vm.Name)' reported heartbeat '$heartbeat' after $($result.WaitedSeconds) seconds."
+            return $result
+        }
+
+        Start-Sleep -Seconds $PollSeconds
+    }
+
+    $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
+    $result.Reason = "no heartbeat after $($result.WaitedSeconds) seconds. The guest may still be booting, or Integration Services may be disabled in it, so the repair must be verified directly rather than assumed"
+    Add-OfflineRepairLog -Level Warning -Message $result.Reason
+
+    return $result
+}
+
+function Stop-NestedRepairVmGraceful {
+    <#
+    .SYNOPSIS
+        Asks a nested guest to shut down cleanly, and only pulls the power if it will not.
+
+    .DESCRIPTION
+        Turning a Windows guest off at the power button leaves its hives and file system dirty, and
+        discards anything the guest had written but not yet flushed. Here the guest has just created
+        a local account, so that write matters: it is the whole point of the run. Asking the guest to
+        shut down instead lets Windows commit it and close the hives cleanly, which also spares the
+        disk a chkdsk on the next boot.
+
+        One value is deliberately not covered by this. While Windows is in setup mode it owns
+        SYSTEM\Setup\SetupType and rewrites it until its setup pass finishes, which cannot happen in
+        a guest that is stopped on purpose part way through. That value is therefore finalised from
+        the rescue VM after the disk comes back, not here.
+
+        The power is only pulled if the guest does not stop in time, and that case is reported as a
+        non-graceful stop so the caller knows what is on the disk cannot be trusted and has to be
+        re-checked.
+
+        If the shutdown request itself cannot be issued, that real reason is returned as-is rather
+        than being replaced by the generic power-off message, so the true cause is not lost.
+
+    .PARAMETER Vm
+        The guest to stop, as returned in the Vm property of Get-NestedRepairVm.
+
+    .PARAMETER TimeoutSeconds
+        How long to wait for the guest to stop on its own before pulling the power. Defaults to 180.
+
+    .PARAMETER PollSeconds
+        How often to re-check. Defaults to 5.
+
+    .OUTPUTS
+        An object with Stopped, Graceful, WaitedSeconds, State and Reason.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true)][AllowNull()]$Vm,
+        [int]$TimeoutSeconds = 180,
+        [int]$PollSeconds = 5
+    )
+
+    $result = [PSCustomObject]@{
+        Stopped       = $false
+        Graceful      = $false
+        WaitedSeconds = 0
+        State         = $null
+        Reason        = $null
+    }
+
+    if (-not $Vm) {
+        $result.Reason = 'no nested guest was supplied, so there was nothing to stop'
+        return $result
+    }
+
+    $name = $Vm.Name
+    # Resolve and act on the guest by its Id. Get-VM (and Stop-VM -Name) treat the name as a wildcard,
+    # so a name containing [ ] * or ? could match the wrong guest, or several.
+    $id = $Vm.Id
+
+    $current = Get-VM -Id $id -ErrorAction SilentlyContinue
+    if (-not $current) {
+        $result.Reason = "the nested guest '$name' no longer exists"
+        return $result
+    }
+
+    if ($current.State -eq 'Off') {
+        # Deliberately not reported as graceful. Reaching here means the guest powered off on its
+        # own before it was asked to, and there is no way from the host to tell an orderly shutdown
+        # apart from a crash, so the caller is told to re-check the disk rather than trust it.
+        $result.Stopped = $true
+        $result.State = 'Off'
+        $result.Reason = "the nested guest '$name' was already off, so it is not known whether it shut down cleanly"
+        Add-OfflineRepairLog -Level Info -Message $result.Reason
+        return $result
+    }
+
+    # The shutdown request is the first thing that changes state, so -WhatIf stops here. Stopped stays
+    # $false, which is what the caller already treats as "the guest is still running".
+    if (-not $PSCmdlet.ShouldProcess("nested guest '$name'", 'Request a clean shutdown, turning it off only if it does not comply')) {
+        $result.State = [string]$current.State
+        $result.Reason = 'the guest was not stopped because -WhatIf was specified'
+        return $result
+    }
+
+    Add-OfflineRepairLog -Level Info -Message "Asking the nested guest '$name' to shut down cleanly so anything it wrote to the registry is flushed to its disk."
+
+    try {
+        Stop-VM -VM $current -Force -AsJob -ErrorAction Stop | Out-Null
+    }
+    catch {
+        # Return here. Falling through to the wait loop and the power-off path would overwrite this with
+        # the generic "had to be turned off" reason and lose the real cause of the failed request.
+        $result.State = [string]$current.State
+        $result.Reason = "the shutdown request to '$name' failed: $($_.Exception.Message)"
+        Add-OfflineRepairLog -Level Warning -Message $result.Reason
+        return $result
+    }
+
+    $started = Get-Date
+    while (((Get-Date) - $started).TotalSeconds -lt $TimeoutSeconds) {
+        $current = Get-VM -Id $id -ErrorAction SilentlyContinue
+
+        if (-not $current) {
+            $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
+            $result.Reason = "the nested guest '$name' disappeared while it was shutting down"
+            Add-OfflineRepairLog -Level Warning -Message $result.Reason
+            return $result
+        }
+
+        if ($current.State -eq 'Off') {
+            $result.Stopped = $true
+            $result.Graceful = $true
+            $result.State = 'Off'
+            $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
+            Add-OfflineRepairLog -Level Info -Message "The nested guest '$name' shut down cleanly after $($result.WaitedSeconds) seconds."
+            return $result
+        }
+
+        Start-Sleep -Seconds $PollSeconds
+    }
+
+    $result.WaitedSeconds = [int]((Get-Date) - $started).TotalSeconds
+    Add-OfflineRepairLog -Level Warning -Message "The nested guest '$name' did not shut down within $($result.WaitedSeconds) seconds, so its power is being turned off. Anything it wrote to the registry and that Windows had not flushed yet is lost, so the disk has to be re-checked rather than trusted."
+
+    Stop-VM -VM $current -TurnOff -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 3
+
+    $current = Get-VM -Id $id -ErrorAction SilentlyContinue
+    $result.State = if ($current) { [string]$current.State } else { $null }
+    $result.Stopped = (-not $current) -or ($current.State -eq 'Off')
+    $result.Graceful = $false
+    $result.Reason = "the nested guest '$name' had to be turned off at the power button after $($result.WaitedSeconds) seconds"
+
+    return $result
+}

--- a/src/windows/common/helpers/Use-OfflineFileRemoval.ps1
+++ b/src/windows/common/helpers/Use-OfflineFileRemoval.ps1
@@ -34,7 +34,9 @@
       3. A hash-verified backup taken before anything is deleted, into a folder unique to the run,
          so one run can never overwrite an earlier run's only copy of the originals. Each file's
          owner and DACL are recorded in binary form alongside its bytes, so a rollback restores the
-         security it had and not merely its contents.
+         security it had and not merely its contents. Backup capacity must be known and sufficient
+         before any file is copied or removed. The verified SHA256 is retained so a rollback checks
+         both the backup and the restored bytes against the same original baseline.
 
       4. Independent checks afterwards, and a rollback of the whole set if any fails. The registry
          check reports INCONCLUSIVE, not PASS, when no hive was loadable beforehand, so a run that
@@ -70,6 +72,10 @@
     Enable-OfflineOwnershipPrivilege, Save-OfflinePathSecurity).
 
 .VERSION
+    v1.2: Query backup capacity natively on the actual directory's volume, without PowerShell drive
+          registration, and refuse unknown, invalid or insufficient capacity. Retain the verified
+          backup hash and verify rollback contents before counting a file as restored. Report hash
+          read failures without making optional snapshot hashes mandatory.
     v1.1: Added the hive base-name veto so a hive's own transaction and recovery logs
           (SYSTEM.LOG1, SOFTWARE.LOG2, SECURITY.blf, SYSTEM.regtrans-ms) can no longer be removed;
           the guard is now genuinely two independent layers. Bound every delete to the offline root
@@ -113,26 +119,90 @@ function Get-OfflineFileHashValue {
     <#
     .SYNOPSIS
         SHA256 of a file, or $null when it cannot be read.
+
+    .DESCRIPTION
+        An unavailable hash is logged and returned as $null, never as a verified match. Snapshot
+        hashing is optional; backup and restore callers must require readable comparison hashes.
     #>
     param([Parameter(Mandatory = $true)][string]$Path)
-    try { return (Get-FileHash -LiteralPath $Path -Algorithm SHA256 -ErrorAction Stop).Hash }
-    catch { return $null }
+    try {
+        $hash = (Get-FileHash -LiteralPath $Path -Algorithm SHA256 -ErrorAction Stop).Hash
+        if ([string]::IsNullOrWhiteSpace($hash)) { throw 'SHA256 was not returned.' }
+        return $hash
+    }
+    catch {
+        Add-OfflineRepairLog -Level Warning -Message "The SHA256 hash of $Path could not be read: $($_.Exception.Message)"
+        return $null
+    }
 }
 
 function Get-OfflineFreeSpace {
     <#
     .SYNOPSIS
-        Free bytes on the volume holding a path, or $null when it cannot be determined.
+        Available bytes on an existing directory's volume, or $null when unknown.
+
+    .DESCRIPTION
+        Queries GetDiskFreeSpaceExW from System32, loaded lazily, without PowerShell drive
+        registration or a Storage module dependency. Uses the directory itself, not its drive
+        letter's root, so a mounted volume below that root is measured correctly. Absolute drive,
+        UNC, extended UNC and volume-GUID directory paths are supported.
+
+        Returns an Int64, including a genuine zero. An invalid path, native failure or byte-count
+        overflow is logged and returns $null. The caller must refuse removal when capacity is
+        unknown. The directory must already exist; falling back to an ancestor could measure a
+        different volume from the intended backup location.
     #>
     param([Parameter(Mandatory = $true)][string]$Path)
 
     try {
-        $root = [System.IO.Path]::GetPathRoot($Path)
-        if ([string]::IsNullOrWhiteSpace($root)) { return $null }
-        $drive = Get-PSDrive -Name $root.Substring(0, 1) -ErrorAction Stop
-        return [int64]$drive.Free
+        $drivePath = $Path -match '^(?:\\\\\?\\)?[A-Za-z]:\\'
+        $volumePath = $Path -match '^\\\\\?\\Volume\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\}\\'
+        $uncPath = $Path -match '^\\\\(?:\?\\UNC\\|(?![?.]\\))[^\\]+\\[^\\]+(?:\\|$)'
+        if ($Path.IndexOf([char]0) -ge 0 -or -not ($drivePath -or $volumePath -or $uncPath)) {
+            throw 'An absolute drive, UNC or volume-GUID directory path is required.'
+        }
+
+        if (-not ('RslOffline.FileRemovalDiskSpace' -as [type])) {
+            Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace RslOffline
+{
+    public static class FileRemovalDiskSpace
+    {
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool GetDiskFreeSpaceExW(string directory,
+            out ulong available, out ulong total, out ulong free);
+
+        public static long GetAvailableBytes(string directory)
+        {
+            ulong available, total, free;
+            if (!GetDiskFreeSpaceExW(directory, out available, out total, out free))
+            {
+                int error = Marshal.GetLastWin32Error();
+                throw new Win32Exception(error, "GetDiskFreeSpaceExW failed (Win32 error " +
+                    error + "): " + new Win32Exception(error).Message);
+            }
+            if (available > total || available > free)
+                throw new InvalidDataException("GetDiskFreeSpaceExW returned inconsistent byte counts.");
+            return checked((long)available);
+        }
     }
-    catch { return $null }
+}
+'@ -ErrorAction Stop
+        }
+
+        return [RslOffline.FileRemovalDiskSpace]::GetAvailableBytes($Path.TrimEnd('\') + '\')
+    }
+    catch {
+        Add-OfflineRepairLog -Level Warning -Message "Free space for $Path could not be determined: $($_.Exception.Message)"
+        return $null
+    }
 }
 
 function Test-OfflineRemovableFile {
@@ -441,8 +511,9 @@ function Backup-OfflineFile {
         log could return owned by the wrong authority.
 
     .OUTPUTS
-        PSCustomObject with Name, Source, Backup, Attributes, Security, Success and Reason.
+        PSCustomObject with Name, Source, Backup, Attributes, Security, Hash, Success and Reason.
         Security is a byte[] security descriptor, or $null when it could not be read.
+        Hash is the verified original SHA256, retained for rollback independently of IncludeHash.
     #>
     param(
         [Parameter(Mandatory = $true)]$File,
@@ -455,6 +526,7 @@ function Backup-OfflineFile {
         Backup     = (Join-Path $BackupPath $File.Name)
         Attributes = $File.Attributes
         Security   = $null
+        Hash       = $null
         Success    = $false
         Reason     = $null
     }
@@ -479,6 +551,7 @@ function Backup-OfflineFile {
         $result.Reason = 'the backup copy does not match the original'
         return $result
     }
+    $result.Hash = $sourceHash
 
     # Record the live source's owner and DACL, so a rollback restores the security the file had and
     # not merely its bytes. Best-effort: a file whose descriptor cannot be read is still backed up
@@ -560,6 +633,15 @@ function Restore-OfflineFileSet {
         and DACL are then reapplied, so a restored file is the one that was there before and not a
         look-alike carrying the rescue VM's idea of permissions.
 
+        When a backup record carries Hash, both the backup before copying and the restored bytes
+        must match that captured, verified original SHA256. An absent or unreadable comparison
+        hash is a failure, never a match. Files not in a supplied record set are refused.
+
+        For a recordless restore, or a legacy metadata-only record with no Hash field, the backup
+        is hashed before copying and the destination must match that baseline. A warning makes
+        this narrower guarantee explicit: it proves the copy, not that the backup still matches
+        the historical original. An explicitly empty Hash field is not a legacy record and fails.
+
         The rollback is deliberately loud. The backup folder is enumerated with -ErrorAction Stop,
         and the run is reported as failed unless the number of files recovered equals the number
         expected. A backup folder that has gone missing or unreadable, or a restore that quietly put
@@ -568,7 +650,9 @@ function Restore-OfflineFileSet {
 
     .OUTPUTS
         PSCustomObject with Restored, Failed, Expected, Succeeded and Detail[]. Succeeded is $true
-        only when nothing failed and every expected file came back.
+        only when nothing failed, every expected file's restored contents were hash-verified,
+        and its recorded metadata was reapplied.
+        Restored counts verified files, not merely successful copy operations.
     #>
     param(
         [Parameter(Mandatory = $true)][string]$BackupPath,
@@ -586,18 +670,23 @@ function Restore-OfflineFileSet {
     }
     $detail = [System.Collections.Generic.List[string]]::new()
 
+    function Add-RestoreFailure {
+        param([string]$Message)
+        $summary.Failed++
+        $detail.Add($Message)
+        Add-OfflineRepairLog -Level Error -Message $Message
+    }
+
     # Restoring goes through the protected-copy path, so the helper that provides it has to be
     # loaded. Saying so once beats failing per file with an obscure "command not found".
     if (-not (Get-Command -Name 'Copy-OfflineProtectedFile' -ErrorAction SilentlyContinue)) {
-        $detail.Add('Use-OfflineProtectedResource.ps1 is not loaded, so files cannot be restored through the protected-copy path.')
-        $summary.Failed = 1
+        Add-RestoreFailure 'Use-OfflineProtectedResource.ps1 is not loaded, so files cannot be restored through the protected-copy path.'
         $summary.Detail = @($detail)
         return $summary
     }
 
     if (-not (Test-Path -LiteralPath $BackupPath)) {
-        $detail.Add("The backup folder $BackupPath is not present, so nothing could be restored.")
-        $summary.Failed = 1
+        Add-RestoreFailure "The backup folder $BackupPath is not present, so nothing could be restored."
         $summary.Detail = @($detail)
         return $summary
     }
@@ -608,8 +697,7 @@ function Restore-OfflineFileSet {
         $backedUp = @(Get-ChildItem -LiteralPath $BackupPath -File -Force -ErrorAction Stop)
     }
     catch {
-        $detail.Add("The backup folder $BackupPath could not be read ($($_.Exception.Message)), so the rollback cannot proceed.")
-        $summary.Failed = 1
+        Add-RestoreFailure "The backup folder $BackupPath could not be read ($($_.Exception.Message)), so the rollback cannot proceed."
         $summary.Detail = @($detail)
         return $summary
     }
@@ -621,31 +709,92 @@ function Restore-OfflineFileSet {
         $destination = Join-Path $TargetPath $item.Name
         $recorded = @($FileRecord) | Where-Object { $_ -and $_.Name -eq $item.Name } | Select-Object -First 1
 
-        $copy = Copy-OfflineProtectedFile -Source $item.FullName -Destination $destination
-        if (-not $copy.Copied) {
-            $summary.Failed++
-            $detail.Add("Could not restore $($item.Name): $($copy.Reason)")
+        if ($recordCount -gt 0 -and -not $recorded) {
+            Add-RestoreFailure "Could not restore $($item.Name): it is not in the expected file record set."
             continue
         }
 
-        if ($recorded -and $recorded.Attributes) {
-            try { (Get-Item -LiteralPath $destination -Force -ErrorAction Stop).Attributes = [System.IO.FileAttributes]$recorded.Attributes }
-            catch { $detail.Add("Restored $($item.Name) but could not reapply its attributes ($($_.Exception.Message)).") }
+        $hasRecordedHash = $false
+        if ($recorded) {
+            $hasRecordedHash = $null -ne $recorded.PSObject.Properties['Hash']
+            if ($recorded -is [System.Collections.IDictionary]) { $hasRecordedHash = $recorded.Contains('Hash') }
         }
+        if ($hasRecordedHash -and [string]::IsNullOrWhiteSpace($recorded.Hash)) {
+            Add-RestoreFailure "Could not restore $($item.Name): the recorded original hash is unavailable."
+            continue
+        }
+
+        $backupHash = Get-OfflineFileHashValue -Path $item.FullName
+        if ([string]::IsNullOrWhiteSpace($backupHash)) {
+            Add-RestoreFailure "Could not restore $($item.Name): the backup hash is unavailable."
+            continue
+        }
+        $expectedHash = $backupHash
+        if ($hasRecordedHash) {
+            $expectedHash = $recorded.Hash
+            if ($backupHash -ne $expectedHash) {
+                Add-RestoreFailure "Could not restore $($item.Name): the backup hash does not match the recorded original."
+                continue
+            }
+        }
+        else {
+            $warning = "No original-file hash was recorded for $($item.Name); verification is only against the backup hash captured before this restore."
+            $detail.Add($warning)
+            Add-OfflineRepairLog -Level Warning -Message $warning
+        }
+
+        try { $copy = Copy-OfflineProtectedFile -Source $item.FullName -Destination $destination }
+        catch {
+            Add-RestoreFailure "Could not restore $($item.Name): $($_.Exception.Message)"
+            continue
+        }
+        if (-not $copy.Copied) {
+            Add-RestoreFailure "Could not restore $($item.Name): $($copy.Reason)"
+            continue
+        }
+
+        # Read before replaying a restrictive descriptor, but replay metadata even if hashing fails.
+        $restoredHash = Get-OfflineFileHashValue -Path $destination
+        $restoreProblems = [System.Collections.Generic.List[string]]::new()
 
         if ($recorded -and $recorded.Security) {
             if (-not (Restore-OfflineFileSecurity -Path $destination -BinaryDescriptor $recorded.Security)) {
-                $detail.Add("Restored $($item.Name) but could not reapply its original owner and DACL.")
+                $restoreProblems.Add('could not reapply its original owner and DACL')
             }
         }
 
+        # NTFS sets Archive when security changes, so exact attributes must be replayed last.
+        if ($recorded -and $recorded.Attributes) {
+            try {
+                $expectedAttributes = [System.IO.FileAttributes]$recorded.Attributes
+                [System.IO.File]::SetAttributes($destination, $expectedAttributes)
+                if ([System.IO.File]::GetAttributes($destination) -ne $expectedAttributes) {
+                    throw 'the attributes read back do not match the recorded original'
+                }
+            }
+            catch {
+                $restoreProblems.Add("could not reapply its attributes ($($_.Exception.Message))")
+            }
+        }
+
+        if ([string]::IsNullOrWhiteSpace($restoredHash)) {
+            $restoreProblems.Add('the restored file hash is unavailable')
+        }
+        elseif ($restoredHash -ne $expectedHash) {
+            $restoreProblems.Add('its hash does not match the captured baseline')
+        }
+        if ($restoreProblems.Count -gt 0) {
+            Add-RestoreFailure "Could not fully restore $($item.Name): $($restoreProblems -join '; ')."
+            continue
+        }
+
         $summary.Restored++
-        $detail.Add("Restored $($item.Name).")
+        $detail.Add("Restored and hash-verified $($item.Name).")
     }
 
     $summary.Succeeded = ($summary.Failed -eq 0 -and $summary.Restored -eq $summary.Expected)
     if (-not $summary.Succeeded -and $summary.Failed -eq 0) {
-        $detail.Add("Rollback recovered $($summary.Restored) of $($summary.Expected) expected file(s).")
+        Add-RestoreFailure "Rollback recovered $($summary.Restored) of $($summary.Expected) expected file(s)."
     }
 
     $summary.Detail = @($detail)
@@ -661,7 +810,8 @@ function Test-OfflineRemovalResult {
         Six checks. Check 5 is the one that matters most: comparing every other file in the folder
         by size, last write time and attributes is the direct evidence that the registry hives and
         their .LOG1/.LOG2 recovery logs were neither removed nor modified. Check 6 then has Windows
-        confirm the hives still parse.
+        confirm the hives still parse. Check 5 compares metadata, not content hashes; IncludeHash
+        captures removable-file hashes for the backup baseline, not every other file's contents.
 
         Check 4 re-reads the filesystem directly rather than trusting the list of files the delete
         loop reported it removed, so it can actually catch a delete that did not take. Check 6
@@ -669,9 +819,9 @@ function Test-OfflineRemovalResult {
         proved nothing about the hives is never mistaken for one that proved them intact; an
         inconclusive check is not a failure and does not roll the run back.
 
-        A folder ACL that could not be read before and cannot be read now is passed rather than
-        failed, because there is nothing to compare and refusing on that basis would roll back a
-        correct repair on a build that simply restricts the folder.
+        A folder timestamp or ACL that could not be read on either side is INCONCLUSIVE rather
+        than PASS or FAIL. There is no comparable evidence, and refusing on that basis would roll
+        back a correct repair on a build that simply restricts the folder.
 
     .OUTPUTS
         PSCustomObject with Passed, Inconclusive, Check[] and Failure[]. Each Check carries Name,
@@ -738,7 +888,7 @@ function Test-OfflineRemovalResult {
         elseif ($stillOnDisk.Count -gt 0) { "still on disk: $($stillOnDisk -join ', ')" }
         else { "removed without being planned: $($unexpectedlyGone -join ', ')" })
 
-    # 5. Everything else in the folder is byte-for-byte and flag-for-flag as it was.
+    # 5. Everything else in the folder retains its size, last-write timestamp and attributes.
     $otherProblems = [System.Collections.Generic.List[string]]::new()
     foreach ($original in @($before.OtherFile)) {
         $current = @($after.OtherFile) | Where-Object { $_.Name -eq $original.Name } | Select-Object -First 1
@@ -803,6 +953,12 @@ function Invoke-OfflineRemovalPlan {
         touched - the folder once, and each file again as it is deleted - so a degraded or unrooted
         path is refused rather than allowed to delete from the rescue VM's own volume. The backup
         goes into a folder unique to this run, so one run cannot overwrite an earlier run's backups.
+        Capacity on that directory's actual volume must be known and sufficient before any file is
+        copied or deleted; a failed query, invalid byte count or headroom overflow refuses the run.
+
+        BackupRecord retains each verified copy's Hash, Attributes and Security. Callers persisting
+        revert metadata should retain these records and pass them as FileRecord to
+        Restore-OfflineFileSet, so a later revert can verify against the same original baseline.
 
         A failure at any point rolls the whole plan back. A partially cleared CLFS log set is worse
         than a full one: the .blf refers to containers that would no longer exist. A rollback that
@@ -815,10 +971,10 @@ function Invoke-OfflineRemovalPlan {
         each call instead.
 
     .OUTPUTS
-        PSCustomObject with Label, BackupPath, Removed[], Verification, Success, Reason,
+        PSCustomObject with Label, BackupPath, BackupRecord[], Removed[], Verification, Success, Reason,
         RollbackAttempted, RollbackSucceeded and RollbackDetail[]. A run where Success is false,
         RollbackAttempted is true and RollbackSucceeded is false is the fatal case: the offline
-        image is missing files the rollback could not put back.
+        image has missing or unverified files, not a proven restoration of the original contents.
     #>
     param(
         [Parameter(Mandatory = $true)]$Plan,
@@ -829,6 +985,7 @@ function Invoke-OfflineRemovalPlan {
     $result = [PSCustomObject]@{
         Label             = $Plan.Label
         BackupPath        = $null
+        BackupRecord      = @()
         Removed           = @()
         Verification      = $null
         Success           = $false
@@ -885,23 +1042,36 @@ function Invoke-OfflineRemovalPlan {
     $result.BackupPath = $backupPath
 
     # Room for the backup, with the same again as headroom.
-    $required = ($Plan.TotalBytes * 2)
-    $free = Get-OfflineFreeSpace -Path $backupPath
-    if ($null -eq $free) {
-        Add-OfflineRepairLog -Level Warning -Message 'Free space on the backup volume could not be confirmed; continuing.'
+    try {
+        if (($Plan.TotalBytes -isnot [int64] -and $Plan.TotalBytes -isnot [int32]) -or $Plan.TotalBytes -lt 0) {
+            throw 'The plan total must be a nonnegative Int64 byte count.'
+        }
+        $required = [int64]([decimal]$Plan.TotalBytes * 2)
+        $free = Get-OfflineFreeSpace -Path $backupPath
+        if ($null -eq $free) { throw 'Free space on the backup volume could not be determined.' }
+        if (($free -isnot [int64] -and $free -isnot [int32]) -or $free -lt 0) {
+            throw 'The free-space query did not return a nonnegative Int64 byte count.'
+        }
     }
-    elseif ($free -lt $required) {
-        $result.Reason = "not enough free space for the backup: $([math]::Round($free / 1MB)) MB free, $([math]::Round($required / 1MB)) MB needed"
+    catch {
+        $result.Reason = "backup capacity could not be confirmed; refusing removal: $($_.Exception.Message)"
+        Add-OfflineRepairLog -Level Error -Message $result.Reason
+        return $result
+    }
+    if ($free -lt $required) {
+        $result.Reason = "not enough free space for the backup: $free bytes free, $required bytes needed including headroom"
+        Add-OfflineRepairLog -Level Error -Message $result.Reason
         return $result
     }
 
     # Back everything up first. Nothing is deleted until every file has a verified copy. The backup
-    # records - each carrying the file's recorded attributes and its owner and DACL - are what a
+    # records - each carrying the verified hash, recorded attributes and owner and DACL - are what a
     # rollback restores from, so they are kept for the rollback calls below.
     $backups = [System.Collections.Generic.List[object]]::new()
     foreach ($file in @($Plan.Snapshot.MatchedFile)) {
         $backup = Backup-OfflineFile -File $file -BackupPath $backupPath
         if (-not $backup.Success) {
+            $result.BackupRecord = @($backups)
             $result.Reason = "$($file.Name) could not be backed up - $($backup.Reason)"
             Add-OfflineRepairLog -Level Error -Message $result.Reason
             return $result
@@ -909,6 +1079,7 @@ function Invoke-OfflineRemovalPlan {
         $backups.Add($backup)
         Add-OfflineRepairLog -Message "Backed up $($file.Name) ($([math]::Round($file.Length / 1KB)) KB)."
     }
+    $result.BackupRecord = @($backups)
 
     # Delete, working from the same list.
     #
@@ -960,7 +1131,7 @@ function Invoke-OfflineRemovalPlan {
 
     if ($deleteFailed) {
         Add-OfflineRepairLog -Level Error -Message "$deleteFailed Rolling this set back."
-        $rollback = Restore-OfflineFileSet -BackupPath $backupPath -TargetPath $Plan.Path -FileRecord @($backups)
+        $rollback = Restore-OfflineFileSet -BackupPath $backupPath -TargetPath $Plan.Path -FileRecord $result.BackupRecord
         foreach ($line in @($rollback.Detail)) { Add-OfflineRepairLog -Message "  $line" }
         $result.RollbackAttempted = $true
         $result.RollbackSucceeded = [bool]$rollback.Succeeded
@@ -971,7 +1142,7 @@ function Invoke-OfflineRemovalPlan {
             Add-OfflineRepairLog -Level Warning -Message "Removal of '$($Plan.Label)' failed and was rolled back cleanly; the offline image is unchanged."
         }
         else {
-            $result.Reason = "FATAL: $deleteFailed The rollback then failed ($($rollback.Restored) of $($rollback.Expected) restored); the offline image is missing files with no restored backup. Recover by hand from $backupPath."
+            $result.Reason = "FATAL: $deleteFailed The rollback then failed ($($rollback.Restored) of $($rollback.Expected) restored and hash-verified); the offline image has missing or unverified files. Recover by hand from $backupPath."
             Add-OfflineRepairLog -Level Error -Message $result.Reason
         }
         return $result
@@ -992,7 +1163,7 @@ function Invoke-OfflineRemovalPlan {
 
     if (-not $verification.Passed) {
         Add-OfflineRepairLog -Level Error -Message "Verification failed for $($Plan.Label). Rolling it back."
-        $rollback = Restore-OfflineFileSet -BackupPath $backupPath -TargetPath $Plan.Path -FileRecord @($backups)
+        $rollback = Restore-OfflineFileSet -BackupPath $backupPath -TargetPath $Plan.Path -FileRecord $result.BackupRecord
         foreach ($line in @($rollback.Detail)) { Add-OfflineRepairLog -Message "  $line" }
         $result.RollbackAttempted = $true
         $result.RollbackSucceeded = [bool]$rollback.Succeeded
@@ -1003,7 +1174,7 @@ function Invoke-OfflineRemovalPlan {
             Add-OfflineRepairLog -Level Warning -Message "Verification of '$($Plan.Label)' failed and was rolled back cleanly; the offline image is unchanged."
         }
         else {
-            $result.Reason = "FATAL: verification failed and the rollback then failed ($($rollback.Restored) of $($rollback.Expected) restored): $($verification.Failure -join '; '). The offline image is missing files with no restored backup. Recover by hand from $backupPath."
+            $result.Reason = "FATAL: verification failed and the rollback then failed ($($rollback.Restored) of $($rollback.Expected) restored and hash-verified): $($verification.Failure -join '; '). The offline image has missing or unverified files. Recover by hand from $backupPath."
             Add-OfflineRepairLog -Level Error -Message $result.Reason
         }
         return $result

--- a/src/windows/common/helpers/Use-OfflineFileRemoval.ps1
+++ b/src/windows/common/helpers/Use-OfflineFileRemoval.ps1
@@ -1,0 +1,1025 @@
+<#
+.SYNOPSIS
+    Removing a set of files from a folder on an offline Windows disk, with a verified backup, a
+    proof that only the intended files went, and an automatic rollback when that proof fails.
+
+.DESCRIPTION
+    Deleting files out of a folder that also holds registry hives is the dangerous shape this
+    helper exists to make safe. System32\config is the example: the transaction logs that a repair
+    legitimately clears sit in the same folder as SYSTEM, SOFTWARE and their .LOG1/.LOG2 recovery
+    logs, and a mistake there is unrecoverable on a disk that is already not booting.
+
+    The safety comes from these things, in order:
+
+      1. A genuine two-layer guard, where either layer on its own is enough to refuse a file:
+
+           a. The hive base-name veto. A file whose name without its extension is one of the
+              folder's registry hives - SYSTEM, SOFTWARE, SECURITY, SAM, DEFAULT and so on - is
+              rejected outright, whether it is the bare hive or one of that hive's transaction and
+              recovery logs (SYSTEM.LOG1, SOFTWARE.LOG2, SECURITY.blf, SYSTEM.regtrans-ms). Clearing
+              a hive's dirty logs while the hive itself stays is a known way to make the hive
+              unmountable, so the hive's own name is never removable in any form.
+
+           b. The extension allow-list. Of what the veto leaves, a file is eligible only if its
+              extension is on the caller's match list and is not on the caller's protected list.
+
+         The two layers are independent on purpose: the veto bounds the file by identity and the
+         allow-list bounds it by kind, so widening one can never quietly defeat the other.
+
+      2. Acting only from a captured list. The folder is enumerated once, into a plan. Nothing is
+         re-enumerated between deciding and deleting, so the set of files removed is exactly the
+         set that was reported and backed up. Reparse points are dropped during that enumeration
+         and never removed, so a link planted in the folder cannot redirect a delete off the disk.
+
+      3. A hash-verified backup taken before anything is deleted, into a folder unique to the run,
+         so one run can never overwrite an earlier run's only copy of the originals. Each file's
+         owner and DACL are recorded in binary form alongside its bytes, so a rollback restores the
+         security it had and not merely its contents.
+
+      4. Independent checks afterwards, and a rollback of the whole set if any fails. The registry
+         check reports INCONCLUSIVE, not PASS, when no hive was loadable beforehand, so a run that
+         proved nothing about the hives cannot look like one that proved them intact. A partially
+         cleared CLFS log set is worse than a full one, because the .blf then refers to containers
+         that no longer exist. A rollback that itself fails - contents now gone with nothing put
+         back - is reported as a distinct, fatal outcome rather than as an ordinary failure.
+
+      5. A hard binding to the offline disk. Every path this helper deletes is checked with
+         Assert-OfflineTarget first, so a caller that passes a degraded or unrooted path is refused
+         rather than allowed to delete from the rescue VM's own volume.
+
+    Deleting itself goes through Invoke-OfflineProtectedFileRemoval. An ordinary delete is tried
+    first, and
+    only when it is actually refused is ownership of the file and its parent folder taken, the
+    delete retried, and both descriptors put straight back. The parent matters because deleting a
+    file is a write to the folder holding it, so rights on the file alone are not enough. This is
+    not a fifth safety measure - it widens what the helper can remove - but it is safe to combine
+    with the four above because check 3 compares the folder's security descriptor before and after:
+    ownership that was taken and not handed back fails the run and rolls it back.
+
+    Callers build a plan with Get-OfflineRemovalPlan and execute it with Invoke-OfflineRemovalPlan.
+    The plan carries its own configuration - match list, protected list, hive names, size limit -
+    so a caller can run several different plans in one script without threading parameters through.
+
+    Nothing here writes to the output stream. Progress is recorded with Add-OfflineRepairLog and the
+    caller flushes it, because these functions return values and a Log-* call would corrupt them.
+
+.NOTES
+    Requires OfflineRepairCommon.ps1 (Add-OfflineRepairLog, Assert-OfflineTarget, Join-OfflinePath,
+    Test-OfflinePath), Use-OfflineRegistryHive.ps1 (Test-OfflineHiveFile) and
+    Use-OfflineProtectedResource.ps1 (Invoke-OfflineProtectedFileRemoval, Copy-OfflineProtectedFile,
+    Enable-OfflineOwnershipPrivilege, Save-OfflinePathSecurity).
+
+.VERSION
+    v1.1: Added the hive base-name veto so a hive's own transaction and recovery logs
+          (SYSTEM.LOG1, SOFTWARE.LOG2, SECURITY.blf, SYSTEM.regtrans-ms) can no longer be removed;
+          the guard is now genuinely two independent layers. Bound every delete to the offline root
+          with Assert-OfflineTarget and stopped following reparse points. Made the rollback loud
+          (it fails when it recovers fewer files than expected), routed restores through
+          Copy-OfflineProtectedFile, and record and replay each file's owner and DACL in binary
+          form. Surfaced rollback status on the result and made a failed rollback a distinct fatal
+          outcome. Gave each run its own backup folder. Made post-check 4 re-test the filesystem
+          instead of trusting the removed list, and post-check 6 report INCONCLUSIVE when no hive
+          was testable.
+    v1.0: Initial version.
+#>
+
+# Resolve every sibling against this file's own folder, so a scenario loads the same helpers
+# wherever it dot-sources this from, and fail loudly here rather than part-way through a
+# destructive removal. This file deletes files on the offline image and rolls them back, so a
+# missing Copy-OfflineProtectedFile or Assert-OfflineTarget discovered mid-run is the worst case.
+$script:OfflineFileRemovalDependencies = @(
+    @{ File = 'OfflineRepairCommon.ps1';          Sentinel = 'Assert-OfflineTarget' },
+    @{ File = 'Use-OfflineProtectedResource.ps1'; Sentinel = 'Copy-OfflineProtectedFile' },
+    @{ File = 'Use-OfflineRegistryHive.ps1';      Sentinel = 'Test-OfflineHiveFile' }
+)
+foreach ($dependency in $script:OfflineFileRemovalDependencies) {
+    if (Get-Command -Name $dependency.Sentinel -ErrorAction SilentlyContinue) { continue }
+    $dependencyPath = Join-Path -Path $PSScriptRoot -ChildPath $dependency.File
+    try {
+        . $dependencyPath
+    }
+    catch {
+        throw "Use-OfflineFileRemoval.ps1 could not load its dependency '$($dependency.File)' from '$dependencyPath': $($_.Exception.Message)"
+    }
+}
+foreach ($required in @('Assert-OfflineTarget', 'Add-OfflineRepairLog', 'Copy-OfflineProtectedFile',
+        'Invoke-OfflineProtectedFileRemoval', 'Save-OfflinePathSecurity', 'Test-OfflineHiveFile')) {
+    if (-not (Get-Command -Name $required -ErrorAction SilentlyContinue)) {
+        throw "Use-OfflineFileRemoval.ps1 requires '$required', which its dependencies did not define."
+    }
+}
+
+function Get-OfflineFileHashValue {
+    <#
+    .SYNOPSIS
+        SHA256 of a file, or $null when it cannot be read.
+    #>
+    param([Parameter(Mandatory = $true)][string]$Path)
+    try { return (Get-FileHash -LiteralPath $Path -Algorithm SHA256 -ErrorAction Stop).Hash }
+    catch { return $null }
+}
+
+function Get-OfflineFreeSpace {
+    <#
+    .SYNOPSIS
+        Free bytes on the volume holding a path, or $null when it cannot be determined.
+    #>
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    try {
+        $root = [System.IO.Path]::GetPathRoot($Path)
+        if ([string]::IsNullOrWhiteSpace($root)) { return $null }
+        $drive = Get-PSDrive -Name $root.Substring(0, 1) -ErrorAction Stop
+        return [int64]$drive.Free
+    }
+    catch { return $null }
+}
+
+function Test-OfflineRemovableFile {
+    <#
+    .SYNOPSIS
+        Decides whether one file name is eligible for removal.
+
+    .DESCRIPTION
+        Two independent layers, either of which is enough on its own to refuse the file:
+
+          1. The base-name veto. A file whose name without its extension matches one of the folder's
+             registry hives is refused outright, whether it is the bare hive (SYSTEM) or one of that
+             hive's transaction and recovery logs (SYSTEM.LOG1, SOFTWARE.LOG2, SECURITY.blf,
+             SYSTEM.regtrans-ms). Deleting a hive's dirty logs while the hive itself stays is a known
+             way to make the hive unmountable - the exact damage this helper exists to prevent - so
+             the hive's own name is never removable in any form.
+
+          2. The extension allow-list. Of what the veto leaves, a file is eligible only if its
+             extension is on the match list and is not on the protected list.
+
+    .PARAMETER Name
+        File name (leaf, not a full path) to test.
+
+    .PARAMETER MatchExtension
+        Extensions eligible for removal, lower-case and with the leading dot, e.g. '.log1'.
+
+    .PARAMETER ProtectedExtension
+        Extensions never eligible even when they appear on the match list.
+
+    .PARAMETER HiveName
+        Registry hive base names (SYSTEM, SOFTWARE, ...) whose files must never be removed. Matched
+        against the name without its extension, ordinal and case-insensitively.
+
+    .OUTPUTS
+        [bool] - $true only when the file may be removed.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$MatchExtension,
+        [Parameter(Mandatory = $false)][AllowEmptyCollection()][string[]]$ProtectedExtension = @(),
+        [Parameter(Mandatory = $false)][AllowEmptyCollection()][string[]]$HiveName = @()
+    )
+
+    # Layer 1: the base-name veto. GetFileNameWithoutExtension collapses both SYSTEM and SYSTEM.LOG1
+    # onto "SYSTEM", so a hive and every one of its logs are refused together, in any casing.
+    $baseName = [System.IO.Path]::GetFileNameWithoutExtension($Name)
+    foreach ($hive in @($HiveName)) {
+        if ([string]::IsNullOrEmpty($hive)) { continue }
+        if ([string]::Equals($baseName, $hive, [System.StringComparison]::OrdinalIgnoreCase)) { return $false }
+    }
+
+    # Layer 2: the extension allow-list.
+    #
+    # The extensionless refusal here is load-bearing and must stay. A bare hive such as SYSTEM has no
+    # extension, and before the veto above existed this was the ONLY reason it was safe; it still
+    # guards every other extensionless file - a hive this folder was never told to name, a caller
+    # that passes no HiveName - that the veto cannot know to reject by name.
+    $extension = [System.IO.Path]::GetExtension($Name)
+    if ([string]::IsNullOrEmpty($extension)) { return $false }
+
+    $extension = $extension.ToLowerInvariant()
+    if (@($ProtectedExtension) -contains $extension) { return $false }
+    return (@($MatchExtension) -contains $extension)
+}
+
+function Get-OfflineFolderSnapshot {
+    <#
+    .SYNOPSIS
+        Records the exact state of a folder, so the same folder can be compared afterwards.
+
+    .DESCRIPTION
+        [System.IO.Directory]::Exists is used rather than Test-Path so that a folder which exists
+        but cannot be enumerated is still recorded as present. config\TxR restricts its own ACL on
+        some builds and reading it can fail even from an elevated rescue VM; reporting it as absent
+        would be wrong, and would make the "folder still exists" check pass for the wrong reason.
+
+        CreationTimeUtc is the folder's identity. If the folder is deleted and recreated - which is
+        what a wildcard delete of the folder itself would do - the timestamp changes even though the
+        path is the same.
+
+        An unreadable SDDL is recorded as $null rather than treated as an error. The comparison
+        later skips a null on either side, because "could not read it before and cannot read it now"
+        is not evidence of a change.
+
+        Reparse points (symlinks, junctions) are recorded as other files and never as matched ones,
+        so a link planted in the folder can never be selected for removal - deleting or taking
+        ownership of a link can reach a target off the offline disk entirely.
+
+    .OUTPUTS
+        PSCustomObject with Path, Present, Accessible, AccessError, CreatedUtc, Sddl, MatchedFile[]
+        and OtherFile[]. Reparse points and registry-hive files are always classified as OtherFile.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$MatchExtension,
+        [Parameter(Mandatory = $false)][AllowEmptyCollection()][string[]]$ProtectedExtension = @(),
+        [Parameter(Mandatory = $false)][AllowEmptyCollection()][string[]]$HiveName = @(),
+        [Parameter(Mandatory = $false)][switch]$IncludeHash,
+        [Parameter(Mandatory = $false)][switch]$LogReparseSkips
+    )
+
+    $snapshot = [PSCustomObject]@{
+        Path        = $Path
+        Present     = $false
+        Accessible  = $false
+        AccessError = $null
+        CreatedUtc  = $null
+        Sddl        = $null
+        MatchedFile = @()
+        OtherFile   = @()
+    }
+
+    try { $snapshot.Present = [System.IO.Directory]::Exists($Path) }
+    catch { $snapshot.Present = $false }
+
+    if (-not $snapshot.Present) { return $snapshot }
+
+    try { $snapshot.CreatedUtc = ([System.IO.Directory]::GetCreationTimeUtc($Path)).ToString('o') }
+    catch { $snapshot.CreatedUtc = $null }
+
+    try { $snapshot.Sddl = (Get-Acl -LiteralPath $Path -ErrorAction Stop).Sddl }
+    catch { $snapshot.Sddl = $null }
+
+    $items = $null
+    try {
+        $items = @(Get-ChildItem -LiteralPath $Path -File -Force -ErrorAction Stop)
+        $snapshot.Accessible = $true
+    }
+    catch {
+        $snapshot.AccessError = $_.Exception.Message
+        return $snapshot
+    }
+
+    $matched = [System.Collections.Generic.List[object]]::new()
+    $others = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($item in $items) {
+        $record = [PSCustomObject]@{
+            Name         = $item.Name
+            FullName     = $item.FullName
+            Length       = $item.Length
+            LastWriteUtc = $item.LastWriteTimeUtc.ToString('o')
+            Attributes   = $item.Attributes.ToString()
+            Hash         = $null
+        }
+
+        # A reparse point (symlink, junction) is a redirection, not a file to be cleared: removing
+        # or taking ownership of one can reach a target outside this folder, and off the offline
+        # disk. It is never eligible, whatever its name; it is kept as an other file so the
+        # verification still proves it was left untouched.
+        if ($item.Attributes.HasFlag([System.IO.FileAttributes]::ReparsePoint)) {
+            if ($LogReparseSkips) { Add-OfflineRepairLog -Level Warning -Message "Skipping $($item.Name): it is a reparse point (link), so it will not be removed." }
+            $others.Add($record)
+            continue
+        }
+
+        if (Test-OfflineRemovableFile -Name $item.Name -MatchExtension $MatchExtension -ProtectedExtension $ProtectedExtension -HiveName $HiveName) {
+            if ($IncludeHash) { $record.Hash = Get-OfflineFileHashValue -Path $item.FullName }
+            $matched.Add($record)
+        }
+        else {
+            $others.Add($record)
+        }
+    }
+
+    $snapshot.MatchedFile = @($matched)
+    $snapshot.OtherFile = @($others)
+    return $snapshot
+}
+
+function Get-OfflineFolderHiveState {
+    <#
+    .SYNOPSIS
+        Reports whether each named registry hive in a folder loads.
+
+    .DESCRIPTION
+        Only used as a before-and-after comparison. A hive that does not load before the deletion
+        and still does not load after it says nothing about the removal; only a hive that loaded
+        before and does not load after is evidence, and that is what the verification tests for.
+
+        Test-OfflineHiveFile parses a scratch copy, so this never modifies the offline disk and
+        never loads a hive in place. That matters: loading a hive in place creates KTM transaction
+        logs next to it, which would show up as unexplained new files in the verification.
+
+        Hives above the size limit are recorded as skipped rather than tested, so a multi-gigabyte
+        COMPONENTS hive does not turn a small file deletion into a long copy. The file-level
+        comparison still proves such a hive was not modified; only the parse is given up.
+
+    .OUTPUTS
+        Array of PSCustomObject with Name, Path, Present, Tested, Loads and Reason.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $false)][AllowEmptyCollection()][string[]]$HiveName = @(),
+        [Parameter(Mandatory = $false)][int64]$MaxBytes = 512MB
+    )
+
+    $results = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($hive in @($HiveName)) {
+        $hivePath = Join-OfflinePath $Path $hive
+        $state = [PSCustomObject]@{
+            Name    = $hive
+            Path    = $hivePath
+            Present = $false
+            Tested  = $false
+            Loads   = $false
+            Reason  = $null
+        }
+
+        if (-not (Test-OfflinePath $hivePath)) {
+            $state.Reason = 'not present'
+            $results.Add($state)
+            continue
+        }
+        $state.Present = $true
+
+        $size = 0
+        try { $size = (Get-Item -LiteralPath $hivePath -Force -ErrorAction Stop).Length }
+        catch { $size = 0 }
+
+        if ($size -gt $MaxBytes) {
+            $state.Reason = "skipped, $([math]::Round($size / 1MB)) MB is above the $([math]::Round($MaxBytes / 1MB)) MB test limit"
+            $results.Add($state)
+            continue
+        }
+
+        $test = Test-OfflineHiveFile -Path $hivePath
+        $state.Tested = $true
+        $state.Loads = [bool]$test.IsValid
+        $state.Reason = $test.Reason
+        $results.Add($state)
+    }
+
+    return @($results)
+}
+
+function Get-OfflineRemovalPlan {
+    <#
+    .SYNOPSIS
+        Captures what would be removed from one folder, and the state to compare against later.
+
+    .DESCRIPTION
+        Building a plan is read-only. It takes the folder snapshot and the hive baseline in one
+        place so that the caller can report exactly what a run would do before deciding to do it,
+        and so that Invoke-OfflineRemovalPlan later works only from this captured list.
+
+        Label is the caller's name for the plan and is used in log lines and in the result, so a
+        script clearing several folders can tell them apart.
+
+    .OUTPUTS
+        PSCustomObject with Label, Path, Snapshot, HiveState, MatchExtension, ProtectedExtension,
+        HiveName, HiveMaxBytes, FileCount and TotalBytes.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$MatchExtension,
+        [Parameter(Mandatory = $false)][AllowEmptyCollection()][string[]]$ProtectedExtension = @(),
+        [Parameter(Mandatory = $false)][AllowEmptyCollection()][string[]]$HiveName = @(),
+        [Parameter(Mandatory = $false)][int64]$HiveMaxBytes = 512MB,
+        [Parameter(Mandatory = $false)][switch]$IncludeHash
+    )
+
+    $snapshot = Get-OfflineFolderSnapshot -Path $Path -MatchExtension $MatchExtension -ProtectedExtension $ProtectedExtension -HiveName $HiveName -IncludeHash:$IncludeHash -LogReparseSkips
+
+    $hiveState = @()
+    if ($snapshot.Present -and @($HiveName).Count -gt 0) {
+        $hiveState = Get-OfflineFolderHiveState -Path $Path -HiveName $HiveName -MaxBytes $HiveMaxBytes
+    }
+
+    $totalBytes = 0
+    foreach ($file in @($snapshot.MatchedFile)) { $totalBytes += [int64]$file.Length }
+
+    return [PSCustomObject]@{
+        Label              = $Label
+        Path               = $Path
+        Snapshot           = $snapshot
+        HiveState          = @($hiveState)
+        MatchExtension     = @($MatchExtension)
+        ProtectedExtension = @($ProtectedExtension)
+        HiveName           = @($HiveName)
+        HiveMaxBytes       = $HiveMaxBytes
+        FileCount          = @($snapshot.MatchedFile).Count
+        TotalBytes         = $totalBytes
+    }
+}
+
+function Backup-OfflineFile {
+    <#
+    .SYNOPSIS
+        Copies one file to the backup folder and proves the copy is identical.
+
+    .DESCRIPTION
+        The hash comparison is the point. A copy that reported success but produced a short or
+        empty file would make the rollback useless at exactly the moment it is needed, and the
+        deletion is only allowed to run once this has returned success.
+
+        Attributes are recorded rather than copied. Copy-Item does not carry them, and the rollback
+        has to put back a file that is byte-identical and marked the same way.
+
+        The owner and DACL are recorded too, in binary form, so the rollback can put back the exact
+        security the file had. Binary rather than SDDL on purpose: a machine-relative SDDL alias
+        (BA, SY and the like) would re-resolve against the rescue VM on the way back in, so a hive
+        log could return owned by the wrong authority.
+
+    .OUTPUTS
+        PSCustomObject with Name, Source, Backup, Attributes, Security, Success and Reason.
+        Security is a byte[] security descriptor, or $null when it could not be read.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]$File,
+        [Parameter(Mandatory = $true)][string]$BackupPath
+    )
+
+    $result = [PSCustomObject]@{
+        Name       = $File.Name
+        Source     = $File.FullName
+        Backup     = (Join-Path $BackupPath $File.Name)
+        Attributes = $File.Attributes
+        Security   = $null
+        Success    = $false
+        Reason     = $null
+    }
+
+    try {
+        Copy-Item -LiteralPath $File.FullName -Destination $result.Backup -Force -ErrorAction Stop
+    }
+    catch {
+        $result.Reason = "copy failed: $($_.Exception.Message)"
+        return $result
+    }
+
+    $sourceHash = $File.Hash
+    if (-not $sourceHash) { $sourceHash = Get-OfflineFileHashValue -Path $File.FullName }
+    $backupHash = Get-OfflineFileHashValue -Path $result.Backup
+
+    if (-not $sourceHash -or -not $backupHash) {
+        $result.Reason = 'the backup copy could not be hash-verified'
+        return $result
+    }
+    if ($sourceHash -ne $backupHash) {
+        $result.Reason = 'the backup copy does not match the original'
+        return $result
+    }
+
+    # Record the live source's owner and DACL, so a rollback restores the security the file had and
+    # not merely its bytes. Best-effort: a file whose descriptor cannot be read is still backed up
+    # and still deletable, but the rollback is warned that it could only put the contents back.
+    try {
+        if (Get-Command -Name 'Enable-OfflineOwnershipPrivilege' -ErrorAction SilentlyContinue) { Enable-OfflineOwnershipPrivilege }
+        $result.Security = (Get-Acl -LiteralPath $File.FullName -ErrorAction Stop).GetSecurityDescriptorBinaryForm()
+    }
+    catch {
+        Add-OfflineRepairLog -Level Warning -Message "The security descriptor of $($File.Name) could not be recorded ($($_.Exception.Message)); a rollback would restore its contents but not its original permissions."
+        $result.Security = $null
+    }
+
+    $result.Success = $true
+    return $result
+}
+
+function Restore-OfflineFileSecurity {
+    <#
+    .SYNOPSIS
+        Replays an owner and DACL captured in binary form onto a restored file.
+
+    .DESCRIPTION
+        Only the Owner, Group and Access sections are written - never the SACL - so the write needs
+        no SeSecurityPrivilege and touches nothing to do with auditing. Setting the owner back to an
+        authority the rescue VM is not (TrustedInstaller, for a system hive) needs SeRestore, which
+        Enable-OfflineOwnershipPrivilege turns on.
+
+        The descriptor is replayed from bytes, not SDDL, because a machine-relative alias in an SDDL
+        string would resolve against the rescue VM rather than the offline image.
+
+    .OUTPUTS
+        [bool] - $true when the security was written, $false when it could not be.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $false)][AllowNull()][byte[]]$BinaryDescriptor = $null
+    )
+
+    if (-not $BinaryDescriptor -or $BinaryDescriptor.Length -eq 0) { return $false }
+    if (-not (Test-OfflinePath $Path)) { return $false }
+
+    try {
+        if (Get-Command -Name 'Enable-OfflineOwnershipPrivilege' -ErrorAction SilentlyContinue) { Enable-OfflineOwnershipPrivilege }
+
+        $security = [System.Security.AccessControl.FileSecurity]::new()
+        $sections = [System.Security.AccessControl.AccessControlSections]::Owner -bor `
+            [System.Security.AccessControl.AccessControlSections]::Group -bor `
+            [System.Security.AccessControl.AccessControlSections]::Access
+        $security.SetSecurityDescriptorBinaryForm($BinaryDescriptor, $sections)
+
+        if (Get-Command -Name 'Save-OfflinePathSecurity' -ErrorAction SilentlyContinue) {
+            Save-OfflinePathSecurity -Path $Path -Security $security
+        }
+        else {
+            [System.IO.File]::SetAccessControl($Path, $security)
+        }
+        return $true
+    }
+    catch {
+        Add-OfflineRepairLog -Level Warning -Message "Could not replay the recorded security on $Path ($($_.Exception.Message)); it may carry inherited permissions instead of its original owner and DACL."
+        return $false
+    }
+}
+
+function Restore-OfflineFileSet {
+    <#
+    .SYNOPSIS
+        Puts a backed-up set of files back where they came from, contents and security both.
+
+    .DESCRIPTION
+        Used both by the automatic rollback when verification fails and by a caller's "-revert"
+        path.
+
+        Each file is copied back through Copy-OfflineProtectedFile, not a plain Copy-Item, so a file
+        that had to be de-protected to be backed up - a system hive log owned by TrustedInstaller -
+        can actually be written back into its hardened folder. A plain copy fails silently on
+        exactly the protected files that matter most. Its recorded attributes and its recorded owner
+        and DACL are then reapplied, so a restored file is the one that was there before and not a
+        look-alike carrying the rescue VM's idea of permissions.
+
+        The rollback is deliberately loud. The backup folder is enumerated with -ErrorAction Stop,
+        and the run is reported as failed unless the number of files recovered equals the number
+        expected. A backup folder that has gone missing or unreadable, or a restore that quietly put
+        back fewer files than it took, is the one moment this must not be mistaken for "there was
+        nothing to restore".
+
+    .OUTPUTS
+        PSCustomObject with Restored, Failed, Expected, Succeeded and Detail[]. Succeeded is $true
+        only when nothing failed and every expected file came back.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$BackupPath,
+        [Parameter(Mandatory = $true)][string]$TargetPath,
+        [Parameter(Mandatory = $false)][AllowNull()]$FileRecord = $null
+    )
+
+    $recordCount = @($FileRecord | Where-Object { $_ }).Count
+    $summary = [PSCustomObject]@{
+        Restored  = 0
+        Failed    = 0
+        Expected  = $recordCount
+        Succeeded = $false
+        Detail    = @()
+    }
+    $detail = [System.Collections.Generic.List[string]]::new()
+
+    # Restoring goes through the protected-copy path, so the helper that provides it has to be
+    # loaded. Saying so once beats failing per file with an obscure "command not found".
+    if (-not (Get-Command -Name 'Copy-OfflineProtectedFile' -ErrorAction SilentlyContinue)) {
+        $detail.Add('Use-OfflineProtectedResource.ps1 is not loaded, so files cannot be restored through the protected-copy path.')
+        $summary.Failed = 1
+        $summary.Detail = @($detail)
+        return $summary
+    }
+
+    if (-not (Test-Path -LiteralPath $BackupPath)) {
+        $detail.Add("The backup folder $BackupPath is not present, so nothing could be restored.")
+        $summary.Failed = 1
+        $summary.Detail = @($detail)
+        return $summary
+    }
+
+    # -ErrorAction Stop, not SilentlyContinue: a folder that cannot be enumerated has to surface as
+    # a failure, not as an empty loop that returns "restored 0, failed 0" and reads as success.
+    try {
+        $backedUp = @(Get-ChildItem -LiteralPath $BackupPath -File -Force -ErrorAction Stop)
+    }
+    catch {
+        $detail.Add("The backup folder $BackupPath could not be read ($($_.Exception.Message)), so the rollback cannot proceed.")
+        $summary.Failed = 1
+        $summary.Detail = @($detail)
+        return $summary
+    }
+
+    # With no file record to go by, the backup folder itself is the expectation.
+    if ($recordCount -le 0) { $summary.Expected = $backedUp.Count }
+
+    foreach ($item in $backedUp) {
+        $destination = Join-Path $TargetPath $item.Name
+        $recorded = @($FileRecord) | Where-Object { $_ -and $_.Name -eq $item.Name } | Select-Object -First 1
+
+        $copy = Copy-OfflineProtectedFile -Source $item.FullName -Destination $destination
+        if (-not $copy.Copied) {
+            $summary.Failed++
+            $detail.Add("Could not restore $($item.Name): $($copy.Reason)")
+            continue
+        }
+
+        if ($recorded -and $recorded.Attributes) {
+            try { (Get-Item -LiteralPath $destination -Force -ErrorAction Stop).Attributes = [System.IO.FileAttributes]$recorded.Attributes }
+            catch { $detail.Add("Restored $($item.Name) but could not reapply its attributes ($($_.Exception.Message)).") }
+        }
+
+        if ($recorded -and $recorded.Security) {
+            if (-not (Restore-OfflineFileSecurity -Path $destination -BinaryDescriptor $recorded.Security)) {
+                $detail.Add("Restored $($item.Name) but could not reapply its original owner and DACL.")
+            }
+        }
+
+        $summary.Restored++
+        $detail.Add("Restored $($item.Name).")
+    }
+
+    $summary.Succeeded = ($summary.Failed -eq 0 -and $summary.Restored -eq $summary.Expected)
+    if (-not $summary.Succeeded -and $summary.Failed -eq 0) {
+        $detail.Add("Rollback recovered $($summary.Restored) of $($summary.Expected) expected file(s).")
+    }
+
+    $summary.Detail = @($detail)
+    return $summary
+}
+
+function Test-OfflineRemovalResult {
+    <#
+    .SYNOPSIS
+        Proves the deletion removed the planned files and nothing else.
+
+    .DESCRIPTION
+        Six checks. Check 5 is the one that matters most: comparing every other file in the folder
+        by size, last write time and attributes is the direct evidence that the registry hives and
+        their .LOG1/.LOG2 recovery logs were neither removed nor modified. Check 6 then has Windows
+        confirm the hives still parse.
+
+        Check 4 re-reads the filesystem directly rather than trusting the list of files the delete
+        loop reported it removed, so it can actually catch a delete that did not take. Check 6
+        reports INCONCLUSIVE rather than PASS when no hive was loadable beforehand, so a run that
+        proved nothing about the hives is never mistaken for one that proved them intact; an
+        inconclusive check is not a failure and does not roll the run back.
+
+        A folder ACL that could not be read before and cannot be read now is passed rather than
+        failed, because there is nothing to compare and refusing on that basis would roll back a
+        correct repair on a build that simply restricts the folder.
+
+    .OUTPUTS
+        PSCustomObject with Passed, Inconclusive, Check[] and Failure[]. Each Check carries Name,
+        Passed, Status ('PASS', 'FAIL' or 'INCONCLUSIVE') and Detail.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]$Plan,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()]$Removed
+    )
+
+    $checks = [System.Collections.Generic.List[object]]::new()
+    $failures = [System.Collections.Generic.List[string]]::new()
+
+    $before = $Plan.Snapshot
+    $after = Get-OfflineFolderSnapshot -Path $Plan.Path -MatchExtension $Plan.MatchExtension -ProtectedExtension $Plan.ProtectedExtension -HiveName $Plan.HiveName
+
+    function Add-Check {
+        param([string]$Name, [bool]$Passed, [string]$Detail, [string]$Status = $null)
+        if ([string]::IsNullOrEmpty($Status)) { $Status = if ($Passed) { 'PASS' } else { 'FAIL' } }
+        $checks.Add([PSCustomObject]@{ Name = $Name; Passed = $Passed; Status = $Status; Detail = $Detail })
+        if (-not $Passed) { $failures.Add("$Name - $Detail") }
+    }
+
+    # 1. The folder is still there.
+    Add-Check -Name 'Folder present' -Passed $after.Present -Detail $(
+        if ($after.Present) { 'the folder is still present' } else { 'the folder is gone' })
+
+    if (-not $after.Present) {
+        return [PSCustomObject]@{ Passed = $false; Inconclusive = $false; Check = @($checks); Failure = @($failures) }
+    }
+
+    # 2. It is the same folder, not a replacement. A timestamp that could not be read on either
+    #    side is INCONCLUSIVE, not PASS. "I could not read it" is the absence of evidence, and
+    #    recording absence of evidence as a passed check is what makes a verification step mean
+    #    nothing. Post-check 6 already draws this distinction; checks 2 and 3 now match it.
+    $folderComparable = ($null -ne $before.CreatedUtc) -and ($null -ne $after.CreatedUtc)
+    $sameFolder = (-not $folderComparable) -or ($before.CreatedUtc -eq $after.CreatedUtc)
+    $folderStatus = if ($folderComparable) { $null } else { 'INCONCLUSIVE' }
+    Add-Check -Name 'Folder not recreated' -Passed $sameFolder -Status $folderStatus -Detail $(
+        if (-not $folderComparable) { 'the creation timestamp could not be read, so whether the folder was replaced could not be proven' }
+        elseif ($sameFolder) { 'the creation timestamp is unchanged' }
+        else { "the creation timestamp changed from $($before.CreatedUtc) to $($after.CreatedUtc)" })
+
+    # 3. The ACL is unchanged. Same rule as check 2: unreadable is unproven, not passed.
+    $aclComparable = ($null -ne $before.Sddl) -and ($null -ne $after.Sddl)
+    $sameAcl = (-not $aclComparable) -or ($before.Sddl -eq $after.Sddl)
+    $aclStatus = if ($aclComparable) { $null } else { 'INCONCLUSIVE' }
+    Add-Check -Name 'Folder ACL unchanged' -Passed $sameAcl -Status $aclStatus -Detail $(
+        if (-not $aclComparable) { 'the ACL could not be read, so whether it changed could not be proven' }
+        elseif ($sameAcl) { 'the ACL is unchanged' }
+        else { 'the ACL changed' })
+
+    # 4. Exactly the planned files went, and no others. This re-reads the offline filesystem
+    #    directly with Test-OfflinePath rather than trusting $Removed - the very list it exists to
+    #    validate - so a delete the loop reported but that did not actually take is still caught.
+    $expectedGone = @($Removed | ForEach-Object { $_.Name })
+    $stillOnDisk = @($expectedGone | Where-Object { Test-OfflinePath (Join-OfflinePath $Plan.Path $_) })
+    $plannedNames = @($before.MatchedFile | ForEach-Object { $_.Name })
+    $unexpectedlyGone = @($plannedNames | Where-Object { $expectedGone -notcontains $_ -and -not (Test-OfflinePath (Join-OfflinePath $Plan.Path $_)) })
+
+    $removalOk = ($stillOnDisk.Count -eq 0 -and $unexpectedlyGone.Count -eq 0)
+    Add-Check -Name 'Planned files removed' -Passed $removalOk -Detail $(
+        if ($removalOk) { "$($expectedGone.Count) file(s) removed as planned" }
+        elseif ($stillOnDisk.Count -gt 0) { "still on disk: $($stillOnDisk -join ', ')" }
+        else { "removed without being planned: $($unexpectedlyGone -join ', ')" })
+
+    # 5. Everything else in the folder is byte-for-byte and flag-for-flag as it was.
+    $otherProblems = [System.Collections.Generic.List[string]]::new()
+    foreach ($original in @($before.OtherFile)) {
+        $current = @($after.OtherFile) | Where-Object { $_.Name -eq $original.Name } | Select-Object -First 1
+        if (-not $current) { $otherProblems.Add("$($original.Name) is missing"); continue }
+        if ($current.Length -ne $original.Length) { $otherProblems.Add("$($original.Name) changed size") }
+        if ($current.LastWriteUtc -ne $original.LastWriteUtc) { $otherProblems.Add("$($original.Name) was written to") }
+        if ($current.Attributes -ne $original.Attributes) { $otherProblems.Add("$($original.Name) had its attributes changed") }
+    }
+    $othersOk = ($otherProblems.Count -eq 0)
+    Add-Check -Name 'Other files untouched' -Passed $othersOk -Detail $(
+        if ($othersOk) { "all $(@($before.OtherFile).Count) other file(s) are unchanged" }
+        else { ($otherProblems -join '; ') })
+
+    # 6. Hives that loaded before still load.
+    $hiveProblems = [System.Collections.Generic.List[string]]::new()
+    $testedBefore = @($Plan.HiveState | Where-Object { $_.Tested -and $_.Loads })
+    if ($testedBefore.Count -eq 0) {
+        # Nothing was provable here - no hive in this folder loaded beforehand, or none was named -
+        # so the removal cannot be said to have preserved them. INCONCLUSIVE, never PASS, so a run
+        # that proved nothing about the hives is not read as one that proved them intact. It is not
+        # counted as a failure and so does not roll the run back.
+        Add-Check -Name 'Registry hives still load' -Passed $true -Status 'INCONCLUSIVE' -Detail 'no hive in this folder was loadable beforehand, so whether the removal preserved them could not be proven'
+    }
+    else {
+        $afterHive = Get-OfflineFolderHiveState -Path $Plan.Path -HiveName $Plan.HiveName -MaxBytes $Plan.HiveMaxBytes
+        foreach ($original in $testedBefore) {
+            $current = @($afterHive) | Where-Object { $_.Name -eq $original.Name } | Select-Object -First 1
+            if (-not $current -or -not $current.Tested) { $hiveProblems.Add("$($original.Name) could not be retested"); continue }
+            if (-not $current.Loads) { $hiveProblems.Add("$($original.Name) no longer loads ($($current.Reason))") }
+        }
+        $hivesOk = ($hiveProblems.Count -eq 0)
+        Add-Check -Name 'Registry hives still load' -Passed $hivesOk -Detail $(
+            if ($hivesOk) { "all $($testedBefore.Count) hive(s) still load" }
+            else { ($hiveProblems -join '; ') })
+    }
+
+    return [PSCustomObject]@{
+        Passed       = ($failures.Count -eq 0)
+        Inconclusive = [bool](@($checks | Where-Object { $_.Status -eq 'INCONCLUSIVE' }).Count -gt 0)
+        Check        = @($checks)
+        Failure      = @($failures)
+    }
+}
+
+function Invoke-OfflineRemovalPlan {
+    <#
+    .SYNOPSIS
+        Backs up, deletes and verifies the files captured in one plan.
+
+    .DESCRIPTION
+        Works only from the file list captured in the plan. The folder is never re-enumerated
+        between deciding and acting, so the set of files that gets deleted is exactly the set that
+        was reported and backed up.
+
+        Deleting is delegated to Invoke-OfflineProtectedFileRemoval, which clears the attributes that
+        block a delete and, only if the delete is actually refused, takes ownership of the file and
+        its parent folder, retries, and restores both descriptors. Verification check 3 compares the
+        folder's SDDL before and after, so an ownership change that was not handed back fails the
+        run and rolls it back rather than being left behind.
+
+        Every path is checked against the bound offline root with Assert-OfflineTarget before it is
+        touched - the folder once, and each file again as it is deleted - so a degraded or unrooted
+        path is refused rather than allowed to delete from the rescue VM's own volume. The backup
+        goes into a folder unique to this run, so one run cannot overwrite an earlier run's backups.
+
+        A failure at any point rolls the whole plan back. A partially cleared CLFS log set is worse
+        than a full one: the .blf refers to containers that would no longer exist. A rollback that
+        itself fails - files now gone with nothing put back - is reported as a distinct, fatal
+        outcome (RollbackAttempted true with RollbackSucceeded false), not as an ordinary failure.
+
+        Progress is recorded with Add-OfflineRepairLog rather than Log-*. The Log-* functions write
+        to the output stream, so calling one here would put log strings into this function's return
+        value and the caller would read them as extra results. The caller flushes the buffer after
+        each call instead.
+
+    .OUTPUTS
+        PSCustomObject with Label, BackupPath, Removed[], Verification, Success, Reason,
+        RollbackAttempted, RollbackSucceeded and RollbackDetail[]. A run where Success is false,
+        RollbackAttempted is true and RollbackSucceeded is false is the fatal case: the offline
+        image is missing files the rollback could not put back.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]$Plan,
+        [Parameter(Mandatory = $true)][string]$BackupRoot,
+        [Parameter(Mandatory = $false)][string]$OfflineRoot
+    )
+
+    $result = [PSCustomObject]@{
+        Label             = $Plan.Label
+        BackupPath        = $null
+        Removed           = @()
+        Verification      = $null
+        Success           = $false
+        Reason            = $null
+        RollbackAttempted = $false
+        RollbackSucceeded = $false
+        RollbackDetail    = @()
+    }
+
+    # Checked here, before anything is copied or deleted, so a script that forgot to dot-source
+    # Use-OfflineProtectedResource.ps1 gets one clear sentence instead of an obscure failure part
+    # way through a set of deletes.
+    if (-not (Get-Command -Name 'Invoke-OfflineProtectedFileRemoval' -ErrorAction SilentlyContinue)) {
+        $result.Reason = 'Use-OfflineProtectedResource.ps1 has not been loaded, so a protected file could not be removed. Dot-source it alongside this helper.'
+        Add-OfflineRepairLog -Level Error -Message $result.Reason
+        return $result
+    }
+
+    # The whole set has to sit under the bound offline root. Asserted once here, loudly, before a
+    # single byte is copied or deleted: a caller that passes a degraded C:\ path, or forgot to bind
+    # a disk at all, is refused outright rather than allowed to clear files off the rescue VM's own
+    # volume.
+    try {
+        if ($PSBoundParameters.ContainsKey('OfflineRoot') -and $OfflineRoot) {
+            [void](Assert-OfflineTarget -Path $Plan.Path -OfflineRoot $OfflineRoot -Action 'delete')
+        }
+        else {
+            [void](Assert-OfflineTarget -Path $Plan.Path -Action 'delete')
+        }
+    }
+    catch {
+        $result.Reason = "the target folder is not on the offline disk: $($_.Exception.Message)"
+        Add-OfflineRepairLog -Level Error -Message $result.Reason
+        return $result
+    }
+
+    # A folder unique to this run - label, PID and a millisecond timestamp - so a second run can
+    # never write over the first run's backups and destroy the only copy of the originals.
+    $runStamp = '{0}_{1}_{2}' -f $Plan.Label, $PID, (Get-Date -Format 'yyyyMMddHHmmssfff')
+    $backupPath = Join-Path $BackupRoot $runStamp
+    try { New-Item -Path $backupPath -ItemType Directory -Force -ErrorAction Stop | Out-Null }
+    catch {
+        $result.Reason = "the backup folder $backupPath could not be created: $($_.Exception.Message)"
+        Add-OfflineRepairLog -Level Error -Message $result.Reason
+        return $result
+    }
+    # Belt and braces: even with the unique name, refuse to reuse a folder that already holds files
+    # rather than risk overwriting a backup that is somehow already there.
+    if (@(Get-ChildItem -LiteralPath $backupPath -Force -ErrorAction SilentlyContinue).Count -gt 0) {
+        $result.Reason = "the backup folder $backupPath already contains files; refusing to reuse it and risk overwriting a previous backup"
+        Add-OfflineRepairLog -Level Error -Message $result.Reason
+        return $result
+    }
+    $result.BackupPath = $backupPath
+
+    # Room for the backup, with the same again as headroom.
+    $required = ($Plan.TotalBytes * 2)
+    $free = Get-OfflineFreeSpace -Path $backupPath
+    if ($null -eq $free) {
+        Add-OfflineRepairLog -Level Warning -Message 'Free space on the backup volume could not be confirmed; continuing.'
+    }
+    elseif ($free -lt $required) {
+        $result.Reason = "not enough free space for the backup: $([math]::Round($free / 1MB)) MB free, $([math]::Round($required / 1MB)) MB needed"
+        return $result
+    }
+
+    # Back everything up first. Nothing is deleted until every file has a verified copy. The backup
+    # records - each carrying the file's recorded attributes and its owner and DACL - are what a
+    # rollback restores from, so they are kept for the rollback calls below.
+    $backups = [System.Collections.Generic.List[object]]::new()
+    foreach ($file in @($Plan.Snapshot.MatchedFile)) {
+        $backup = Backup-OfflineFile -File $file -BackupPath $backupPath
+        if (-not $backup.Success) {
+            $result.Reason = "$($file.Name) could not be backed up - $($backup.Reason)"
+            Add-OfflineRepairLog -Level Error -Message $result.Reason
+            return $result
+        }
+        $backups.Add($backup)
+        Add-OfflineRepairLog -Message "Backed up $($file.Name) ($([math]::Round($file.Length / 1KB)) KB)."
+    }
+
+    # Delete, working from the same list.
+    #
+    # Each file goes through Invoke-OfflineProtectedFileRemoval rather than a plain Remove-Item, so a
+    # file whose DACL refuses the delete is retried after ownership is taken and handed straight
+    # back. config\TxR is exactly that case: its CLFS artifacts are owned by TrustedInstaller, and
+    # without the escalation the whole set rolls back over one refused file.
+    $removed = [System.Collections.Generic.List[object]]::new()
+    $deleteFailed = $null
+    foreach ($file in @($Plan.Snapshot.MatchedFile)) {
+        # Assert each resolved path again, immediately before it is deleted. The set-level check
+        # above proves the folder is on the offline disk; this proves the individual file still is,
+        # closing the gap a caller-supplied or link-redirected path could otherwise slip through.
+        try {
+            if ($PSBoundParameters.ContainsKey('OfflineRoot') -and $OfflineRoot) {
+                [void](Assert-OfflineTarget -Path $file.FullName -OfflineRoot $OfflineRoot -Action 'delete')
+            }
+            else {
+                [void](Assert-OfflineTarget -Path $file.FullName -Action 'delete')
+            }
+        }
+        catch {
+            $deleteFailed = "$($file.Name) is not on the offline disk: $($_.Exception.Message)"
+            break
+        }
+
+        $attempt = Invoke-OfflineProtectedFileRemoval -Path $file.FullName
+
+        if ($attempt.Removed) {
+            $removed.Add([PSCustomObject]@{ Name = $file.Name; Length = $file.Length })
+            if ($attempt.TookOwnership) {
+                Add-OfflineRepairLog -Message "Removed $($file.Name) after taking ownership of it and its folder."
+                if (-not $attempt.Restored) {
+                    Add-OfflineRepairLog -Level Warning -Message "The original permissions on $($file.Name) or its folder could not be fully restored."
+                }
+            }
+            else { Add-OfflineRepairLog -Message "Removed $($file.Name)." }
+            continue
+        }
+
+        # Anything else rolls the set back, including "the file was not present". Every file here
+        # was in the snapshot and was backed up seconds earlier, and nothing else should be touching
+        # a disk attached to a rescue VM, so a file that has since vanished is an anomaly rather
+        # than a result. Check 4 would fail it as unexpectedly gone in any case.
+        $deleteFailed = "$($file.Name) could not be removed: $($attempt.Reason)"
+        break
+    }
+    $result.Removed = @($removed)
+
+    if ($deleteFailed) {
+        Add-OfflineRepairLog -Level Error -Message "$deleteFailed Rolling this set back."
+        $rollback = Restore-OfflineFileSet -BackupPath $backupPath -TargetPath $Plan.Path -FileRecord @($backups)
+        foreach ($line in @($rollback.Detail)) { Add-OfflineRepairLog -Message "  $line" }
+        $result.RollbackAttempted = $true
+        $result.RollbackSucceeded = [bool]$rollback.Succeeded
+        $result.RollbackDetail = @($rollback.Detail)
+        # Verdict last, so it survives the 4096-character tail az vm run-command keeps.
+        if ($rollback.Succeeded) {
+            $result.Reason = "$deleteFailed The set was rolled back and the offline image is unchanged."
+            Add-OfflineRepairLog -Level Warning -Message "Removal of '$($Plan.Label)' failed and was rolled back cleanly; the offline image is unchanged."
+        }
+        else {
+            $result.Reason = "FATAL: $deleteFailed The rollback then failed ($($rollback.Restored) of $($rollback.Expected) restored); the offline image is missing files with no restored backup. Recover by hand from $backupPath."
+            Add-OfflineRepairLog -Level Error -Message $result.Reason
+        }
+        return $result
+    }
+
+    # Prove it did what it was supposed to and nothing more.
+    $verification = Test-OfflineRemovalResult -Plan $Plan -Removed $result.Removed
+    $result.Verification = $verification
+
+    foreach ($check in @($verification.Check)) {
+        $line = "  [$($check.Status)] $($check.Name): $($check.Detail)"
+        switch ($check.Status) {
+            'FAIL' { Add-OfflineRepairLog -Level Error -Message $line }
+            'INCONCLUSIVE' { Add-OfflineRepairLog -Level Warning -Message $line }
+            default { Add-OfflineRepairLog -Message $line }
+        }
+    }
+
+    if (-not $verification.Passed) {
+        Add-OfflineRepairLog -Level Error -Message "Verification failed for $($Plan.Label). Rolling it back."
+        $rollback = Restore-OfflineFileSet -BackupPath $backupPath -TargetPath $Plan.Path -FileRecord @($backups)
+        foreach ($line in @($rollback.Detail)) { Add-OfflineRepairLog -Message "  $line" }
+        $result.RollbackAttempted = $true
+        $result.RollbackSucceeded = [bool]$rollback.Succeeded
+        $result.RollbackDetail = @($rollback.Detail)
+        # Verdict last, so it survives the 4096-character tail az vm run-command keeps.
+        if ($rollback.Succeeded) {
+            $result.Reason = ($verification.Failure -join '; ')
+            Add-OfflineRepairLog -Level Warning -Message "Verification of '$($Plan.Label)' failed and was rolled back cleanly; the offline image is unchanged."
+        }
+        else {
+            $result.Reason = "FATAL: verification failed and the rollback then failed ($($rollback.Restored) of $($rollback.Expected) restored): $($verification.Failure -join '; '). The offline image is missing files with no restored backup. Recover by hand from $backupPath."
+            Add-OfflineRepairLog -Level Error -Message $result.Reason
+        }
+        return $result
+    }
+
+    $result.Success = $true
+    # Verdict last. An inconclusive check is a success with a caveat and must not read as a clean,
+    # fully proven one. The caveat names the checks that were actually unproven rather than
+    # assuming it was the hive check: checks 2 and 3 can also land here, and a hardcoded
+    # explanation would confidently report the wrong reason.
+    if ($verification.Inconclusive) {
+        $unproven = @($verification.Check | Where-Object { $_.Status -eq 'INCONCLUSIVE' })
+        $unprovenDetail = ($unproven | ForEach-Object { "$($_.Name) - $($_.Detail)" }) -join '; '
+        Add-OfflineRepairLog -Level Warning -Message "Removal of '$($Plan.Label)' succeeded, but $($unproven.Count) check(s) could not be proven: $unprovenDetail"
+    }
+    else {
+        Add-OfflineRepairLog -Message "Removal of '$($Plan.Label)' succeeded and every check passed."
+    }
+    return $result
+}

--- a/src/windows/common/helpers/Use-OfflineFileRemoval.ps1
+++ b/src/windows/common/helpers/Use-OfflineFileRemoval.ps1
@@ -313,12 +313,13 @@ function Get-OfflineFolderHiveState {
         and still does not load after it says nothing about the removal; only a hive that loaded
         before and does not load after is evidence, and that is what the verification tests for.
 
-        Test-OfflineHiveFile parses a scratch copy, so this never modifies the offline disk and
-        never loads a hive in place. That matters: loading a hive in place creates KTM transaction
-        logs next to it, which would show up as unexplained new files in the verification.
+        Test-OfflineHiveFile parses with offreg in memory, so this never modifies the offline
+        disk or mounts a hive. That avoids the KTM transaction logs an in-place registry mount
+        can create next to a hive, which would look like unexplained new files in verification.
+        Loads records offreg's result for comparison, not a guarantee that Windows will boot.
 
         Hives above the size limit are recorded as skipped rather than tested, so a multi-gigabyte
-        COMPONENTS hive does not turn a small file deletion into a long copy. The file-level
+        COMPONENTS hive does not turn a small file deletion into a large in-memory parse. The file-level
         comparison still proves such a hive was not modified; only the parse is given up.
 
     .OUTPUTS


### PR DESCRIPTION
## What this adds

The three helpers that perform destructive or boot-affecting repairs.

| Helper | Used by | Purpose |
|---|---|---|
| `Use-OfflineFileRemoval.ps1` | 2 | Removes a set of files from an offline disk with a verified backup, a proof that only the intended files went, and automatic rollback when that proof fails |
| `Get-OfflineBcdStore.ps1` | 2 | Reads and modifies the Boot Configuration Data store of an offline installation |
| `Use-NestedRepairVm.ps1` | 1 | Drives the nested Hyper-V guest that `az vm repair create --enable-nested` provides |

No `map.json` entries are added. Helpers are not run-ids, so nothing new is invocable yet.

## Part of the #143 split

This came from the three-way split of #143. **#143 is now merged and stays unchanged.**
#146 carries the additional shared state/discovery/coordination support used here. The briefly
opened #148 split is closed; all remaining fixes stay in **#146 and #147**, which merge cleanly
in either order. Consuming scenario PRs must wait for both.

## Command injection in the BCD helper

`Invoke-BcdEdit` built a command string and ran it through `cmd.exe /c`. Any value that reached it
from the offline store — a description field, a device path — was re-parsed by the shell.

It now takes `[string[]]$Arguments` and invokes `& bcdedit.exe /store $StorePath @Arguments`
directly. No shell, no re-parsing. This was verified rather than assumed: under the old shape a
payload embedded in an argument executed; under the new shape the identical payload arrives as a
single literal argument.

The signature change touches exactly one scenario, `win-fix-bcd.ps1`, at three call sites, all of
which already build proper argument arrays.

## Removing files from an offline disk

The review found that the "two-layer" allow-list was extension-only on both layers. In the
documented `System32\config` use case that made `SYSTEM.LOG1`, `SOFTWARE.LOG2` and the transaction
`.blf` files removable — deleting a hive's log alongside the hive is how a recoverable image becomes
an unbootable one.

There is now a **base-name veto**: a file whose name without its extension matches a hive name is
refused, ordinal and case-insensitive. This was checked against the real scenarios rather than
assumed safe — genuine transaction files carry a GUID and a `.TM`/`.TxR` infix, so their base name
never equals a hive name and `win-fix-transaction-logs` is unaffected.

Rollback was also silently ineffective: it enumerated the backup with `-ErrorAction
SilentlyContinue`, so a rollback that recovered nothing reported `Restored = 0; Failed = 0` and read
as success. It now fails loudly when the recovered count does not match, routes restores through the
protected-file path so an ACL cannot block them, and reports a distinct fatal outcome when rollback
itself fails.

The initial September 10 dependency follow-up updated hive-comparison documentation to match #146:
`Test-OfflineHiveFile` now parses through the shared in-memory offreg reader from #143, not a
scratch registry mount. The before/after `Loads` field remains a comparison result, not a promise
that Windows will boot. The subsequent review fixes below change removal, rollback and VM coordination.

## Capacity, hashes and rollback

`Get-OfflineFreeSpace` now uses `GetDiskFreeSpaceExW` on the actual directory's volume, without
depending on the PowerShell drive list. Real volume-GUID and boot-volume paths are exercised.
Unknown, invalid or insufficient capacity refuses removal before any backup copy or deletion;
zero bytes remains a valid capacity result, not an unknown one.

The existing backup comparison already rejected missing hashes, and
`Test-OfflineRemovalResult` did not contain a null-equals-null hash comparison. The gap was later
restoration: verified original hashes now survive in `BackupRecord`, and rollback checks both
the backup before copying and the destination afterward. A missing comparison hash is a failure.
Consumers must persist these records and pass them as `-FileRecord` on later revert.

Native testing also found that applying an ACL after attributes set the NTFS Archive bit.
Rollback now restores security first, then reapplies and reads back exact attributes. Failed
metadata replay is a failed restore, not a warning alongside `Succeeded = true`. Legacy records
without a Hash field explicitly warn that they verify the copy against the current backup,
not against a recorded historical original.

## The nested guest

`Start-NestedRepairVm` passed the wrong variable to the attach call, so the disk it took offline was
not the disk it handed to the guest. Four early returns left host disks offline on failure. An
already-running guest short-circuited to `Started = $true` without checking whether the requested
disk was attached at all.

All three are fixed, and a fourth case that the review did not raise is now refused at both ends: if
every requested disk is skipped, the guest would previously start with **no disk**, report success,
and leave the caller waiting out the full heartbeat timeout.

Disks are restored in a `finally`, and only the disks this call took offline — a disk that was
already offline at entry was offline for a reason this helper does not own.

The new coordination fix marks started/adopted guests in Notes before reporting success.
The shared support in #146 recognizes that marker across processes and refuses discovery while
the guest is active. It also protects unrelated guests and serializes lifecycle transitions.
The temporary-user caller no longer invokes the broad stopper after its explicit shutdown;
it confirms `Stopped` before rediscovery. An unconfirmed/failed forced stop is not success.

## First consumer and end-to-end scope

The first planned upstream consumer of `Invoke-OfflineRemovalPlan` is
[`win-fix-transaction-logs`](https://github.com/mvaferreira/repair-script-library/blob/main/src/windows/win-fix-transaction-logs.ps1)
in wave 1. `win-fix-pending-servicing` also consumes it, in wave 3.

This review follow-up exercised real attached **MBR/Gen1 and GPT/Gen2 VHD volumes**, including a
FAT32 EFI partition: native capacity checks, protected file deletion/restoration, same-size
backup tampering, original ACL/attribute restoration, automatic rollback, and BCD
create/edit/read-back/restore through each generation-specific path. **51 assertions passed.**
The originals were preserved and the fixtures removed.

An additional **22 native assertions** exercised the real manifest writers and both scenario
revert entry points in four separate PowerShell processes. Each refused a same-size modified
backup with `STATUS_ERROR`, retained its manifest, and completed a verified retry after the
original backup was restored. Pending servicing also kept the pending.xml rename retryable.
These used synthetic files/hives on a disposable attached VHD, not a complete Windows repair.

These are full helper-level operations on real volumes, not bootable customer-image fixtures.
They do **not** establish a new full Gen1/Gen2 Windows scenario
`az vm repair create/run --preview/restore` acceptance matrix. That distinction is retained
explicitly; scenario acceptance belongs to the consuming PRs.

## Conventions followed

- Every repair is evidence-driven: nothing is written unless a specific fault is detected, so a
  healthy image produces no changes.
- No security protection is disabled as a workaround.
- Logging is ordered so the verdict is last, because `az vm run-command` keeps only the final 4096
  characters of the output stream.

## Testing

- **PSScriptAnalyzer: 0 findings** on all three files, at every severity.
- **66/66 removal regressions** and **87/87 nested lifecycle regressions** pass on PS5.1 and PS7.
- **57/57 consumer regressions** pass on both engines: verified records survive JSON/merged
  manifests, failed or partial restores keep retry data and return error, and successful retries
  complete without misleading rollback claims.
- Defect-level tests covering bcdedit argument injection, the hive base-name veto (including real
  transaction-log filenames that must stay removable), the nested-VM disk hand-off, and `-WhatIf`
  safety on every function that changes host state.
- No `map.json` run-id resolves to a helper, so these files cannot be exercised through
  `az vm repair run` on their own. They are validated by the test suite here; the scenario scripts
  that consume them are validated end-to-end in their own pull requests. `win-fix-bcd.ps1` is the
  one existing script whose call sites change (`Invoke-BcdEdit -Command` → `-Arguments`, 3 sites),
  and it ships in its own pull request with that validation.
- Earlier nested Hyper-V lab validation is recorded in the
  [September 8 follow-up](https://github.com/Azure/repair-script-library/pull/143#issuecomment-5589235133).
- This round adds **93 native Hyper-V assertions** with disposable Gen1/Gen2 guests and actual
  passthrough-disk hand-offs. A separate PowerShell process cannot interrupt a helper-owned guest.
  Five existing guests and seven original disks were preserved. These guests have no Windows OS;
  their role is lifecycle/disk coordination, not boot or payload validation.
