### PR TITLE
Follow up #143: share hive state and protect nested repair handoffs

### DIFF
--- a/src/windows/common/helpers/Get-OfflineWindowsDisk.ps1
+++ b/src/windows/common/helpers/Get-OfflineWindowsDisk.ps1
@@ -22,8 +22,8 @@
       Clear-OfflineDriveLetter      Release every drive letter this run assigned (finally).
       Stop-NestedRepairVm           Stop a nested Hyper-V repair VM holding the disk.
 
-    Get-OfflineWindowsDisk sets $script:OfflineWindowsDrive, which the offline registry
-    hive helper (Use-OfflineRegistryHive.ps1) uses as its default Windows path.
+    Get-OfflineWindowsDisk publishes the selected Windows drive through the shared repair
+    state, which the offline registry hive helper uses as its default Windows path.
 
 .NOTES
     Name:   Get-OfflineWindowsDisk.ps1
@@ -61,9 +61,14 @@
     v1.4: Verify disk state after diskpart, skip writes to already-ready disks, and recognise
           the resource disk by its language-independent warning file as well as its label.
           Probe hive metadata in memory through offreg, without registry mounts.
+    v1.5: Refuse discovery while a helper-managed guest owns its disks. Limit automatic
+          shutdown to ProblemVM or an explicit Id, and serialize guest/disk hand-offs.
 #>
 
-if (-not (Get-Command Open-OfflineRegistryReader -ErrorAction SilentlyContinue)) {
+if (-not (Get-Command Open-OfflineRegistryReader -ErrorAction SilentlyContinue) -or
+    -not (Get-Command Set-OfflineWindowsDrive -ErrorAction SilentlyContinue) -or
+    -not (Get-Command Enter-OfflineNestedVmLifecycle -ErrorAction SilentlyContinue) -or
+    -not (Get-Command Test-OfflineNestedVmManaged -ErrorAction SilentlyContinue)) {
     try {
         . (Join-Path $PSScriptRoot 'OfflineRepairCommon.ps1')
     }
@@ -269,42 +274,91 @@ function Get-PartitionExistingRoot {
 function Stop-NestedRepairVm {
     <#
     .SYNOPSIS
-        Stops a running nested Hyper-V VM so its VHD can be mounted offline.
+        Releases the Azure-created nested guest before an offline repair.
 
     .DESCRIPTION
         Only relevant when the repair VM was created with 'az vm repair create --enable-nested'.
-        Returns the names of the VMs that were stopped. Silently does nothing when the
-        Hyper-V role is not installed.
+        The default target is exactly one guest named ProblemVM; a custom guest requires its
+        explicit Id. Other active guests block discovery rather than being turned off.
 
-        SupportsShouldProcess is declared so -WhatIf reports each VM it would turn off.
-        ConfirmImpact is left at the default (Medium), below the default $ConfirmPreference
-        (High), so the non-interactive SYSTEM run under az vm repair proceeds without a prompt.
+        A guest claimed by Start-NestedRepairVm is never stopped here. The owning flow must
+        call Stop-NestedRepairVmGraceful and confirm Stopped before rediscovering the disk.
+        Refusing, rather than merely skipping that guest, prevents disk preparation from
+        proceeding while the guest still owns it. The Notes marker persists across processes.
+
+        Returns the name only after the selected guest is confirmed Off. Does nothing when
+        Hyper-V is absent. Enumeration or shutdown failures abort the hand-off.
+
+    .PARAMETER VmId
+        Exact Id of a custom, unmanaged repair guest. Omit for the Azure-created ProblemVM.
     #>
     [CmdletBinding(SupportsShouldProcess)]
     [OutputType([System.Object[]])]
-    param()
+    param([guid]$VmId = [guid]::Empty)
 
     $stopped = @()
-
     if (-not (Get-Command Get-VM -ErrorAction SilentlyContinue)) { return $stopped }
 
+    $lease = Enter-OfflineNestedVmLifecycle
     try {
-        $running = @(Get-VM -ErrorAction SilentlyContinue | Where-Object { $_.State -eq 'Running' })
-    }
-    catch {
-        Add-OfflineRepairLog -Level Info -Message "Hyper-V is present but VMs could not be enumerated: $($_.Exception.Message)"
+        $guests = @(Get-VM -ErrorAction Stop)
+        $active = @($guests | Where-Object { $_.State -ne 'Off' })
+        $managed = @($active | Where-Object { Test-OfflineNestedVmManaged -Vm $_ })
+        if ($managed.Count -gt 0) {
+            $names = ($managed | ForEach-Object { "'$($_.Name)' ($($_.Id))" }) -join ', '
+            throw "Offline discovery refused: helper-managed guest(s) $names are still active. The owning flow must use Stop-NestedRepairVmGraceful and confirm Stopped before taking the disk back."
+        }
+
+        $target = @(if ($VmId -ne [guid]::Empty) {
+                $guests | Where-Object { $_.Id -eq $VmId }
+            }
+            else {
+                $guests | Where-Object { $_.Name -eq 'ProblemVM' }
+            })
+
+        if ($VmId -ne [guid]::Empty -and $target.Count -ne 1) {
+            throw "The explicitly selected nested repair guest '$VmId' could not be resolved uniquely."
+        }
+        if ($active.Count -eq 0) { return $stopped }
+        if ($target.Count -ne 1) {
+            throw 'Active Hyper-V guests exist but there is not exactly one ProblemVM. Nothing was stopped. Select the intended unmanaged repair guest explicitly with -NestedVmId on Get-OfflineWindowsDisk.'
+        }
+
+        $other = @($active | Where-Object { $_.Id -ne $target[0].Id })
+        if ($other.Count -gt 0) {
+            $names = ($other | ForEach-Object { "'$($_.Name)' ($($_.Id))" }) -join ', '
+            throw "Offline discovery refused: other Hyper-V guest(s) $names are active. Nothing was stopped; complete their disk hand-off explicitly first."
+        }
+
+        $vm = Get-VM -Id $target[0].Id -ErrorAction Stop
+        if (-not $vm) { throw 'The selected nested repair guest disappeared before shutdown.' }
+        if ($vm.State -eq 'Off') { return $stopped }
+        if (Test-OfflineNestedVmManaged -Vm $vm) {
+            throw "Nested guest '$($vm.Name)' was claimed by a repair flow; automatic shutdown was refused."
+        }
+        if ($vm.State -ne 'Running') {
+            throw "Nested guest '$($vm.Name)' is '$($vm.State)', not Running or Off. Resolve that state explicitly before offline discovery."
+        }
+        if (-not $PSCmdlet.ShouldProcess($vm.Name, 'Turn off the selected unmanaged repair VM so its disk can be mounted offline')) {
+            return $stopped
+        }
+
+        Add-OfflineRepairLog -Level Info -Message "Stopping unmanaged nested repair guest '$($vm.Name)' ($($vm.Id)) so its disk can be mounted offline."
+        Stop-VM -VM $vm -TurnOff -Force -ErrorAction Stop
+        $after = Get-VM -Id $vm.Id -ErrorAction Stop
+        if (-not $after -or $after.State -ne 'Off') {
+            throw "Nested guest '$($vm.Name)' could not be confirmed Off after shutdown; disk preparation was refused."
+        }
+        $stopped += $vm.Name
         return $stopped
     }
-
-    foreach ($vm in $running) {
-        if (-not $PSCmdlet.ShouldProcess($vm.Name, 'Turn off nested Hyper-V VM so its disk can be mounted offline')) { continue }
-        Add-OfflineRepairLog -Level Info -Message "Stopping nested Hyper-V VM '$($vm.Name)' so its disk can be mounted offline."
-        Stop-VM -Name $vm.Name -TurnOff -Force -ErrorAction SilentlyContinue
-        $stopped += $vm.Name
+    catch {
+        Add-OfflineRepairLog -Level Error -Message $_.Exception.Message
+        throw
     }
-
-    if ($stopped.Count -gt 0) { Start-Sleep -Seconds 3 }
-    return $stopped
+    finally {
+        Exit-OfflineNestedVmLifecycle -Lease $lease
+    }
 }
 
 function Test-TemporaryStorageDisk {
@@ -825,17 +879,21 @@ function Get-OfflineWindowsDisk {
         Locates the offline Windows installation on the attached broken OS disk.
 
     .DESCRIPTION
-        Stops a nested repair VM if one is running, brings the attached virtual disks
+        Releases an unmanaged Azure-created nested repair VM, brings the attached virtual disks
         online, assigns drive letters to partitions that have none, then selects the
-        best Windows installation and its matching boot partition.
+        best Windows installation and its matching boot partition. Active helper-managed
+        or unrelated guests block discovery before disks or drive letters are changed.
 
-        Sets $script:OfflineWindowsDrive for the offline registry hive helper.
+        Publishes the selected Windows drive through the shared repair state.
 
     .PARAMETER DiskNumber
         Restrict the search to a specific disk number.
 
     .PARAMETER WindowsDrive
         Skip discovery and use this drive letter as the offline Windows volume.
+
+    .PARAMETER NestedVmId
+        Exact Id of a custom unmanaged repair guest. Omit for the Azure-created ProblemVM.
 
     .OUTPUTS
         PSCustomObject with DiskNumber, PartitionStyle, Generation, WindowsDrive,
@@ -850,7 +908,8 @@ function Get-OfflineWindowsDisk {
     #>
     param(
         [Parameter(Mandatory = $false)][int]$DiskNumber = -1,
-        [Parameter(Mandatory = $false)][string]$WindowsDrive
+        [Parameter(Mandatory = $false)][string]$WindowsDrive,
+        [Parameter(Mandatory = $false)][guid]$NestedVmId = [guid]::Empty
     )
 
     # The rescue VM's own OS disk must be known before anything is brought online, because
@@ -864,8 +923,14 @@ function Get-OfflineWindowsDisk {
         throw "Could not determine the rescue VM's own system disk number, so the broken disk cannot be told apart from it: $($_.Exception.Message)"
     }
 
-    $null = Stop-NestedRepairVm
-    $onlineDiskNumbers = @(Set-OfflineDisksOnline -ExcludeDiskNumber @($systemDiskNumber | Where-Object { $_ -ge 0 }))
+    $lease = Enter-OfflineNestedVmLifecycle
+    try {
+        $null = Stop-NestedRepairVm -VmId $NestedVmId
+        $onlineDiskNumbers = @(Set-OfflineDisksOnline -ExcludeDiskNumber @($systemDiskNumber | Where-Object { $_ -ge 0 }))
+    }
+    finally {
+        Exit-OfflineNestedVmLifecycle -Lease $lease
+    }
 
     # Select by bus type, not model name: Azure NVMe disks report 'Microsoft NVMe Direct
     # Disk', which the old '*Virtual Disk*' match missed. The rescue VM's own system disk,
@@ -1007,15 +1072,13 @@ function Get-OfflineWindowsDisk {
     # VM's own system drive, which is the fail-closed behaviour we want. The boot/EFI
     # partition is a separate volume on the same disk that BCD repairs write to, so it is
     # bound too or the gate would refuse them.
-    $null = Set-OfflineRepairRoot -Path $selected.Drive
+    $null = Set-OfflineWindowsDrive -WindowsDrive $selected.Drive
     if ($bootDrive) {
         $bootRoot = "$bootDrive".TrimEnd('\')
         if ($bootRoot -match '^[A-Za-z]:$' -and $bootRoot -ne $selected.Drive) {
             $null = Set-OfflineRepairRoot -Path $bootRoot
         }
     }
-
-    $script:OfflineWindowsDrive = $selected.Drive
 
     $result = [PSCustomObject]@{
         DiskNumber           = $selected.DiskNumber

--- a/src/windows/common/helpers/OfflineRepairCommon.ps1
+++ b/src/windows/common/helpers/OfflineRepairCommon.ps1
@@ -58,6 +58,8 @@
           resource.
     v1.2: Added a read-only offreg reader for discovery and hive validation, without
           mounting hives in the rescue VM's registry or replaying logs onto the source.
+    v1.3: Shared writable-hive lifecycle and default-drive state across dot-source scopes.
+          Added numeric, read-only native queries for mounted keys and DWORD metadata.
 #>
 
 function Get-OfflineRepairState {
@@ -66,8 +68,8 @@ function Get-OfflineRepairState {
         Returns the shared helper state, creating it on first use.
 
     .DESCRIPTION
-        One hashtable in $global: holds the log buffer, the bound offline roots and the
-        registered hive mount keys. See the file header for why this is not $script:.
+        One hashtable in $global: holds the log buffer, target bindings, default Windows
+        drive and hive lifecycle. See the file header for why this is not $script:.
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidGlobalVars', '',
         Justification = 'Deliberate, and confined to this one function. These helpers are dot-sourced, and a $script: variable binds to the scope that did the dot-sourcing: a helper sourced from inside a function would get its own private copy of the root list, so Assert-OfflineTarget would check a set the caller never populated and the gate would fail open. Each az vm repair run is a fresh process, so there is nothing to leak into; Clear-OfflineRepairRoot resets it for tests.')]
@@ -76,12 +78,67 @@ function Get-OfflineRepairState {
 
     if (-not $global:OfflineRepairState) {
         $global:OfflineRepairState = @{
-            LogBuffer = [System.Collections.Generic.List[object]]::new()
-            Roots     = [System.Collections.Generic.List[string]]::new()
-            HiveKeys  = [System.Collections.Generic.List[string]]::new()
+            LogBuffer     = [System.Collections.Generic.List[object]]::new()
+            Roots         = [System.Collections.Generic.List[string]]::new()
+            HiveKeys      = [System.Collections.Generic.List[string]]::new()
+            WindowsDrive  = $null
+            HiveLoadDepth = @{}
+            HiveFilePaths = @{}
         }
     }
+    # Upgrade an existing state without resetting another dot-source scope's acquisitions.
+    foreach ($name in @('HiveLoadDepth', 'HiveFilePaths')) {
+        if (-not $global:OfflineRepairState.ContainsKey($name)) {
+            $global:OfflineRepairState[$name] = @{}
+        }
+    }
+    if (-not $global:OfflineRepairState.ContainsKey('WindowsDrive')) {
+        $global:OfflineRepairState.WindowsDrive = $null
+    }
     return $global:OfflineRepairState
+}
+
+function Set-OfflineWindowsDrive {
+    <#
+    .SYNOPSIS
+        Binds the default offline Windows drive for every dot-source scope.
+
+    .DESCRIPTION
+        Call after discovery selects the Windows volume. Returns the bound root, like
+        Set-OfflineRepairRoot. An active hive caller must not have its default retargeted.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '',
+        Justification = 'Only updates the in-process offline target binding; skipping it for WhatIf would leave subsequent helpers bound to the wrong default.')]
+    param([Parameter(Mandatory = $true)][string]$WindowsDrive)
+
+    $state = Get-OfflineRepairState
+    $normalised = ConvertTo-OfflineComparablePath $WindowsDrive
+    if ($state.WindowsDrive -and $normalised -ne $state.WindowsDrive -and $state.HiveLoadDepth.Count -gt 0) {
+        throw "Cannot change the offline Windows drive from '$($state.WindowsDrive)' to '$WindowsDrive' while hives are in use."
+    }
+    $state.WindowsDrive = Set-OfflineRepairRoot -Path $WindowsDrive
+    return $state.WindowsDrive
+}
+
+function Get-OfflineWindowsDrive {
+    <#
+    .SYNOPSIS
+        Returns the shared default offline Windows drive.
+
+    .DESCRIPTION
+        Imports a legacy $script:OfflineWindowsDrive only when no shared default is set.
+        Once imported, shared state is authoritative; callers changing disks must use
+        Set-OfflineWindowsDrive rather than updating a scope-private variable.
+    #>
+    $state = Get-OfflineRepairState
+    if ([string]::IsNullOrWhiteSpace($state.WindowsDrive)) {
+        $legacy = Get-Variable -Name OfflineWindowsDrive -Scope Script -ErrorAction SilentlyContinue
+        if ($legacy -and -not [string]::IsNullOrWhiteSpace($legacy.Value)) {
+            $null = Set-OfflineWindowsDrive -WindowsDrive $legacy.Value
+            Add-OfflineRepairLog -Level Warning -Message 'Imported the legacy OfflineWindowsDrive default. Use Set-OfflineWindowsDrive when selecting another disk.'
+        }
+    }
+    return $state.WindowsDrive
 }
 
 function Add-OfflineRepairLog {
@@ -302,6 +359,122 @@ function Open-OfflineRegistryReader {
     return [RslOffline.RegistryHiveReader]::Open($Path)
 }
 
+function Initialize-OfflineMountedRegistry {
+    <#
+    .SYNOPSIS
+        Initialises read-only native queries of already mounted HKLM keys.
+
+    .DESCRIPTION
+        RegOpenKeyEx returns numeric errors for the key itself, independently of its
+        default value or the OS language. Every handle is disposed before returning.
+        No privileges, registry provider handles, mounts or writes are involved.
+        Offline file discovery and validation continue to use the separate offreg reader.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if ('RslOffline.MountedRegistry' -as [type]) { return }
+
+    Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace RslOffline
+{
+    public static class MountedRegistry
+    {
+        private static readonly IntPtr HKLM = new IntPtr(unchecked((int)0x80000002));
+        private const int KeyQueryValue = 1;
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        private static extern int RegOpenKeyExW(IntPtr key, string subKey, int options,
+            int access, out SafeRegistryHandle result);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        private static extern int RegQueryValueExW(SafeRegistryHandle key, string name,
+            IntPtr reserved, out uint type, byte[] data, ref uint size);
+
+        private static void Check(int result, string operation)
+        {
+            if (result != 0)
+                throw new Win32Exception(result, operation + " failed (Win32 error " +
+                    result + "): " + new Win32Exception(result).Message);
+        }
+
+        public static int OpenKeyResult(string subKey)
+        {
+            SafeRegistryHandle key;
+            int result = RegOpenKeyExW(HKLM, subKey, 0, KeyQueryValue, out key);
+            using (key) { return result; }
+        }
+
+        public static uint? ReadDword(string subKey, string name)
+        {
+            SafeRegistryHandle key;
+            int result = RegOpenKeyExW(HKLM, subKey, 0, KeyQueryValue, out key);
+            using (key)
+            {
+                if (result == 2 || result == 3) return null;
+                Check(result, "Opening HKLM\\" + subKey);
+                uint type;
+                uint size = 4;
+                byte[] data = new byte[size];
+                result = RegQueryValueExW(key, name, IntPtr.Zero, out type, data, ref size);
+                if (result == 2) return null;
+                if (result != 234) Check(result, "Reading HKLM\\" + subKey + "\\" + name);
+                if (result == 234 || type != 4 || size != 4)
+                    throw new InvalidDataException("HKLM\\" + subKey + "\\" + name +
+                        " is not a four-byte registry DWORD.");
+                return BitConverter.ToUInt32(data, 0);
+            }
+        }
+    }
+}
+'@ -ErrorAction Stop
+}
+
+function Get-OfflineRegistryKeyOpenResult {
+    <#
+    .SYNOPSIS
+        Returns the native result of opening an existing HKLM key for query access.
+    #>
+    param([Parameter(Mandatory = $true)][string]$Key)
+
+    $normalised = ConvertTo-OfflineComparableRegistryPath $Key
+    if (-not $normalised -or $normalised -eq 'HKLM') {
+        throw "'$Key' is not an HKLM subkey."
+    }
+    Initialize-OfflineMountedRegistry
+    return [RslOffline.MountedRegistry]::OpenKeyResult($normalised.Substring(5))
+}
+
+function Get-OfflineRegistryDword {
+    <#
+    .SYNOPSIS
+        Reads a mounted HKLM DWORD without retaining a registry handle.
+
+    .DESCRIPTION
+        Returns null only for an absent key/value. A wrong type, access denial or any
+        other native read failure throws instead of converting it into a missing value.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$Key,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Name
+    )
+
+    $normalised = ConvertTo-OfflineComparableRegistryPath $Key
+    if (-not $normalised -or $normalised -eq 'HKLM') {
+        throw "'$Key' is not an HKLM subkey."
+    }
+    Initialize-OfflineMountedRegistry
+    return [RslOffline.MountedRegistry]::ReadDword($normalised.Substring(5), $Name)
+}
+
 #region Offline target binding
 
 $script:OfflineRootPattern = '^([A-Za-z]:|\\\\[^\\]+\\[^\\]+)$'
@@ -477,6 +650,7 @@ function Clear-OfflineRepairRoot {
     $state = Get-OfflineRepairState
     $state.Roots.Clear()
     $state.HiveKeys.Clear()
+    $state.WindowsDrive = $null
 }
 
 function Register-OfflineHiveKey {
@@ -876,4 +1050,85 @@ function Get-OfflineSecureBootState {
 
     $result.Source = 'the SecureBoot variable was not present in the most recent Measured Boot logs'
     return $result
+}
+
+function Get-OfflineNestedVmOwnershipTag {
+    <#
+    .SYNOPSIS
+        Returns the persistent Notes marker shared by discovery and nested-guest helpers.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+    return 'repair-script-library:nested-repair:v1'
+}
+
+function Test-OfflineNestedVmManaged {
+    <#
+    .SYNOPSIS
+        Reports whether a guest has the exact ownership marker on a separate Notes line.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param([Parameter(Mandatory = $true)][AllowNull()]$Vm)
+
+    if ($null -eq $Vm) { return $false }
+    $notes = $Vm.PSObject.Properties['Notes']
+    if (-not $notes) { return $false }
+    $tag = Get-OfflineNestedVmOwnershipTag
+    foreach ($line in ([string]$notes.Value -split '\r\n|\n|\r')) {
+        if ([string]::Equals($line, $tag, [StringComparison]::Ordinal)) { return $true }
+    }
+    return $false
+}
+
+function Enter-OfflineNestedVmLifecycle {
+    <#
+    .SYNOPSIS
+        Serializes nested-guest ownership and disk hand-offs across host processes.
+
+    .DESCRIPTION
+        The lease is reentrant on the current thread, so discovery can call the guarded
+        stopper while holding its own disk-preparation lease. Another thread or process
+        is refused immediately. Release each acquired lease in finally; this is not a
+        lease for an entire repair session or the lifetime of a running guest.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Threading.Mutex])]
+    param()
+
+    $lease = $null
+    $acquired = $false
+    try {
+        $lease = [System.Threading.Mutex]::new($false, 'Global\RslOfflineNestedVmLifecycleV1')
+        try { $acquired = $lease.WaitOne(0) }
+        catch [System.Threading.AbandonedMutexException] {
+            $acquired = $true
+            Add-OfflineRepairLog -Level Warning -Message 'The previous nested-VM lifecycle owner exited unexpectedly. Guest ownership and disk state will be checked again before proceeding.'
+        }
+        if (-not $acquired) {
+            throw 'Another nested-VM lifecycle operation is in progress on this host; the disk hand-off was refused.'
+        }
+        return $lease
+    }
+    catch {
+        if ($lease) {
+            try { if ($acquired) { $lease.ReleaseMutex() } }
+            finally { $lease.Dispose() }
+        }
+        Add-OfflineRepairLog -Level Error -Message "Could not acquire the nested-VM lifecycle lease: $($_.Exception.Message)"
+        throw
+    }
+}
+
+function Exit-OfflineNestedVmLifecycle {
+    <#
+    .SYNOPSIS
+        Releases and disposes a lifecycle lease acquired by the current thread.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory = $true)][System.Threading.Mutex]$Lease)
+
+    try { $Lease.ReleaseMutex() }
+    finally { $Lease.Dispose() }
 }

--- a/src/windows/common/helpers/README.md
+++ b/src/windows/common/helpers/README.md
@@ -8,14 +8,14 @@ Each helper script and description should be listed here.
 | `Get-Disk-Partitions.ps1` | Returns partitions of attached disks whose `Win32_diskdrive` model is `Microsoft Virtual Disk`, bringing them online with `diskpart`. **SCSI-attached disks only.** |
 | `Get-Disk-Partitions-v2.ps1` | As v1, with `$partitionlist` initialised to an array so a single result is not unrolled. **SCSI-attached disks only.** |
 | `Get-Disk-Partitions-v3.ps1` | `Get-Disk-Partitions-v3` selects attached disks by **BusType** (SCSI/SAS/RAID/NVMe) instead of the SCSI-only model string, so it also works when the repair VM uses the NVMe disk controller. Excludes the Azure resource disk. `Get-Windows-OsDrives-v3` narrows the result to drive letters that contain a Windows installation. |
-| `OfflineRepairCommon.ps1` | Shared primitives for offline repair: buffered logging, path joining and validation, Authenticode/catalog signature inspection, a read-only `offreg.dll` hive reader, and the offline-target gate (`Set-OfflineRepairRoot` / `Assert-OfflineTarget`) that binds every other offline helper to the attached disk. |
-| `Get-OfflineWindowsDisk.ps1` | Finds the offline Windows installation on the attached disk, verifies its disks are online and writable, and manages temporary drive letters for hidden EFI System and Recovery partitions. Selects by **BusType**, excludes resource disks by label or warning-file marker, and refuses the rescue VM's own boot/system disk. Reads hive metadata without registry mounts and binds the offline root for `Assert-OfflineTarget`. |
-| `Use-OfflineRegistryHive.ps1` | Mounts writable hives from the attached disk, runs a scriptblock, and verifies their unload even after a partial mount failure. Its separate `Test-OfflineHiveFile` validation uses the shared in-memory reader without mounting or copying hives. |
+| `OfflineRepairCommon.ps1` | Shared primitives for offline repair: buffered logging, drive-safe paths, signature inspection, a read-only `offreg.dll` reader, shared hive/default-drive state, the offline-target gate, and cross-process nested-VM lifecycle coordination. |
+| `Get-OfflineWindowsDisk.ps1` | Finds the offline Windows installation, verifies its disks are online and writable, and manages temporary drive letters. Selects by **BusType**, excludes resource disks and the rescue VM's own disks, reads hive metadata without mounts, and publishes the shared offline target. Active helper-managed or unrelated guests block discovery before disk preparation. |
+| `Use-OfflineRegistryHive.ps1` | Mounts writable hives, runs reentrant callbacks, and verifies unload with language-independent key-state checks. Provides strict control-set selection for writers. Its separate `Test-OfflineHiveFile` uses the shared in-memory reader without mounting or copying hives. |
 | `Use-OfflineProtectedResource.ps1` | Takes ownership of, reads and restores files and registry keys on the attached disk that `SYSTEM` cannot otherwise open, restoring every security descriptor it changed and verifying the restore rather than counting it. |
 | `Use-OfflinePrivilegedRegistry.ps1` | The privileged registry operations from `Use-OfflineProtectedResource.ps1`: enabling `SeTakeOwnershipPrivilege`/`SeRestorePrivilege` and removing or rewriting keys that deny access to `SYSTEM`. |
 | `Get-OfflineBcdStore.ps1` | Locates the BCD store on the attached disk and runs `bcdedit.exe` against it directly, without a shell. Distinguishes an empty boot inventory from a failed enumeration, and refuses to operate on the rescue VM's own store. |
-| `Use-OfflineFileRemoval.ps1` | Removes files from the attached disk with a backup, a verified rollback, and post-removal checks. Refuses to remove a registry hive or any of its side files, refuses to follow reparse points, and refuses any path outside the bound offline root. |
-| `Use-NestedRepairVm.ps1` | Boots the offline Windows installation as a nested Hyper-V guest on the rescue VM for repairs that only the running OS can perform. Restores the offline state of every disk it took, on every exit path. |
+| `Use-OfflineFileRemoval.ps1` | Removes approved files with hash-verified backups and rollback. Unknown or insufficient native volume capacity refuses removal. Retains original hashes and recorded metadata for later restores, refuses hive side files and reparse points, and enforces the bound offline target. |
+| `Use-NestedRepairVm.ps1` | Hands named disks to an existing nested guest and records ownership in Notes so discovery cannot interrupt it. A failed start restores only disks that call took offline. Reports whether an explicit shutdown actually completed before the caller takes the disk back. |
 
 **Which one to use:** new scripts that need the *Windows installation* — to mount its hives, edit its
 BCD, or repair files on it — should use `Get-OfflineWindowsDisk.ps1`, which also binds the offline root
@@ -78,3 +78,51 @@ not that the guest will boot or that a separate structural check is unnecessary.
 `Invoke-WithHive` and the protected-registry helpers still expose writable HKLM paths. The in-memory
 reader does not replace that contract; callers requiring those paths must keep using the guarded
 mount/unmount helpers.
+
+## Writable hives and control-set selection
+
+Mounted-key state is `Present`, `Absent`, or `Unknown`, determined through registry APIs rather
+than localized `reg.exe` messages. Access denial is not absence, and a file-sharing check is not
+used as proof of which registry key owns a hive.
+
+Writers must use `Get-OfflineSystemRootPath -Strict`, `Get-OfflineControlSetName -Strict`, or
+`Get-OfflineReferencedControlSetName -Strict`. Strict selection rejects an unreadable, wrongly typed,
+out-of-range or missing current control set instead of guessing `ControlSet001`. The non-strict
+fallback remains for tolerant reads, not for deriving a write target.
+
+`Invoke-WithHive` shares its depth and file bindings across dot-source scopes. An inner callback
+cannot unload an outer caller's hive or switch that active hive to another file. Discovery sets
+the default through `Set-OfflineWindowsDrive`; manual selection must use that setter too, rather
+than assigning a scope-private `$script:OfflineWindowsDrive`.
+
+## Removal and later rollback
+
+Persist `Invoke-OfflineRemovalPlan`'s `BackupRecord` with the backup location. Pass those records as
+`Restore-OfflineFileSet -FileRecord` on a later revert; reconstructing just names and attributes
+discards the verified original hashes and security descriptors.
+
+A restore checks the backup and restored contents against the recorded hash, reapplies the recorded
+security, then restores and verifies exact attributes. Attributes come last because an NTFS security
+change can set Archive. Treat `Succeeded = $false` as a failed or incomplete restore and retain the
+undo manifest, even when some files were restored.
+
+Legacy records without a Hash field remain supported with an explicit warning: the check proves the
+copy against the current backup, not against a recorded historical original. An explicitly empty
+Hash field is an unavailable verification result and is refused.
+
+## Nested-guest hand-offs
+
+Automatic discovery shutdown is limited to the unmanaged Azure-created `ProblemVM`, or an exact
+custom guest selected with `Get-OfflineWindowsDisk -NestedVmId`. Other active guests are never
+implicitly turned off.
+
+`Start-NestedRepairVm` marks a started or adopted guest with a separate
+`repair-script-library:nested-repair:v1` Notes line, preserving existing notes. A fresh discovery
+process recognizes it and refuses to proceed while it is active. Skipping the guest and onlining
+its disk would not be safe.
+
+Sequence offline editing, `Start-NestedRepairVm`, boot/result observation,
+`Stop-NestedRepairVmGraceful`, and rediscovery. **Confirm `Stopped` before taking the disk back.**
+A timeout power-off is reported as non-graceful and requires rechecking the disk. The shared host
+mutex serializes lifecycle transitions, not an entire repair session; it does not replace this
+caller sequencing.


### PR DESCRIPTION
## Why this follow-up exists

#143 merged as `1b2a597` while the additional #146/#147 review fixes were being validated.
This PR contains only the shared-foundation changes those reviews need; it does not alter the
approved/merged #143 history.

| File | Change |
|---|---|
| `OfflineRepairCommon.ps1` | Shared writable-hive depth/file bindings and default Windows drive; persistent nested-VM ownership marker and a reentrant cross-process lifecycle mutex |
| `Get-OfflineWindowsDisk.ps1` | Publishes the shared default; refuses active managed/unrelated guests before disk preparation; limits automatic shutdown to `ProblemVM` or an explicit custom Id |
| `README.md` | Documents strict writers, persistent rollback records and verified guest hand-offs |

No scenario or `map.json` entry is added. #146 and #147 use this shared contract; consuming
scenario PRs must wait until all three outstanding helper changes have merged.

## Registry state across dot-source scopes

`Set-OfflineWindowsDrive` binds the selected root and publishes the default through
`Get-OfflineRepairState`. Scope-private variables are no longer independent sources of truth.
The same state owns hive depth and active file bindings, preventing an inner callback from
unloading its outer caller's hive or silently switching the file/default underneath it.

## Nested-guest coordination

Discovery previously turned off every running Hyper-V guest. It now fails before any disk
preparation when another guest is active or #147's helper has marked a guest as managed. It does
not merely skip that guest and attempt to online its disk.

The persistent `repair-script-library:nested-repair:v1` Notes line works across PowerShell
processes. A shared mutex serializes ownership/start/stop and disk-preparation transitions.
The owning flow must explicitly call `Stop-NestedRepairVmGraceful`, confirm `Stopped`, and
then rediscover the disk. Automatic unmanaged shutdown uses an exact VM object and verifies Off;
no wildcard-name shutdown or success-shaped enumeration failure remains.

## Validation and limits

- Existing **120/120** defect and **53/53** follow-up cases pass on PS5.1 and PS7.
- Dedicated registry regressions pass **140/140** on both engines; PSScriptAnalyzer is zero
  across all eight helper files.
- **87/87** nested lifecycle cases pass on both engines, including cross-process mutex exclusion.
- **33 native assertions** on a disposable VHD verify discovery/default-drive binding, real
  writable synthetic hives, strict selected-set writes, cross-scope calls and unwind/cleanup.
- **93 native Hyper-V assertions** use disposable Gen1/Gen2 guests with actual passthrough VHD
  disks. Fresh-process discovery refuses to interrupt them; disk return is verified. Five
  original guests and seven original disks remain unchanged.
- The test guests are firmware-only and the hives are synthetic. These results are not
  presented as Windows guest boot/payload validation or a fresh `--preview` scenario matrix.

Local test tooling stays outside the contribution, as requested. No protection was disabled,
and no existing lab guest or original disk was repurposed for these checks.
