### PR TITLE
Add preview Windows NVMe boot-driver recovery script

### DIFF
--- a/src/windows/win-enable-nvme-boot-driver.ps1
+++ b/src/windows/win-enable-nvme-boot-driver.ps1
@@ -1,0 +1,193 @@
+#########################################################################################################
+#
+# .SYNOPSIS
+#   Enable the Windows inbox NVMe storage driver on the boot path of an offline OS disk. v1.0.0
+#
+# .DESCRIPTION
+#   Runs on a repair VM against the source VM's OS disk attached as a data disk. Report mode is the
+#   default and makes no configuration changes. Repair mode backs up, corrects, and verifies the
+#   stornvme service values. Rollback mode restores a backup created by Repair mode.
+#
+# .PARAMETER Mode
+#   Report (default), Repair, or Rollback.
+#
+# .PARAMETER OsDriveLetter
+#   Optional drive letter selecting one offline Windows installation, for example F or F:.
+#
+# .PARAMETER IncludeCriticalDeviceDatabase
+#   Reserved opt-in parameter. CriticalDeviceDatabase entries are not changed by this version.
+#
+# .PARAMETER BackupFile
+#   Full path to the .reg backup created by Repair mode. Required for Rollback mode.
+#
+#########################################################################################################
+
+Param(
+    [Parameter(Mandatory = $false)][ValidateSet('Report', 'Repair', 'Rollback')][string]$Mode = 'Report',
+    [Parameter(Mandatory = $false)][ValidatePattern('^[A-Za-z]:?$')][string]$OsDriveLetter = '',
+    [Parameter(Mandatory = $false)][ValidateSet('true', 'false')][string]$IncludeCriticalDeviceDatabase = 'false',
+    [Parameter(Mandatory = $false)][string]$BackupFile = ''
+)
+
+. .\src\windows\common\setup\init.ps1
+
+$status = $STATUS_ERROR
+try {
+    . .\src\windows\common\helpers\OfflineRepairCommon.ps1
+    . .\src\windows\common\helpers\Get-OfflineWindowsDisk.ps1
+    . .\src\windows\common\helpers\Use-OfflineRegistryHive.ps1
+
+    $discoveryParameters = @{}
+    if (-not [string]::IsNullOrWhiteSpace($OsDriveLetter)) {
+        $discoveryParameters.WindowsDrive = $OsDriveLetter
+    }
+    $offline = Get-OfflineWindowsDisk @discoveryParameters
+
+    if ([string]::IsNullOrWhiteSpace($OsDriveLetter) -and @($offline.Candidates).Count -gt 1) {
+        $candidateDrives = @($offline.Candidates | ForEach-Object { $_.Drive }) -join ', '
+        throw "Found $(@($offline.Candidates).Count) Windows installations ($candidateDrives). Refusing to guess; re-run with OsDriveLetter=<drive>."
+    }
+
+    $driverPath = Join-OfflinePath -Root $offline.WindowsPath -ChildPath 'System32\drivers\stornvme.sys'
+    if (-not (Test-OfflinePath $driverPath)) {
+        throw "stornvme.sys was not found at '$driverPath'. Enabling a missing boot driver could make the guest unbootable; no changes were made."
+    }
+
+    if ($IncludeCriticalDeviceDatabase -eq 'true') {
+        Log-Warning 'IncludeCriticalDeviceDatabase=true was requested, but this version never writes CriticalDeviceDatabase entries. Only stornvme service values are inspected or repaired.'
+    }
+
+    $desiredValues = [ordered]@{
+        Start        = [PSCustomObject]@{ Value = 0; Kind = 'DWord' }
+        Type         = [PSCustomObject]@{ Value = 1; Kind = 'DWord' }
+        ErrorControl = [PSCustomObject]@{ Value = 3; Kind = 'DWord' }
+        Group        = [PSCustomObject]@{ Value = 'SCSI miniport'; Kind = 'String' }
+        ImagePath    = [PSCustomObject]@{ Value = 'system32\drivers\stornvme.sys'; Kind = 'ExpandString' }
+    }
+
+    $result = Invoke-WithHive 'SYSTEM' {
+        $root = Get-OfflineSystemRootPath -Strict
+        $servicePath = "$root\Services\stornvme"
+        $nativeServicePath = $servicePath -replace '^HKLM:\\', 'HKLM\'
+        if ((Get-OfflineHiveKeyState -HiveKey $servicePath) -ne 'Present') {
+            throw "The offline stornvme service key '$servicePath' is not present. No changes were made."
+        }
+
+        $current = Get-ItemProperty -LiteralPath $servicePath -ErrorAction Stop
+        $changes = @()
+        foreach ($name in $desiredValues.Keys) {
+            $desired = $desiredValues[$name].Value
+            $actual = $current.$name
+            if ($actual -ne $desired) {
+                $changes += [PSCustomObject]@{ Name = $name; Before = $actual; After = $desired }
+            }
+        }
+
+        if ($Mode -eq 'Report') {
+            return [PSCustomObject]@{ Outcome = 'Report'; ServicePath = $servicePath; Changes = $changes; BackupFile = $null }
+        }
+
+        if ($Mode -eq 'Rollback') {
+            if ([string]::IsNullOrWhiteSpace($BackupFile) -or -not [System.IO.Path]::IsPathRooted($BackupFile) -or
+                -not (Test-Path -LiteralPath $BackupFile -PathType Leaf)) {
+                throw "Mode=Rollback requires BackupFile=<full path> to a .reg backup created by Repair mode. Not found: '$BackupFile'."
+            }
+
+            $backupText = [System.IO.File]::ReadAllText((Resolve-Path -LiteralPath $BackupFile).Path)
+            $expectedKey = ($servicePath -replace '^HKLM:\\', 'HKEY_LOCAL_MACHINE\')
+            $sections = @([regex]::Matches($backupText, '(?m)^\s*\[(-?[^\]]+)\]\s*$'))
+            if ($sections.Count -eq 0) {
+                throw "BackupFile '$BackupFile' contains no registry section."
+            }
+            foreach ($section in $sections) {
+                $sectionKey = $section.Groups[1].Value.TrimStart('-')
+                if (-not $sectionKey.Equals($expectedKey, [System.StringComparison]::OrdinalIgnoreCase) -and
+                    -not $sectionKey.StartsWith($expectedKey + '\', [System.StringComparison]::OrdinalIgnoreCase)) {
+                    throw "BackupFile '$BackupFile' contains an out-of-scope registry section '$sectionKey'."
+                }
+            }
+
+            [void](Assert-OfflineTarget -Path $servicePath -Action 'import the offline stornvme rollback backup')
+            $importOutput = & reg.exe import $BackupFile 2>&1
+            if ($LASTEXITCODE -ne 0) {
+                throw "Registry rollback import failed with exit code $LASTEXITCODE`: $(($importOutput | Out-String).Trim())"
+            }
+
+            $backedUpValueNames = @([regex]::Matches($backupText, '(?m)^\s*"([^"]+)"=') |
+                ForEach-Object { $_.Groups[1].Value })
+            foreach ($name in $desiredValues.Keys) {
+                if ($backedUpValueNames -contains $name) { continue }
+                [void](Assert-OfflineTarget -Path $servicePath -Action "remove the offline stornvme $name value during rollback")
+                Remove-ItemProperty -LiteralPath $servicePath -Name $name -Force -ErrorAction Stop
+            }
+
+            $verificationPath = Join-Path ([System.IO.Path]::GetTempPath()) "nvme-rollback-$([guid]::NewGuid()).reg"
+            try {
+                $verificationOutput = & reg.exe export $nativeServicePath $verificationPath /y 2>&1
+                if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $verificationPath -PathType Leaf)) {
+                    throw "The restored stornvme key could not be exported for verification: $(($verificationOutput | Out-String).Trim())"
+                }
+                $restoredText = [System.IO.File]::ReadAllText($verificationPath).Trim()
+                if (-not $restoredText.Equals($backupText.Trim(), [System.StringComparison]::Ordinal)) {
+                    throw "Rollback import completed, but the restored stornvme subtree does not exactly match '$BackupFile'."
+                }
+            }
+            finally {
+                Microsoft.PowerShell.Management\Remove-Item -LiteralPath $verificationPath -Force -ErrorAction SilentlyContinue
+            }
+
+            return [PSCustomObject]@{ Outcome = 'RolledBack'; ServicePath = $servicePath; Changes = @(); BackupFile = $BackupFile }
+        }
+
+        if ($changes.Count -eq 0) {
+            return [PSCustomObject]@{ Outcome = 'NoChangeNeeded'; ServicePath = $servicePath; Changes = @(); BackupFile = $null }
+        }
+
+        $evidenceRoot = Join-Path $env:PUBLIC "Desktop\nvme-repair-$(Get-Date -Format yyyyMMddHHmmss)"
+        New-Item -Path $evidenceRoot -ItemType Directory -Force -ErrorAction Stop | Out-Null
+        $backupPath = Join-Path $evidenceRoot "$($offline.WindowsDrive.TrimEnd(':'))-stornvme-before.reg"
+        $exportOutput = & reg.exe export $nativeServicePath $backupPath /y 2>&1
+        if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $backupPath -PathType Leaf) -or
+            (Get-Item -LiteralPath $backupPath).Length -eq 0) {
+            throw "Could not verify the pre-repair registry backup '$backupPath'; no service values were changed. reg export: $(($exportOutput | Out-String).Trim())"
+        }
+
+        foreach ($change in $changes) {
+            [void](Assert-OfflineTarget -Path $servicePath -Action "set the offline stornvme $($change.Name) value")
+            $desired = $desiredValues[$change.Name]
+            New-ItemProperty -LiteralPath $servicePath -Name $change.Name -Value $desired.Value -PropertyType $desired.Kind -Force -ErrorAction Stop | Out-Null
+        }
+
+        $verified = Get-ItemProperty -LiteralPath $servicePath -ErrorAction Stop
+        foreach ($name in $desiredValues.Keys) {
+            if ($verified.$name -ne $desiredValues[$name].Value) {
+                throw "Verification failed for $servicePath\$name. Expected '$($desiredValues[$name].Value)', read '$($verified.$name)'. Roll back with Mode=Rollback BackupFile='$backupPath'."
+            }
+        }
+
+        return [PSCustomObject]@{ Outcome = 'Repaired'; ServicePath = $servicePath; Changes = $changes; BackupFile = $backupPath }
+    }
+
+    foreach ($change in @($result.Changes)) {
+        Log-Output "PLAN: $($result.ServicePath)\$($change.Name) = '$($change.After)' (was '$($change.Before)')"
+    }
+    switch ($result.Outcome) {
+        'Report' {
+            if (@($result.Changes).Count -eq 0) { Log-Output 'NoChangeNeeded: all stornvme boot-driver values already match the required state.' }
+            else { Log-Output "Report only: $(@($result.Changes).Count) value(s) would change. No configuration writes were made." }
+        }
+        'NoChangeNeeded' { Log-Output 'NoChangeNeeded: all stornvme boot-driver values already match the required state. No backup or registry write was needed.' }
+        'Repaired' { Log-Output "VERIFIED: stornvme boot-driver values were repaired and read back successfully. Rollback file: $($result.BackupFile)" }
+        'RolledBack' { Log-Output "VERIFIED: rollback backup was imported successfully from $($result.BackupFile)." }
+    }
+
+    $status = $STATUS_SUCCESS
+}
+catch {
+    Log-Error $_.Exception.Message
+}
+finally {
+    if (Get-Command Clear-OfflineDriveLetter -ErrorAction SilentlyContinue) { Clear-OfflineDriveLetter }
+    if (Get-Command Write-OfflineRepairLog -ErrorAction SilentlyContinue) { Write-OfflineRepairLog }
+}
+return $status

--- a/src/windows/win-enable-nvme-boot-driver.ps1
+++ b/src/windows/win-enable-nvme-boot-driver.ps1
@@ -69,17 +69,22 @@ try {
         $root = Get-OfflineSystemRootPath -Strict
         $servicePath = "$root\Services\stornvme"
         $nativeServicePath = $servicePath -replace '^HKLM:\\', 'HKLM\'
-        if ((Get-OfflineHiveKeyState -HiveKey $servicePath) -ne 'Present') {
+        $serviceKeyState = Get-OfflineHiveKeyState -HiveKey $servicePath
+        if ($Mode -ne 'Rollback' -and $serviceKeyState -ne 'Present') {
             throw "The offline stornvme service key '$servicePath' is not present. No changes were made."
         }
 
-        $current = Get-ItemProperty -LiteralPath $servicePath -ErrorAction Stop
         $changes = @()
-        foreach ($name in $desiredValues.Keys) {
-            $desired = $desiredValues[$name].Value
-            $actual = $current.$name
-            if ($actual -ne $desired) {
-                $changes += [PSCustomObject]@{ Name = $name; Before = $actual; After = $desired }
+        if ($Mode -ne 'Rollback') {
+            $current = Get-ItemProperty -LiteralPath $servicePath -ErrorAction Stop
+            $currentKey = Get-Item -LiteralPath $servicePath -ErrorAction Stop
+            foreach ($name in $desiredValues.Keys) {
+                $desired = $desiredValues[$name]
+                $actual = $current.$name
+                $actualKind = if ($current.PSObject.Properties.Name -contains $name) { $currentKey.GetValueKind($name).ToString() } else { $null }
+                if ($actual -ne $desired.Value -or $actualKind -ne $desired.Kind) {
+                    $changes += [PSCustomObject]@{ Name = $name; Before = $actual; BeforeKind = $actualKind; After = $desired.Value; AfterKind = $desired.Kind }
+                }
             }
         }
 
@@ -100,7 +105,10 @@ try {
                 throw "BackupFile '$BackupFile' contains no registry section."
             }
             foreach ($section in $sections) {
-                $sectionKey = $section.Groups[1].Value.TrimStart('-')
+                $sectionKey = $section.Groups[1].Value
+                if ($sectionKey.StartsWith('-', [System.StringComparison]::Ordinal)) {
+                    throw "BackupFile '$BackupFile' contains a deletion section '$sectionKey'."
+                }
                 if (-not $sectionKey.Equals($expectedKey, [System.StringComparison]::OrdinalIgnoreCase) -and
                     -not $sectionKey.StartsWith($expectedKey + '\', [System.StringComparison]::OrdinalIgnoreCase)) {
                     throw "BackupFile '$BackupFile' contains an out-of-scope registry section '$sectionKey'."
@@ -113,10 +121,16 @@ try {
                 throw "Registry rollback import failed with exit code $LASTEXITCODE`: $(($importOutput | Out-String).Trim())"
             }
 
-            $backedUpValueNames = @([regex]::Matches($backupText, '(?m)^\s*"([^"]+)"=') |
+            $escapedExpectedKey = [regex]::Escape($expectedKey)
+            $rootSection = [regex]::Match($backupText, "(?ms)^\s*\[$escapedExpectedKey\]\s*\r?\n(?<Body>.*?)(?=^\s*\[|\z)")
+            if (-not $rootSection.Success) {
+                throw "BackupFile '$BackupFile' contains no exact '$expectedKey' section."
+            }
+            $backedUpValueNames = @([regex]::Matches($rootSection.Groups['Body'].Value, '(?m)^\s*"([^"]+)"=') |
                 ForEach-Object { $_.Groups[1].Value })
+            $restored = Get-ItemProperty -LiteralPath $servicePath -ErrorAction Stop
             foreach ($name in $desiredValues.Keys) {
-                if ($backedUpValueNames -contains $name) { continue }
+                if ($backedUpValueNames -contains $name -or -not ($restored.PSObject.Properties.Name -contains $name)) { continue }
                 [void](Assert-OfflineTarget -Path $servicePath -Action "remove the offline stornvme $name value during rollback")
                 Remove-ItemProperty -LiteralPath $servicePath -Name $name -Force -ErrorAction Stop
             }
@@ -143,8 +157,8 @@ try {
             return [PSCustomObject]@{ Outcome = 'NoChangeNeeded'; ServicePath = $servicePath; Changes = @(); BackupFile = $null }
         }
 
-        $evidenceRoot = Join-Path $env:PUBLIC "Desktop\nvme-repair-$(Get-Date -Format yyyyMMddHHmmss)"
-        New-Item -Path $evidenceRoot -ItemType Directory -Force -ErrorAction Stop | Out-Null
+        $evidenceRoot = Join-Path $env:PUBLIC "Desktop\nvme-repair-$(Get-Date -Format yyyyMMddHHmmss)-$([guid]::NewGuid().ToString('N'))"
+        New-Item -Path $evidenceRoot -ItemType Directory -ErrorAction Stop | Out-Null
         $backupPath = Join-Path $evidenceRoot "$($offline.WindowsDrive.TrimEnd(':'))-stornvme-before.reg"
         $exportOutput = & reg.exe export $nativeServicePath $backupPath /y 2>&1
         if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $backupPath -PathType Leaf) -or
@@ -159,9 +173,11 @@ try {
         }
 
         $verified = Get-ItemProperty -LiteralPath $servicePath -ErrorAction Stop
+        $verifiedKey = Get-Item -LiteralPath $servicePath -ErrorAction Stop
         foreach ($name in $desiredValues.Keys) {
-            if ($verified.$name -ne $desiredValues[$name].Value) {
-                throw "Verification failed for $servicePath\$name. Expected '$($desiredValues[$name].Value)', read '$($verified.$name)'. Roll back with Mode=Rollback BackupFile='$backupPath'."
+            $verifiedKind = if ($verified.PSObject.Properties.Name -contains $name) { $verifiedKey.GetValueKind($name).ToString() } else { $null }
+            if ($verified.$name -ne $desiredValues[$name].Value -or $verifiedKind -ne $desiredValues[$name].Kind) {
+                throw "Verification failed for $servicePath\$name. Expected '$($desiredValues[$name].Value)' ($($desiredValues[$name].Kind)), read '$($verified.$name)' ($verifiedKind). Roll back with Mode=Rollback BackupFile='$backupPath'."
             }
         }
 

--- a/src/windows/win-enable-nvme-boot-driver.ps1
+++ b/src/windows/win-enable-nvme-boot-driver.ps1
@@ -104,6 +104,10 @@ try {
             if ($sections.Count -eq 0) {
                 throw "BackupFile '$BackupFile' contains no registry section."
             }
+
+            # Record what each section declares so the offline subtree can be checked against the
+            # backup before anything is written.
+            $backupValueNames = @{}
             foreach ($section in $sections) {
                 $sectionKey = $section.Groups[1].Value
                 if ($sectionKey.StartsWith('-', [System.StringComparison]::Ordinal)) {
@@ -113,6 +117,42 @@ try {
                     -not $sectionKey.StartsWith($expectedKey + '\', [System.StringComparison]::OrdinalIgnoreCase)) {
                     throw "BackupFile '$BackupFile' contains an out-of-scope registry section '$sectionKey'."
                 }
+                $sectionBody = [regex]::Match(
+                    $backupText,
+                    "(?ms)^\s*\[$([regex]::Escape($sectionKey))\]\s*\r?\n(?<Body>.*?)(?=^\s*\[|\z)")
+                $declared = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
+                if ($sectionBody.Success) {
+                    foreach ($value in [regex]::Matches($sectionBody.Groups['Body'].Value, '(?m)^\s*(?:"(?<Name>[^"]+)"|(?<Default>@))=')) {
+                        [void]$declared.Add($(if ($value.Groups['Default'].Success) { '(default)' } else { $value.Groups['Name'].Value }))
+                    }
+                }
+                $backupValueNames[$sectionKey] = $declared
+            }
+
+            if (-not $backupValueNames.ContainsKey($expectedKey)) {
+                throw "BackupFile '$BackupFile' contains no exact '$expectedKey' section."
+            }
+            $backedUpValueNames = $backupValueNames[$expectedKey]
+
+            # reg.exe import only adds and overwrites, so anything present offline but absent from the
+            # backup would survive the rollback. Refuse before writing rather than fail verification
+            # once the hive has already been changed.
+            if ($serviceKeyState -eq 'Present') {
+                $liveKeys = @(Get-Item -LiteralPath $servicePath -ErrorAction Stop) +
+                            @(Get-ChildItem -LiteralPath $servicePath -Recurse -ErrorAction Stop)
+                foreach ($liveKey in $liveKeys) {
+                    if (-not $backupValueNames.ContainsKey($liveKey.Name)) {
+                        throw "The offline subtree contains the key '$($liveKey.Name)', which '$BackupFile' does not restore. Rollback would leave it behind; no changes were made."
+                    }
+                    $isRootKey = $liveKey.Name.Equals($expectedKey, [System.StringComparison]::OrdinalIgnoreCase)
+                    foreach ($liveValueName in @($liveKey.GetValueNames())) {
+                        $reportedName = if ([string]::IsNullOrEmpty($liveValueName)) { '(default)' } else { $liveValueName }
+                        if ($backupValueNames[$liveKey.Name].Contains($reportedName)) { continue }
+                        # Values this script writes are removed after the import when the backup omits them.
+                        if ($isRootKey -and $desiredValues.Contains($reportedName)) { continue }
+                        throw "The offline key '$($liveKey.Name)' has a '$reportedName' value that '$BackupFile' does not restore. Rollback would leave it behind; no changes were made."
+                    }
+                }
             }
 
             [void](Assert-OfflineTarget -Path $servicePath -Action 'import the offline stornvme rollback backup')
@@ -121,16 +161,9 @@ try {
                 throw "Registry rollback import failed with exit code $LASTEXITCODE`: $(($importOutput | Out-String).Trim())"
             }
 
-            $escapedExpectedKey = [regex]::Escape($expectedKey)
-            $rootSection = [regex]::Match($backupText, "(?ms)^\s*\[$escapedExpectedKey\]\s*\r?\n(?<Body>.*?)(?=^\s*\[|\z)")
-            if (-not $rootSection.Success) {
-                throw "BackupFile '$BackupFile' contains no exact '$expectedKey' section."
-            }
-            $backedUpValueNames = @([regex]::Matches($rootSection.Groups['Body'].Value, '(?m)^\s*"([^"]+)"=') |
-                ForEach-Object { $_.Groups[1].Value })
             $restored = Get-ItemProperty -LiteralPath $servicePath -ErrorAction Stop
             foreach ($name in $desiredValues.Keys) {
-                if ($backedUpValueNames -contains $name -or -not ($restored.PSObject.Properties.Name -contains $name)) { continue }
+                if ($backedUpValueNames.Contains($name) -or -not ($restored.PSObject.Properties.Name -contains $name)) { continue }
                 [void](Assert-OfflineTarget -Path $servicePath -Action "remove the offline stornvme $name value during rollback")
                 Remove-ItemProperty -LiteralPath $servicePath -Name $name -Force -ErrorAction Stop
             }

--- a/tests/test-win-enable-nvme-boot-driver.ps1
+++ b/tests/test-win-enable-nvme-boot-driver.ps1
@@ -26,25 +26,43 @@ function Copy-FixtureState {
     return $copy
 }
 
+function Get-HealthyKinds {
+    return [ordered]@{
+        Start = 'DWord'
+        Type = 'DWord'
+        ErrorControl = 'DWord'
+        Group = 'String'
+        ImagePath = 'ExpandString'
+        Sentinel = 'String'
+    }
+}
+
 function Set-NvmeFixture {
     Param(
         [hashtable]$State,
+        [hashtable]$Kinds = (Get-HealthyKinds),
         [bool]$DriverPresent = $true,
         [int]$CandidateCount = 1,
-        [bool]$HiveReadable = $true
+        [bool]$HiveReadable = $true,
+        [bool]$KeyPresent = $true,
+        [bool]$WriteWrongKind = $false
     )
 
     $global:NvmeFixture = @{
         State = Copy-FixtureState $State
+        Kinds = Copy-FixtureState $Kinds
         DriverPresent = $DriverPresent
         CandidateCount = $CandidateCount
         HiveReadable = $HiveReadable
         HiveActive = $false
         StrictCalls = 0
         ImportFails = $false
+        KeyPresent = $KeyPresent
+        WriteWrongKind = $WriteWrongKind
         Operations = [System.Collections.Generic.List[string]]::new()
         Backups = @{}
         LastBackup = $null
+        ImportedSuffix = ''
     }
     $global:LASTEXITCODE = 0
 }
@@ -106,7 +124,12 @@ function Assert-OfflineTarget {
     return $Path
 }
 function Write-OfflineRepairLog { }
-function Get-OfflineHiveKeyState { Param([string]$HiveKey) return 'Present' }
+function Get-OfflineHiveKeyState {
+    Param([string]$HiveKey)
+    Assert-FixtureServicePath $HiveKey
+    if ($global:NvmeFixture.KeyPresent) { return 'Present' }
+    return 'Missing'
+}
 '@ | Set-Content -LiteralPath (Join-Path $helperRoot 'OfflineRepairCommon.ps1') -Encoding Utf8
 
     @'
@@ -141,9 +164,27 @@ function Get-OfflineSystemRootPath {
     $global:NvmeFixture.StrictCalls++
     return 'HKLM:\BROKENSYSTEM\ControlSet001'
 }
+function Get-Item {
+    Param([string]$LiteralPath, $ErrorAction)
+    if (-not $LiteralPath.StartsWith('HKLM:\', [System.StringComparison]::OrdinalIgnoreCase)) {
+        if ($null -ne $ErrorAction) {
+            return Microsoft.PowerShell.Management\Get-Item -LiteralPath $LiteralPath -ErrorAction $ErrorAction
+        }
+        return Microsoft.PowerShell.Management\Get-Item -LiteralPath $LiteralPath
+    }
+    Assert-FixtureServicePath $LiteralPath
+    if (-not $global:NvmeFixture.KeyPresent) { throw "Fixture service key '$LiteralPath' is missing." }
+    $key = [PSCustomObject]@{}
+    $key | Add-Member -MemberType ScriptMethod -Name GetValueKind -Value {
+        Param([string]$Name)
+        return [System.Enum]::Parse([Microsoft.Win32.RegistryValueKind], $global:NvmeFixture.Kinds[$Name])
+    }
+    return $key
+}
 function Get-ItemProperty {
     Param([string]$LiteralPath, $ErrorAction)
     Assert-FixtureServicePath $LiteralPath
+    if (-not $global:NvmeFixture.KeyPresent) { throw "Fixture service key '$LiteralPath' is missing." }
     return [PSCustomObject](Copy-FixtureState $global:NvmeFixture.State)
 }
 function New-ItemProperty {
@@ -154,7 +195,9 @@ function New-ItemProperty {
         throw "Fixture observed an unguarded registry write to $Name."
     }
     [void]$operations.Add("Write:$Name")
+    $global:NvmeFixture.KeyPresent = $true
     $global:NvmeFixture.State[$Name] = $Value
+    $global:NvmeFixture.Kinds[$Name] = if ($global:NvmeFixture.WriteWrongKind) { 'String' } else { $PropertyType }
 }
 function Remove-ItemProperty {
     Param([string]$LiteralPath, [string]$Name, [switch]$Force, $ErrorAction)
@@ -165,6 +208,7 @@ function Remove-ItemProperty {
     }
     [void]$operations.Add("Remove:$Name")
     [void]$global:NvmeFixture.State.Remove($Name)
+    [void]$global:NvmeFixture.Kinds.Remove($Name)
 }
 function global:reg.exe {
     $verb = "$($args[0])".ToLowerInvariant()
@@ -174,16 +218,26 @@ function global:reg.exe {
         if (-not "$($args[1])".Equals($expected, [System.StringComparison]::OrdinalIgnoreCase)) {
             throw "Fixture observed registry export outside the strict stornvme target: '$($args[1])'."
         }
-        $global:NvmeFixture.Backups[$path] = Copy-FixtureState $global:NvmeFixture.State
+        $global:NvmeFixture.Backups[$path] = @{
+            State = Copy-FixtureState $global:NvmeFixture.State
+            Kinds = Copy-FixtureState $global:NvmeFixture.Kinds
+            Suffix = $global:NvmeFixture.ImportedSuffix
+        }
         $global:NvmeFixture.LastBackup = $path
         $key = "$($args[1])" -replace '^HKLM\\', 'HKEY_LOCAL_MACHINE\'
         $valueLines = @($global:NvmeFixture.State.Keys | Sort-Object | ForEach-Object {
                 $name = $_
                 $value = $global:NvmeFixture.State[$name]
-                if ($value -is [int]) { '"{0}"=dword:{1:x8}' -f $name, $value }
+                $kind = $global:NvmeFixture.Kinds[$name]
+                if ($kind -eq 'DWord') { '"{0}"=dword:{1:x8}' -f $name, $value }
+                elseif ($kind -eq 'ExpandString') {
+                    $bytes = [System.Text.Encoding]::Unicode.GetBytes("$value`0")
+                    '"{0}"=hex(2):{1}' -f $name, (($bytes | ForEach-Object { $_.ToString('x2') }) -join ',')
+                }
                 else { '"{0}"="{1}"' -f $name, "$value".Replace('\', '\\').Replace('"', '\"') }
             })
-        "Windows Registry Editor Version 5.00`r`n`r`n[$key]`r`n$($valueLines -join "`r`n")`r`n" | Set-Content -LiteralPath $path -Encoding Unicode
+        "Windows Registry Editor Version 5.00`r`n`r`n[$key]`r`n$($valueLines -join "`r`n")`r`n$($global:NvmeFixture.ImportedSuffix)" |
+            Set-Content -LiteralPath $path -Encoding Unicode
         $global:LASTEXITCODE = 0
         return
     }
@@ -198,7 +252,14 @@ function global:reg.exe {
             $global:LASTEXITCODE = 5
             return 'fixture import failure'
         }
-        $global:NvmeFixture.State = Copy-FixtureState $global:NvmeFixture.Backups[$path]
+        $backup = $global:NvmeFixture.Backups[$path]
+        if ($null -eq $backup) { throw "Fixture has no parsed state for '$path'." }
+        $global:NvmeFixture.KeyPresent = $true
+        $global:NvmeFixture.ImportedSuffix = $backup.Suffix
+        foreach ($name in $backup.State.Keys) {
+            $global:NvmeFixture.State[$name] = $backup.State[$name]
+            $global:NvmeFixture.Kinds[$name] = $backup.Kinds[$name]
+        }
         $global:LASTEXITCODE = 0
         return
     }
@@ -227,7 +288,7 @@ function global:reg.exe {
 
     Set-NvmeFixture -State $broken
     $repair = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
-    Assert-Equal 0 $repair.Status 'Repair mode should succeed.'
+    Assert-Equal 0 $repair.Status "Repair mode should succeed. Output: $($repair.Output)"
     Assert-True ($repair.Output -match 'VERIFIED') 'Repair mode should report verification.'
     foreach ($name in @('Start', 'Type', 'ErrorControl', 'Group', 'ImagePath')) {
         Assert-True ($global:NvmeFixture.Operations -contains "Write:$name") "Repair mode should write $name."
@@ -236,6 +297,7 @@ function global:reg.exe {
     Assert-True (-not $global:NvmeFixture.State.Contains('CriticalDeviceDatabase')) 'Repair must not write CriticalDeviceDatabase.'
     $backupPath = $global:NvmeFixture.LastBackup
     Assert-True (Test-Path -LiteralPath $backupPath -PathType Leaf) 'Repair should create a verified rollback backup.'
+    Assert-True ((Get-Content -LiteralPath $backupPath -Raw) -match '(?m)^"ImagePath"=hex\(2\):') 'The fixture backup must preserve ImagePath as REG_EXPAND_SZ.'
 
     $global:NvmeFixture.Operations.Clear()
     $secondRepair = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
@@ -265,6 +327,43 @@ function global:reg.exe {
     Assert-True ($global:NvmeFixture.Operations -contains 'Remove:ImagePath') 'Rollback should explicitly remove the value that Repair introduced.'
     Assert-Equal 'unchanged' $global:NvmeFixture.State.Sentinel 'Absent-value rollback must preserve unrelated values.'
 
+    $global:NvmeFixture.Operations.Clear()
+    $secondRollbackMissingValue = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $missingValueBackup }
+    Assert-Equal 0 $secondRollbackMissingValue.Status 'Repeating an absent-value rollback should succeed.'
+    Assert-True (-not ($global:NvmeFixture.Operations -contains 'Remove:ImagePath')) 'Repeated rollback must not remove an already absent value.'
+
+    $global:NvmeFixture.State = [ordered]@{}
+    $global:NvmeFixture.Kinds = [ordered]@{}
+    $global:NvmeFixture.KeyPresent = $false
+    $global:NvmeFixture.Operations.Clear()
+    $rollbackMissingKey = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $missingValueBackup }
+    Assert-Equal 0 $rollbackMissingKey.Status "Rollback should recreate a missing stornvme key. Output: $($rollbackMissingKey.Output)"
+    Assert-True $global:NvmeFixture.KeyPresent 'Rollback should recreate the missing service key.'
+    Assert-Equal 4 $global:NvmeFixture.State.Start 'A recreated service key should contain the backed-up values.'
+
+    $childSuffix = "[HKEY_LOCAL_MACHINE\BROKENSYSTEM\ControlSet001\Services\stornvme\Parameters]`r`n`"ImagePath`"=`"child-only`"`r`n"
+    $global:NvmeFixture.Backups[$missingValueBackup].Suffix = $childSuffix
+    [System.IO.File]::WriteAllText(
+        $missingValueBackup,
+        [System.IO.File]::ReadAllText($missingValueBackup).TrimEnd() + "`r`n" + $childSuffix,
+        [System.Text.Encoding]::Unicode)
+    $global:NvmeFixture.State.ImagePath = 'current-root-value'
+    $global:NvmeFixture.Kinds.ImagePath = 'String'
+    $global:NvmeFixture.Operations.Clear()
+    $rollbackWithChildValue = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $missingValueBackup }
+    Assert-Equal 0 $rollbackWithChildValue.Status "Rollback should isolate root values from child sections. Output: $($rollbackWithChildValue.Output)"
+    Assert-True ($global:NvmeFixture.Operations -contains 'Remove:ImagePath') 'A child-section ImagePath must not count as a root service value.'
+    Assert-True (-not $global:NvmeFixture.State.Contains('ImagePath')) 'Rollback should remove a root value absent from the root backup section.'
+
+    $deletionBackup = Join-Path $fixtureRoot 'deletion.reg'
+    "Windows Registry Editor Version 5.00`r`n`r`n[-HKEY_LOCAL_MACHINE\BROKENSYSTEM\ControlSet001\Services\stornvme]`r`n" |
+        Set-Content -LiteralPath $deletionBackup -Encoding Unicode
+    Set-NvmeFixture -State $healthy
+    $deletion = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $deletionBackup }
+    Assert-Equal 1 $deletion.Status 'Rollback should reject a registry deletion section.'
+    Assert-True ($deletion.Output -match 'contains a deletion section') 'Deletion-section refusal should identify the unsafe section.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'A deletion-section backup must be rejected before import.'
+
     $outOfScopeBackup = Join-Path $fixtureRoot 'out-of-scope.reg'
     "Windows Registry Editor Version 5.00`r`n`r`n[HKEY_LOCAL_MACHINE\BROKENSYSTEM\ControlSet001\Services\stornvme]`r`n`r`n[HKEY_CURRENT_USER\Software\Unexpected]`r`n" |
         Set-Content -LiteralPath $outOfScopeBackup -Encoding Unicode
@@ -283,6 +382,29 @@ function global:reg.exe {
     Assert-True (-not $global:NvmeFixture.HiveActive) 'A failed registry import must unload the hive.'
     Assert-Equal $beforeFailedImport.Start $global:NvmeFixture.State.Start 'A failed import must leave current service values intact.'
     Assert-True (-not ($global:NvmeFixture.Operations -match '^Remove:')) 'A failed import must not remove any current service value.'
+
+    $wrongKinds = Get-HealthyKinds
+    $wrongKinds.ImagePath = 'String'
+    Set-NvmeFixture -State $healthy -Kinds $wrongKinds
+    $repairWrongKind = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
+    Assert-Equal 0 $repairWrongKind.Status "Repair should correct a kind-only mismatch. Output: $($repairWrongKind.Output)"
+    Assert-True ($global:NvmeFixture.Operations -contains 'Write:ImagePath') 'Repair should rewrite ImagePath when only its registry kind is wrong.'
+    Assert-Equal 'ExpandString' $global:NvmeFixture.Kinds.ImagePath 'Repair should restore ImagePath to REG_EXPAND_SZ.'
+
+    Set-NvmeFixture -State $broken -WriteWrongKind $true
+    $repairWrongWriteKind = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
+    Assert-Equal 1 $repairWrongWriteKind.Status 'Repair should fail if a write rereads with the wrong registry kind.'
+    Assert-True ($repairWrongWriteKind.Output -match 'Verification failed') 'Wrong-kind verification failure should be explicit.'
+
+    Set-NvmeFixture -State $broken
+    $firstCollisionRepair = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
+    Assert-Equal 0 $firstCollisionRepair.Status 'The first collision fixture repair should succeed.'
+    $firstCollisionBackup = $global:NvmeFixture.LastBackup
+    $global:NvmeFixture.State.Start = 4
+    $global:NvmeFixture.Operations.Clear()
+    $secondCollisionRepair = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
+    Assert-Equal 0 $secondCollisionRepair.Status 'The immediate second collision fixture repair should succeed.'
+    Assert-True ($firstCollisionBackup -ne $global:NvmeFixture.LastBackup) 'Immediate repairs must create distinct backup paths.'
 
     Set-NvmeFixture -State $broken -DriverPresent $false
     $missingDriver = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }

--- a/tests/test-win-enable-nvme-boot-driver.ps1
+++ b/tests/test-win-enable-nvme-boot-driver.ps1
@@ -1,0 +1,324 @@
+# Standalone fixture tests for win-enable-nvme-boot-driver.ps1.
+# Run from the repository root:
+#   pwsh -NoProfile -File ./tests/test-win-enable-nvme-boot-driver.ps1
+
+$ErrorActionPreference = 'Stop'
+$repositoryRoot = Split-Path $PSScriptRoot -Parent
+$sourceScript = Join-Path $repositoryRoot 'src/windows/win-enable-nvme-boot-driver.ps1'
+$fixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) "rsl-nvme-recovery-$([guid]::NewGuid())"
+$fixtureScript = Join-Path $fixtureRoot 'src/windows/win-enable-nvme-boot-driver.ps1'
+$originalPublic = $env:PUBLIC
+
+function Assert-True {
+    Param([bool]$Condition, [string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-Equal {
+    Param($Expected, $Actual, [string]$Message)
+    if ($Expected -ne $Actual) { throw "$Message Expected '$Expected', found '$Actual'." }
+}
+
+function Copy-FixtureState {
+    Param([hashtable]$State)
+    $copy = [ordered]@{}
+    foreach ($key in $State.Keys) { $copy[$key] = $State[$key] }
+    return $copy
+}
+
+function Set-NvmeFixture {
+    Param(
+        [hashtable]$State,
+        [bool]$DriverPresent = $true,
+        [int]$CandidateCount = 1,
+        [bool]$HiveReadable = $true
+    )
+
+    $global:NvmeFixture = @{
+        State = Copy-FixtureState $State
+        DriverPresent = $DriverPresent
+        CandidateCount = $CandidateCount
+        HiveReadable = $HiveReadable
+        HiveActive = $false
+        StrictCalls = 0
+        ImportFails = $false
+        Operations = [System.Collections.Generic.List[string]]::new()
+        Backups = @{}
+        LastBackup = $null
+    }
+    $global:LASTEXITCODE = 0
+}
+
+function Invoke-NvmeFixture {
+    Param([hashtable]$Parameters = @{})
+    Push-Location $fixtureRoot
+    try {
+        $output = @(& $fixtureScript @Parameters)
+        return [PSCustomObject]@{ Status = $output[-1]; Output = ($output -join "`n") }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Get-HealthyState {
+    return [ordered]@{
+        Start = 0
+        Type = 1
+        ErrorControl = 3
+        Group = 'SCSI miniport'
+        ImagePath = 'system32\drivers\stornvme.sys'
+        Sentinel = 'unchanged'
+    }
+}
+
+function Assert-FixtureServicePath {
+    Param([string]$Path)
+    $expected = 'HKLM:\BROKENSYSTEM\ControlSet001\Services\stornvme'
+    if (-not $Path.Equals($expected, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Fixture observed registry access outside the strict stornvme target: '$Path'."
+    }
+}
+
+try {
+    $helperRoot = Join-Path $fixtureRoot 'src/windows/common/helpers'
+    $setupRoot = Join-Path $fixtureRoot 'src/windows/common/setup'
+    New-Item -Path (Split-Path $fixtureScript -Parent), $helperRoot, $setupRoot -ItemType Directory -Force | Out-Null
+    Copy-Item -LiteralPath $sourceScript -Destination $fixtureScript
+    $env:PUBLIC = $fixtureRoot
+
+    @'
+$STATUS_SUCCESS = 0
+$STATUS_ERROR = 1
+function Log-Output { Param([string]$Message) Write-Output $Message }
+function Log-Info { Param([string]$Message) Write-Output $Message }
+function Log-Warning { Param([string]$Message) Write-Output "WARNING: $Message" }
+function Log-Error { Param([string]$Message) Write-Output "ERROR: $Message" }
+'@ | Set-Content -LiteralPath (Join-Path $setupRoot 'init.ps1') -Encoding Utf8
+
+    @'
+function Join-OfflinePath { Param([string]$Root, [string]$ChildPath) return "$($Root.TrimEnd('\'))\$($ChildPath.TrimStart('\'))" }
+function Test-OfflinePath { Param([string]$Path) return [bool]$global:NvmeFixture.DriverPresent }
+function Assert-OfflineTarget {
+    Param([string]$Path, [string]$Action)
+    Assert-FixtureServicePath $Path
+    [void]$global:NvmeFixture.Operations.Add("Assert:$Action")
+    return $Path
+}
+function Write-OfflineRepairLog { }
+function Get-OfflineHiveKeyState { Param([string]$HiveKey) return 'Present' }
+'@ | Set-Content -LiteralPath (Join-Path $helperRoot 'OfflineRepairCommon.ps1') -Encoding Utf8
+
+    @'
+function Get-OfflineWindowsDisk {
+    Param([string]$WindowsDrive)
+    $count = $global:NvmeFixture.CandidateCount
+    $candidates = @(for ($index = 0; $index -lt $count; $index++) { [PSCustomObject]@{ Drive = "$(if ($index -eq 0) { 'F' } else { 'G' }):" } })
+    return [PSCustomObject]@{
+        WindowsDrive = if ($WindowsDrive) { $WindowsDrive.TrimEnd(':') + ':' } else { 'F:' }
+        WindowsPath = if ($WindowsDrive) { $WindowsDrive.TrimEnd(':') + ':\Windows' } else { 'F:\Windows' }
+        Candidates = $candidates
+    }
+}
+function Clear-OfflineDriveLetter { }
+'@ | Set-Content -LiteralPath (Join-Path $helperRoot 'Get-OfflineWindowsDisk.ps1') -Encoding Utf8
+
+    @'
+function Invoke-WithHive {
+    Param([string[]]$Hive, [scriptblock]$ScriptBlock)
+    $global:NvmeFixture.HiveActive = $true
+    try {
+        if (-not $global:NvmeFixture.HiveReadable) { throw 'Fixture SYSTEM hive is unreadable.' }
+        return & $ScriptBlock
+    }
+    finally {
+        $global:NvmeFixture.HiveActive = $false
+    }
+}
+function Get-OfflineSystemRootPath {
+    Param([switch]$Strict)
+    if (-not $Strict) { throw 'Fixture refused a non-strict control-set lookup.' }
+    $global:NvmeFixture.StrictCalls++
+    return 'HKLM:\BROKENSYSTEM\ControlSet001'
+}
+function Get-ItemProperty {
+    Param([string]$LiteralPath, $ErrorAction)
+    Assert-FixtureServicePath $LiteralPath
+    return [PSCustomObject](Copy-FixtureState $global:NvmeFixture.State)
+}
+function New-ItemProperty {
+    Param([string]$LiteralPath, [string]$Name, $Value, [string]$PropertyType, [switch]$Force, $ErrorAction)
+    Assert-FixtureServicePath $LiteralPath
+    $operations = $global:NvmeFixture.Operations
+    if ($operations.Count -eq 0 -or -not $operations[$operations.Count - 1].StartsWith('Assert:')) {
+        throw "Fixture observed an unguarded registry write to $Name."
+    }
+    [void]$operations.Add("Write:$Name")
+    $global:NvmeFixture.State[$Name] = $Value
+}
+function Remove-ItemProperty {
+    Param([string]$LiteralPath, [string]$Name, [switch]$Force, $ErrorAction)
+    Assert-FixtureServicePath $LiteralPath
+    $operations = $global:NvmeFixture.Operations
+    if ($operations.Count -eq 0 -or -not $operations[$operations.Count - 1].StartsWith('Assert:')) {
+        throw "Fixture observed an unguarded registry-value removal from $Name."
+    }
+    [void]$operations.Add("Remove:$Name")
+    [void]$global:NvmeFixture.State.Remove($Name)
+}
+function global:reg.exe {
+    $verb = "$($args[0])".ToLowerInvariant()
+    if ($verb -eq 'export') {
+        $path = "$($args[2])"
+        $expected = 'HKLM\BROKENSYSTEM\ControlSet001\Services\stornvme'
+        if (-not "$($args[1])".Equals($expected, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Fixture observed registry export outside the strict stornvme target: '$($args[1])'."
+        }
+        $global:NvmeFixture.Backups[$path] = Copy-FixtureState $global:NvmeFixture.State
+        $global:NvmeFixture.LastBackup = $path
+        $key = "$($args[1])" -replace '^HKLM\\', 'HKEY_LOCAL_MACHINE\'
+        $valueLines = @($global:NvmeFixture.State.Keys | Sort-Object | ForEach-Object {
+                $name = $_
+                $value = $global:NvmeFixture.State[$name]
+                if ($value -is [int]) { '"{0}"=dword:{1:x8}' -f $name, $value }
+                else { '"{0}"="{1}"' -f $name, "$value".Replace('\', '\\').Replace('"', '\"') }
+            })
+        "Windows Registry Editor Version 5.00`r`n`r`n[$key]`r`n$($valueLines -join "`r`n")`r`n" | Set-Content -LiteralPath $path -Encoding Unicode
+        $global:LASTEXITCODE = 0
+        return
+    }
+    if ($verb -eq 'import') {
+        $path = "$($args[1])"
+        $operations = $global:NvmeFixture.Operations
+        if ($operations.Count -eq 0 -or -not $operations[$operations.Count - 1].StartsWith('Assert:')) {
+            throw 'Fixture observed an unguarded registry import.'
+        }
+        [void]$operations.Add('Import:stornvme')
+        if ($global:NvmeFixture.ImportFails) {
+            $global:LASTEXITCODE = 5
+            return 'fixture import failure'
+        }
+        $global:NvmeFixture.State = Copy-FixtureState $global:NvmeFixture.Backups[$path]
+        $global:LASTEXITCODE = 0
+        return
+    }
+    $global:LASTEXITCODE = 1
+}
+'@ | Set-Content -LiteralPath (Join-Path $helperRoot 'Use-OfflineRegistryHive.ps1') -Encoding Utf8
+
+    $healthy = Get-HealthyState
+    Set-NvmeFixture -State $healthy
+    $reportHealthy = Invoke-NvmeFixture
+    Assert-Equal 0 $reportHealthy.Status 'Healthy Report mode should succeed.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'Healthy Report mode must not write.'
+    Assert-True ($reportHealthy.Output -match 'NoChangeNeeded') 'Healthy Report mode should report NoChangeNeeded.'
+
+    $broken = Get-HealthyState
+    $broken.Start = 4
+    $broken.Type = 2
+    $broken.ErrorControl = 1
+    $broken.Group = 'wrong group'
+    $broken.ImagePath = 'wrong.sys'
+    Set-NvmeFixture -State $broken
+    $reportBroken = Invoke-NvmeFixture
+    Assert-Equal 0 $reportBroken.Status 'Broken Report mode should succeed.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'Broken Report mode must not write.'
+    Assert-True ($reportBroken.Output -match '5 value\(s\) would change') 'Broken Report mode should list five planned changes.'
+
+    Set-NvmeFixture -State $broken
+    $repair = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
+    Assert-Equal 0 $repair.Status 'Repair mode should succeed.'
+    Assert-True ($repair.Output -match 'VERIFIED') 'Repair mode should report verification.'
+    foreach ($name in @('Start', 'Type', 'ErrorControl', 'Group', 'ImagePath')) {
+        Assert-True ($global:NvmeFixture.Operations -contains "Write:$name") "Repair mode should write $name."
+    }
+    Assert-Equal 'unchanged' $global:NvmeFixture.State.Sentinel 'Repair must not change unrelated values.'
+    Assert-True (-not $global:NvmeFixture.State.Contains('CriticalDeviceDatabase')) 'Repair must not write CriticalDeviceDatabase.'
+    $backupPath = $global:NvmeFixture.LastBackup
+    Assert-True (Test-Path -LiteralPath $backupPath -PathType Leaf) 'Repair should create a verified rollback backup.'
+
+    $global:NvmeFixture.Operations.Clear()
+    $secondRepair = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
+    Assert-Equal 0 $secondRepair.Status 'A second Repair run should succeed.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'A second Repair run must make no writes.'
+    Assert-True ($secondRepair.Output -match 'NoChangeNeeded') 'A second Repair run should report NoChangeNeeded.'
+
+    $global:NvmeFixture.Operations.Clear()
+    $rollback = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $backupPath }
+    Assert-Equal 0 $rollback.Status "Rollback mode should succeed. Output: $($rollback.Output)"
+    Assert-True ($rollback.Output -match 'rollback backup was imported') 'Rollback should report a verified import.'
+    Assert-Equal 4 $global:NvmeFixture.State.Start 'Rollback should restore the original Start value.'
+    Assert-Equal 'wrong.sys' $global:NvmeFixture.State.ImagePath 'Rollback should restore the original ImagePath.'
+    Assert-Equal 'unchanged' $global:NvmeFixture.State.Sentinel 'Rollback should restore unrelated values exactly.'
+
+    $missingValue = Get-HealthyState
+    [void]$missingValue.Remove('ImagePath')
+    $missingValue.Start = 4
+    Set-NvmeFixture -State $missingValue
+    $repairMissingValue = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
+    Assert-Equal 0 $repairMissingValue.Status 'Repair should create a missing managed value.'
+    $missingValueBackup = $global:NvmeFixture.LastBackup
+    $global:NvmeFixture.Operations.Clear()
+    $rollbackMissingValue = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $missingValueBackup }
+    Assert-Equal 0 $rollbackMissingValue.Status 'Rollback should restore a fixture with an originally absent value.'
+    Assert-True (-not $global:NvmeFixture.State.Contains('ImagePath')) 'Rollback should remove a managed value that was absent originally.'
+    Assert-True ($global:NvmeFixture.Operations -contains 'Remove:ImagePath') 'Rollback should explicitly remove the value that Repair introduced.'
+    Assert-Equal 'unchanged' $global:NvmeFixture.State.Sentinel 'Absent-value rollback must preserve unrelated values.'
+
+    $outOfScopeBackup = Join-Path $fixtureRoot 'out-of-scope.reg'
+    "Windows Registry Editor Version 5.00`r`n`r`n[HKEY_LOCAL_MACHINE\BROKENSYSTEM\ControlSet001\Services\stornvme]`r`n`r`n[HKEY_CURRENT_USER\Software\Unexpected]`r`n" |
+        Set-Content -LiteralPath $outOfScopeBackup -Encoding Unicode
+    Set-NvmeFixture -State $healthy
+    $outOfScope = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $outOfScopeBackup }
+    Assert-Equal 1 $outOfScope.Status 'Rollback should reject an out-of-scope registry backup.'
+    Assert-True (-not $global:NvmeFixture.HiveActive) 'An out-of-scope backup failure must unload the hive.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'An out-of-scope backup must not write.'
+
+    Set-NvmeFixture -State $healthy
+    $global:NvmeFixture.Backups[$backupPath] = Copy-FixtureState $broken
+    $global:NvmeFixture.ImportFails = $true
+    $beforeFailedImport = Copy-FixtureState $global:NvmeFixture.State
+    $failedImport = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $backupPath }
+    Assert-Equal 1 $failedImport.Status 'A failed registry import should fail Rollback.'
+    Assert-True (-not $global:NvmeFixture.HiveActive) 'A failed registry import must unload the hive.'
+    Assert-Equal $beforeFailedImport.Start $global:NvmeFixture.State.Start 'A failed import must leave current service values intact.'
+    Assert-True (-not ($global:NvmeFixture.Operations -match '^Remove:')) 'A failed import must not remove any current service value.'
+
+    Set-NvmeFixture -State $broken -DriverPresent $false
+    $missingDriver = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
+    Assert-Equal 1 $missingDriver.Status 'A missing driver should fail.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'A missing driver must not write.'
+    Assert-True ($missingDriver.Output -match 'could make the guest unbootable') 'The missing-driver refusal should be actionable.'
+
+    Set-NvmeFixture -State $broken -CandidateCount 2
+    $ambiguous = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
+    Assert-Equal 1 $ambiguous.Status 'Ambiguous Windows installations should fail.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'An ambiguous target must not write.'
+    Assert-True ($ambiguous.Output -match 'Refusing to guess') 'The ambiguous-target refusal should be explicit.'
+
+    Set-NvmeFixture -State $broken -CandidateCount 2
+    $selected = Invoke-NvmeFixture -Parameters @{ Mode = 'Report'; OsDriveLetter = 'F' }
+    Assert-Equal 0 $selected.Status 'An explicit OS drive should resolve an ambiguous fixture.'
+
+    Set-NvmeFixture -State $broken -HiveReadable $false
+    $corruptHive = Invoke-NvmeFixture -Parameters @{ Mode = 'Repair' }
+    Assert-Equal 1 $corruptHive.Status 'An unreadable hive should fail.'
+    Assert-True (-not $global:NvmeFixture.HiveActive) 'An unreadable hive must not remain mounted.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'An unreadable hive must not write.'
+
+    Set-NvmeFixture -State $broken
+    $strict = Invoke-NvmeFixture
+    Assert-Equal 0 $strict.Status 'The strict-control-set fixture should succeed.'
+    Assert-Equal 1 $global:NvmeFixture.StrictCalls 'The script should resolve the control set exactly once with -Strict.'
+
+    $sourceText = Get-Content -LiteralPath $sourceScript -Raw
+    Assert-True ($sourceText -notmatch 'ControlSet001') 'The script must not contain a ControlSet001 fallback.'
+    Assert-True ($sourceText -notmatch 'CriticalDeviceDatabase\\') 'The script must not contain a CriticalDeviceDatabase write path.'
+
+    Write-Host 'PASS: win-enable-nvme-boot-driver report, repair, idempotency, rollback, refusal, cleanup, strict-selection, and write-gate fixtures.'
+}
+finally {
+    $env:PUBLIC = $originalPublic
+    Remove-Item Function:\reg.exe -ErrorAction SilentlyContinue
+    Microsoft.PowerShell.Management\Remove-Item -LiteralPath $fixtureRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/test-win-enable-nvme-boot-driver.ps1
+++ b/tests/test-win-enable-nvme-boot-driver.ps1
@@ -45,7 +45,8 @@ function Set-NvmeFixture {
         [int]$CandidateCount = 1,
         [bool]$HiveReadable = $true,
         [bool]$KeyPresent = $true,
-        [bool]$WriteWrongKind = $false
+        [bool]$WriteWrongKind = $false,
+        [string[]]$SubKeys = @()
     )
 
     $global:NvmeFixture = @{
@@ -59,6 +60,7 @@ function Set-NvmeFixture {
         ImportFails = $false
         KeyPresent = $KeyPresent
         WriteWrongKind = $WriteWrongKind
+        SubKeys = @($SubKeys)
         Operations = [System.Collections.Generic.List[string]]::new()
         Backups = @{}
         LastBackup = $null
@@ -174,12 +176,26 @@ function Get-Item {
     }
     Assert-FixtureServicePath $LiteralPath
     if (-not $global:NvmeFixture.KeyPresent) { throw "Fixture service key '$LiteralPath' is missing." }
-    $key = [PSCustomObject]@{}
+    $key = [PSCustomObject]@{ Name = 'HKEY_LOCAL_MACHINE\BROKENSYSTEM\ControlSet001\Services\stornvme' }
     $key | Add-Member -MemberType ScriptMethod -Name GetValueKind -Value {
         Param([string]$Name)
         return [System.Enum]::Parse([Microsoft.Win32.RegistryValueKind], $global:NvmeFixture.Kinds[$Name])
     }
+    $key | Add-Member -MemberType ScriptMethod -Name GetValueNames -Value {
+        return @($global:NvmeFixture.State.Keys)
+    }
     return $key
+}
+function Get-ChildItem {
+    Param([string]$LiteralPath, [switch]$Recurse, $ErrorAction)
+    if (-not $LiteralPath.StartsWith('HKLM:\', [System.StringComparison]::OrdinalIgnoreCase)) {
+        return Microsoft.PowerShell.Management\Get-ChildItem @PSBoundParameters
+    }
+    Assert-FixtureServicePath $LiteralPath
+    return @($global:NvmeFixture.SubKeys | ForEach-Object {
+            $subKey = [PSCustomObject]@{ Name = $_ }
+            $subKey | Add-Member -MemberType ScriptMethod -Name GetValueNames -Value { return @() } -PassThru
+        })
 }
 function Get-ItemProperty {
     Param([string]$LiteralPath, $ErrorAction)
@@ -363,6 +379,54 @@ function global:reg.exe {
     Assert-Equal 1 $deletion.Status 'Rollback should reject a registry deletion section.'
     Assert-True ($deletion.Output -match 'contains a deletion section') 'Deletion-section refusal should identify the unsafe section.'
     Assert-Equal 0 $global:NvmeFixture.Operations.Count 'A deletion-section backup must be rejected before import.'
+
+    # A child-only backup passes the section-scope loop, so the missing root section has to be
+    # detected before the import rather than after it.
+    $childOnlyBackup = Join-Path $fixtureRoot 'child-only.reg'
+    "Windows Registry Editor Version 5.00`r`n`r`n[HKEY_LOCAL_MACHINE\BROKENSYSTEM\ControlSet001\Services\stornvme\Parameters]`r`n`"Example`"=`"value`"`r`n" |
+        Set-Content -LiteralPath $childOnlyBackup -Encoding Unicode
+    Set-NvmeFixture -State $healthy
+    # Registered so a premature import would succeed, leaving the mutation the assertions look for.
+    $global:NvmeFixture.Backups[$childOnlyBackup] = @{
+        State = Copy-FixtureState $broken
+        Kinds = Get-HealthyKinds
+        Suffix = ''
+    }
+    $childOnly = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $childOnlyBackup }
+    Assert-Equal 1 $childOnly.Status 'Rollback should reject a backup with no exact root section.'
+    Assert-True (-not ($global:NvmeFixture.Operations -contains 'Import:stornvme')) 'A backup without a root section must be rejected before import.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'A backup without a root section must not write.'
+    Assert-Equal 0 $global:NvmeFixture.State.Start 'A backup without a root section must leave current values intact.'
+
+    # reg.exe import merges, so a subkey the backup does not restore would survive the rollback.
+    Set-NvmeFixture -State $healthy -SubKeys @('HKEY_LOCAL_MACHINE\BROKENSYSTEM\ControlSet001\Services\stornvme\Unexpected')
+    $global:NvmeFixture.Backups[$backupPath] = @{
+        State = Copy-FixtureState $broken
+        Kinds = Get-HealthyKinds
+        Suffix = ''
+    }
+    $residualSubKey = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $backupPath }
+    Assert-Equal 1 $residualSubKey.Status 'Rollback should refuse when the offline subtree has a subkey the backup omits.'
+    Assert-True ($residualSubKey.Output -match 'Rollback would leave it behind') 'The residue refusal should explain why it stopped.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'A subtree with unrestorable residue must not be imported.'
+    Assert-Equal 0 $global:NvmeFixture.State.Start 'A refused rollback must leave current values intact.'
+
+    # Same for a value the backup does not declare and this script never writes.
+    $residualState = Copy-FixtureState $healthy
+    $residualState.Unrelated = 'keep-me'
+    $residualKinds = Get-HealthyKinds
+    $residualKinds.Unrelated = 'String'
+    Set-NvmeFixture -State $residualState -Kinds $residualKinds
+    $global:NvmeFixture.Backups[$backupPath] = @{
+        State = Copy-FixtureState $broken
+        Kinds = Get-HealthyKinds
+        Suffix = ''
+    }
+    $residualValue = Invoke-NvmeFixture -Parameters @{ Mode = 'Rollback'; BackupFile = $backupPath }
+    Assert-Equal 1 $residualValue.Status 'Rollback should refuse when the root key has a value the backup omits.'
+    Assert-True ($residualValue.Output -match "'Unrelated' value") 'The residue refusal should name the offending value.'
+    Assert-Equal 0 $global:NvmeFixture.Operations.Count 'A root key with unrestorable residue must not be imported.'
+    Assert-Equal 'keep-me' $global:NvmeFixture.State.Unrelated 'A refused rollback must not remove the unrestorable value.'
 
     $outOfScopeBackup = Join-Path $fixtureRoot 'out-of-scope.reg'
     "Windows Registry Editor Version 5.00`r`n`r`n[HKEY_LOCAL_MACHINE\BROKENSYSTEM\ControlSet001\Services\stornvme]`r`n`r`n[HKEY_CURRENT_USER\Software\Unexpected]`r`n" |


### PR DESCRIPTION
> Draft only. Do not merge or publish a permanent run-id until the remaining work-order gates are complete.

## Summary

Adds the Windows recovery script for inspecting, repairing, and rolling back the offline `stornvme` boot-driver configuration. The script defaults to read-only Report mode, refuses ambiguous or unsafe targets, backs up before Repair writes, verifies exact desired values after Repair, and verifies exact backup restoration after Rollback.

The permanent `win-enable-nvme-boot-driver` entry is intentionally withheld from `map.json`. Until binary SYSTEM-hive and live broken-VM validation are complete, test this branch through the work order's `--preview` workflow.

## Requested by / source

Edwin Bernal / `WORKORDER-repair-scripts.md`

## Type

[ ] Bug fix (patch)  [x] Feature (preview-only; public run-id withheld)  [ ] Breaking (major, sign-off attached)  [ ] Docs

## Changes

- `src/windows/win-enable-nvme-boot-driver.ps1`
  - Adds Report, Repair, and Rollback modes for the offline `stornvme` service.
  - Uses merged offline disk, hive, strict control-set, and write-gate helpers.
  - Refuses missing drivers and ambiguous Windows installations.
  - Backs up before mutation and rereads exact desired values after Repair.
  - Restricts Rollback imports to the selected offline `stornvme` subtree and verifies exact restoration.
  - Does not write CriticalDeviceDatabase entries.
- `tests/test-win-enable-nvme-boot-driver.ps1`
  - Covers read-only reporting, repair, idempotency, rollback, absent-value restoration, missing driver, ambiguous targets, explicit selection, unreadable hives, strict control-set selection, exact registry paths, write ordering, typed backup content, out-of-scope backup refusal, and import-failure cleanup.
- `map.json`
  - No change. The permanent run-id remains unpublished.

## Version & changelog

- `setup.py` VERSION: not applicable; this PR does not change the Azure CLI extension.
- `HISTORY.rst` entry added: no; this PR changes only the repair-script-library.

## Testing

- PowerShell parser: pass for production script and fixture suite.
- `tests/test-win-enable-nvme-boot-driver.ps1`: pass.
- `tests/test-get-disk-partitions-v3.ps1`: pass.
- `map.json` parse, unique IDs, and path resolution: pass (28 entries).
- Staged `git diff --check`: pass.
- Security pattern scan: pass.
- PSScriptAnalyzer: not run; module is not installed locally.

## Remaining Release Gates

- SCR-2: add and run binary offline SYSTEM-hive fixtures; current helper-boundary fixtures do not prove byte-level hive isolation.
- SCR-4: live-validate resource-disk exclusion on both SCSI and NVMe repair VMs before any customer-disk write.
- SCR-5: prove the full cycle on a genuinely non-booting VM: inject, controller flip, confirm failure, repair, restore, and confirm boot.
- SCR-3: add the permanent `map.json` run-id only after SCR-2, SCR-4, and SCR-5 evidence is reviewed.

## Cross-repo impact (repair-script-library)

- Run-id / `map.json` / script changes: adds an unregistered script for preview validation; no `map.json` or Azure CLI extension change.
- Preview testing depends on the existing `az vm repair run --preview` workflow.

## Security review

- Every registry mutation is preceded by `Assert-OfflineTarget`.
- Rollback rejects registry sections outside the selected offline `stornvme` subtree, including mixed-hive files.
- Failed imports do not perform post-import removals.
- No `Invoke-Expression`, `cmd /c`, string-built shell command, CriticalDeviceDatabase write, credential handling, or secret logging is introduced.

## Backward compatibility

- Breaking changes: none. No existing script or run-id changes, and no permanent public contract is introduced while validation remains incomplete.
